### PR TITLE
ci(jenkinsfile): add no-verify-access to lerna publish

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -219,11 +219,13 @@ pipeline {
       steps {
         script {
           setLastStageName();
+          sh "npm config set //registry.npmjs.org/:_authToken=${env.NPM_TOKEN}"
           sh "git fetch --tags origin ${env.BRANCH_NAME}"
 
           if (env.BRANCH_NAME ==~ /release-.*/) {
             // release
             sh "npx lerna publish patch \
+            --no-verify-access \
             --create-release github \
             --no-commit-hooks \
             --force-publish \
@@ -233,6 +235,7 @@ pipeline {
           } else if (env.BRANCH_NAME == "next") {
             // next
             sh "npx lerna publish \
+            --no-verify-access \
             --conventional-commits \
             --create-release github \
             --conventional-prerelease \
@@ -246,6 +249,7 @@ pipeline {
           } else {
             // master
             sh "npx lerna publish \
+            --no-verify-access \
             --conventional-commits \
             --create-release github \
             --no-commit-hooks \


### PR DESCRIPTION
### Proposed Changes

Following [this pr suggestion](https://github.com/lerna/lerna/issues/2788) to fix the fact that Lerna needs to be **removed** from our projects.

... 

Wait :neutral_face: 

I meant that Lerna does not support NPM automation tokens. And we need a NPM automation token beause of the new policiy about 2FA for npm.

This pr will be fine, the publish stage only run in master so  wait for it :sweat_smile: 

### Potential Breaking Changes

Should be none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
