### PR TITLE
feat(demo): implement PropsDoc component

### DIFF
--- a/packages/demo/src/demo-building-blocs/ExampleLayout.tsx
+++ b/packages/demo/src/demo-building-blocs/ExampleLayout.tsx
@@ -1,8 +1,11 @@
+import '@demo-styling/example-layout.scss';
+
 import * as React from 'react';
 import {useSelector} from 'react-redux';
 import {TabContent, TabPaneConnected, TabSelectors, TabsHeader, Tile} from 'react-vapor';
+
 import {GuidelinesTab} from './GuidelinesTab';
-import '@demo-styling/example-layout.scss';
+import {PropsDoc} from './PropsDoc';
 import Sandbox from './Sandbox';
 
 export interface ExampleLayoutProps {
@@ -43,26 +46,30 @@ export const ExampleLayout: React.FunctionComponent<ExampleLayoutProps> = ({
             />
             <TabContent>
                 <TabPaneConnected id="implementation" groupId="page">
-                    {isShowingCode && <Content code={code} examples={examples} />}
+                    {isShowingCode && <Content id={id} code={code} examples={examples} />}
                 </TabPaneConnected>
                 <GuidelinesTab id={id} />
             </TabContent>
         </div>
     );
 };
-const Content: React.FunctionComponent<Pick<ExampleLayoutProps, 'code' | 'examples'>> = ({code, examples}) => (
+const Content: React.FunctionComponent<Pick<ExampleLayoutProps, 'code' | 'examples' | 'id'>> = ({
+    code,
+    examples,
+    id,
+}) => (
     <>
         <div className="example-layout__main-code example-layout__section">
             <Sandbox id="main-code">{code}</Sandbox>
         </div>
         <div className="example-layout__props example-layout__section">
-            <h4 className="h2 mb5">Props</h4>
-            <div>Insert table props here</div>
+            <h4 className="h2 mb1">Props</h4>
+            <PropsDoc componentName={id} />
         </div>
         <div className="example-layout__examples example-layout__section">
             <h4 className="h2 mb5">Examples</h4>
-            {Object.entries(examples).map(([id, {code: exampleCode, title}]) => (
-                <Sandbox key={id} id={id} title={title}>
+            {Object.entries(examples).map(([exampleId, {code: exampleCode, title}]) => (
+                <Sandbox key={exampleId} id={exampleId} title={title}>
                     {exampleCode}
                 </Sandbox>
             ))}

--- a/packages/demo/src/demo-building-blocs/PropsDoc.tsx
+++ b/packages/demo/src/demo-building-blocs/PropsDoc.tsx
@@ -1,0 +1,101 @@
+import {createSystem, createVirtualTypeScriptEnvironment} from '@typescript/vfs';
+import * as React from 'react';
+import {Loading} from 'react-vapor';
+import * as ts from 'typescript';
+import '@demo-styling/props-doc.scss';
+
+import {useTypescriptServer} from './useTypescriptServer';
+
+interface PropInfo {
+    name: string;
+    description: string;
+    type: string;
+    optional: boolean;
+}
+
+export const PropsDoc: React.FunctionComponent<{componentName: string}> = ({componentName}) => {
+    const [propsList, setPropsList] = React.useState<PropInfo[]>();
+    const {fsMap, compilerOptions} = useTypescriptServer();
+
+    React.useEffect(() => {
+        if (fsMap === null) {
+            return;
+        }
+        const system = createSystem(fsMap);
+        const content = `import * as React from 'react';
+import {${componentName}} from 'react-vapor';
+const props: React.ComponentProps<typeof ${componentName}> = {`;
+        fsMap.set('props.ts', content);
+
+        const env = createVirtualTypeScriptEnvironment(system, [...fsMap.keys()], ts, compilerOptions);
+        const checker = env.languageService.getProgram().getTypeChecker();
+        const {entries} = env.languageService.getCompletionsAtPosition('props.ts', content.length, undefined);
+        const accumulator: PropInfo[] = [];
+
+        if (!entries) {
+            setPropsList(accumulator);
+        } else {
+            entries.forEach((entry) => {
+                const symbol = env.languageService.getCompletionEntrySymbol(
+                    'props.ts',
+                    content.length,
+                    entry.name,
+                    entry.source
+                );
+                const type = checker.getTypeOfSymbolAtLocation(symbol, symbol.valueDeclaration);
+                accumulator.push({
+                    name: entry.name,
+                    description: ts.displayPartsToString(symbol.getDocumentationComment(checker)),
+                    type: checker.typeToString(type),
+                    optional: entry.kindModifiers.includes('optional'),
+                });
+            });
+        }
+
+        setPropsList(accumulator);
+    }, [componentName, fsMap]);
+
+    if (!propsList) {
+        return <Loading />;
+    }
+
+    if (propsList.length < 1) {
+        return <p>This component has no props.</p>;
+    }
+
+    return (
+        <div className="props-doc">
+            <table>
+                <thead className="body-m">
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {propsList.sort(requiredFirst).map(({name, type, description, optional}) => (
+                        <tr key={name}>
+                            <td>
+                                <span className="code">{name}</span>
+                                {optional ? null : <span className="body-s-book-italic-subdued ml2">required</span>}
+                            </td>
+                            <td>
+                                <span className="code">{type}</span>
+                            </td>
+                            <td>{description}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+const requiredFirst = (a: PropInfo, b: PropInfo): number => {
+    if (a.optional === b.optional) {
+        return 0;
+    }
+
+    return a.optional ? 1 : -1;
+};

--- a/packages/demo/src/demo-styling/props-doc.scss
+++ b/packages/demo/src/demo-styling/props-doc.scss
@@ -1,0 +1,36 @@
+.props-doc {
+    max-height: 500px;
+    margin-left: -24px;
+    overflow: auto;
+
+    table {
+        color: var(--grey-100);
+
+        th {
+            position: sticky;
+            top: 0;
+            height: 44px;
+            padding: 0 24px;
+            text-align: left;
+            vertical-align: middle;
+            background-color: var(--white);
+        }
+
+        td {
+            padding: 0 24px;
+            vertical-align: middle;
+        }
+
+        tr {
+            height: 44px;
+
+            &:nth-child(odd) {
+                background-color: var(--grey-20);
+            }
+        }
+
+        .code {
+            color: var(--grey-100);
+        }
+    }
+}

--- a/packages/demo/tsconfig.json
+++ b/packages/demo/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../tsconfig-base",
     "compilerOptions": {
         "removeComments": false,
+        "noUnusedLocals": false,
         "rootDir": "src",
         "outDir": "built",
         "baseUrl": ".",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -25,6 +25,6 @@
         "rimraf": "3.0.2",
         "ts-node": "10.4.0",
         "tslib": "2.3.1",
-        "typescript": "4.4.4"
+        "typescript": "3.8.3"
     }
 }

--- a/packages/tsconfig-base.json
+++ b/packages/tsconfig-base.json
@@ -5,23 +5,23 @@
         "target": "es5",
         "jsx": "react",
         "lib": ["ES2015", "DOM"],
-        
+
         "composite": true,
         "sourceMap": true,
         "declaration": true,
         "declarationMap": true,
-        
+
         "allowJs": true,
         "skipLibCheck": true,
-        
+
         "noImplicitAny": true,
         "noImplicitThis": true,
         "noUnusedLocals": true,
         "strictBindCallApply": true,
-        
+
         "experimentalDecorators": true,
         "downlevelIteration": true,
-        "removeComments": true,
+        "removeComments": false,
         "emitDecoratorMetadata": true,
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,7 +388,7 @@ importers:
       rimraf: 3.0.2
       ts-node: 10.4.0
       tslib: 2.3.1
-      typescript: 4.4.4
+      typescript: 3.8.3
     devDependencies:
       '@types/fs-extra': 9.0.13
       '@types/node': 16.11.12
@@ -398,9 +398,9 @@ importers:
       fs-extra: 10.0.0
       prettier: 2.4.1
       rimraf: 3.0.2
-      ts-node: 10.4.0_b7303747f27c31077eba8de44bbb9cc4
+      ts-node: 10.4.0_0885aa7ce5ba26c3ff83080fb5ee2db9
       tslib: 2.3.1
-      typescript: 4.4.4
+      typescript: 3.8.3
 
   packages/vapor:
     specifiers:
@@ -17275,7 +17275,7 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-node/10.4.0_b7303747f27c31077eba8de44bbb9cc4:
+  /ts-node/10.4.0_0885aa7ce5ba26c3ff83080fb5ee2db9:
     resolution: {integrity: sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==}
     hasBin: true
     peerDependencies:
@@ -17301,7 +17301,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.4.4
+      typescript: 3.8.3
       yn: 3.1.1
     dev: true
 
@@ -17479,8 +17479,8 @@ packages:
     resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
     dev: true
 
-  /typescript/4.4.4:
-    resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
+  /typescript/3.8.3:
+    resolution: {integrity: sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
### Proposed Changes

Implemented a table that displays the props of a component exported from react-vapor.

Usage:

```tsx
<PropsDoc componentName='Button' />
```

You can view the result here: https://vapor.coveo.com/feature/PR-2362/index.html#/input/Buttonv2

### Potential Breaking Changes

none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
