### PR TITLE
fix: the area above the file input is no longer clickable

### DIFF
--- a/packages/style/scss/controls/file-input.scss
+++ b/packages/style/scss/controls/file-input.scss
@@ -2,13 +2,17 @@
     position: relative;
     display: flex;
     width: 100%;
+    margin-top: $button-margin-width;
+
+    .input-field {
+        margin-top: 0;
+    }
 
     .file-path-wrapper {
         flex-grow: 1;
     }
 
     .btn {
-        margin-top: $button-margin-width;
         margin-left: $button-margin-width;
 
         input {


### PR DESCRIPTION
### Proposed Changes

Part of [ADUI-7729](https://coveord.atlassian.net/jira/software/c/projects/ADUI/boards/927?modal=detail&selectedIssue=ADUI-7729&assignee=6112c656627b560068748319)

This seems to be some legacy CSS in plasma that is used in the admin-ui for "file input".  The reason it remains I believe in Plasma is because the templates using it are all Backbone templates, otherwise we may have created a reusable component for this or used the `file picker` component from Plasma.

#### Before hovering over the input or button was clickable:

https://user-images.githubusercontent.com/5728044/148082501-7604ec83-e4db-448c-a910-e5ef6b2891f4.mov

#### Fix hovering over the input or button is not clickable, note this is just manually applying the changes here into admin-ui:

https://user-images.githubusercontent.com/5728044/148082384-79e6f30f-cffc-4730-995e-60a45729cf38.mov

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/5728044/148082711-9796fa10-f5e7-4b50-9ff7-22b2fd0865d6.png" width="400" /> | <img src="https://user-images.githubusercontent.com/5728044/148082809-0794fa68-04e9-4f91-a17a-304b12773479.png" width="400" /> |

This aligns the input with the button as well!

The easiest way to see the existing problem is to:

- go to sources
- click "add source"
- Click "Box business"
- Below there is an input field and file upload button

### Potential Breaking Changes

There shouldn't be any breaking changes.  This moves the margin to a different DOM element.  Visually it should be the same but the hover over shouldn't bleed outside on the button/input.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
