### PR TITLE
feat(tile): make title, description, href optional

### DIFF
--- a/packages/react/src/components/tile/Tile.tsx
+++ b/packages/react/src/components/tile/Tile.tsx
@@ -3,20 +3,38 @@ import * as React from 'react';
 import {Svg, SvgNames} from '../svg';
 
 export interface TileProps {
-    title: string;
+    title?: string;
     svgName: SvgNames;
-    description: string;
-    href: string;
+    description?: string;
+    href?: string;
 }
 
-export const Tile: React.FunctionComponent<TileProps> = ({title, description, svgName, href}) => (
-    <a className="tile" href={href}>
+export const Tile: React.FunctionComponent<TileProps> = ({title, description, svgName, href}) => {
+    const tileIcon = (
         <div className="tile-icon">
             <Svg svgName={svgName} svgClass="icon" />
         </div>
+    );
+    const tileInfo = (title || description) && (
         <div className="tile-information">
-            <div className="tile-title h6-subdued">{title}</div>
-            <div className="tile-description body-m-book-subdued">{description}</div>
+            {title && <div className="tile-title h6-subdued">{title}</div>}
+            {description && <div className="tile-description body-m-book-subdued">{description}</div>}
         </div>
-    </a>
-);
+    );
+
+    if (href && href.length > 0) {
+        return (
+            <a className="tile" href={href}>
+                {tileIcon}
+                {tileInfo}
+            </a>
+        );
+    }
+
+    return (
+        <div className="tile">
+            {tileIcon}
+            {tileInfo}
+        </div>
+    );
+};

--- a/packages/react/src/components/tile/tests/Tile.spec.tsx
+++ b/packages/react/src/components/tile/tests/Tile.spec.tsx
@@ -28,6 +28,12 @@ describe('Tile', () => {
             />
         );
 
-        expect(document.querySelector('a')).toHaveAttribute('href', '/somewhere');
+        expect(screen.getByRole('link', {name: /my component/i})).toHaveAttribute('href', '/somewhere');
+    });
+
+    it('does not render a link if no href is provided', () => {
+        render(<Tile title="My tile" description="not a link" svgName="plasmaComponentBox" />);
+
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
     });
 });

--- a/packages/style/scss/components/tile.scss
+++ b/packages/style/scss/components/tile.scss
@@ -7,11 +7,11 @@
     border: $default-border;
     border-radius: $small-border-radius;
     box-shadow: var(--low-elevation-on-light);
+}
 
-    &:hover {
-        border: $border-radius solid var(--digital-blue-60);
-        box-shadow: var(--medium-elevation-on-light);
-    }
+a.tile:hover {
+    border: $border-radius solid var(--digital-blue-60);
+    box-shadow: var(--medium-elevation-on-light);
 }
 
 .tile-icon {
@@ -58,12 +58,4 @@
 .tile-description {
     width: 100%;
     height: 100%;
-}
-
-// for 4k screens
-@media screen and (min-width: 160em) {
-    .tile {
-        width: 15%;
-        height: 15%;
-    }
 }

--- a/packages/website/src/demo-building-blocs/ExampleLayout.tsx
+++ b/packages/website/src/demo-building-blocs/ExampleLayout.tsx
@@ -1,6 +1,6 @@
 import '@demo-styling/example-layout.scss';
 
-import {TabContent, TabPaneConnected, TabSelectors, TabsHeader, Tile} from '@coveord/plasma-react';
+import {SvgNames, TabContent, TabPaneConnected, TabSelectors, TabsHeader, Tile} from '@coveord/plasma-react';
 import * as React from 'react';
 import {useSelector} from 'react-redux';
 
@@ -12,6 +12,7 @@ import Sandbox from './Sandbox';
 export interface ExampleLayoutProps {
     id: string;
     title: string;
+    icon?: SvgNames;
     description?: React.ReactNode;
     section: string;
     code: string;
@@ -28,6 +29,7 @@ export const ExampleLayout: React.FunctionComponent<ExampleLayoutProps> = ({
     id,
     title,
     description,
+    icon,
     section,
     code,
     examples,
@@ -47,7 +49,7 @@ export const ExampleLayout: React.FunctionComponent<ExampleLayoutProps> = ({
                     View source
                 </GithubButton>
                 <h3 className="h1-light normal-white-space">{title}</h3>
-                <Tile title="" svgName="plasmaComponentBox" description="" href={undefined} />
+                <Tile svgName={icon || 'plasmaComponentBox'} />
                 <div>{description}</div>
             </div>
             <TabsHeader

--- a/packages/website/src/demo-styling/example-layout.scss
+++ b/packages/website/src/demo-styling/example-layout.scss
@@ -10,6 +10,7 @@
 
         .tile {
             grid-area: icon;
+            justify-self: end;
             width: 264px;
             height: 173px;
         }

--- a/packages/website/src/demo-styling/home.scss
+++ b/packages/website/src/demo-styling/home.scss
@@ -43,4 +43,12 @@
         padding-top: 24px;
         padding-right: 24px;
     }
+
+    // for 4k screens
+    @media screen and (min-width: 160em) {
+        .tile {
+            width: 15%;
+            height: 15%;
+        }
+    }
 }


### PR DESCRIPTION
### Proposed Changes

Making the title, description and href props optional on the tile component. We have a use-case in the website where we only want to display the icon in the tile.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
