### PR TITLE
feat(textinput): apply the new example layout to the textinput examples

### DIFF
--- a/packages/react/src/components/textInput/TextInput.tsx
+++ b/packages/react/src/components/textInput/TextInput.tsx
@@ -10,18 +10,47 @@ import {useTextInput} from './useTextInput';
 export type InputValidator = (value: string) => {status: 'valid' | 'invalid' | 'warning'; message?: string};
 
 interface TextInputProps {
+    /**
+     * Tells the browser which type of text content to expect
+     */
     type: 'email' | 'search' | 'text' | 'url' | 'password';
+    /**
+     * The text displayed inside the input box
+     */
     label: string;
+    /**
+     * The text displayed just above the input box
+     */
     description?: string;
+    /**
+     * The text displayed just underneath the input box
+     */
     helpText?: string;
+    /**
+     * Additional text to display as tooltip when hovering over a question icon
+     */
     tooltip?: string;
+    /**
+     * Provides the validation logic to the input
+     */
     validate?: InputValidator;
+    /**
+     * Whether the validation result should be visible when the input is rendered for the first time
+     */
     showValidationOnMount?: boolean;
+    /**
+     * Whether the validation result should be visible when the input value changes
+     */
     showValidationOnChange?: boolean;
+    /**
+     * Whether the validation result should be visible when the input looses the focus (recommended)
+     */
     showValidationOnBlur?: boolean;
 }
 
-export const TextInput: React.FunctionComponent<TextInputProps & React.HTMLProps<HTMLInputElement>> = ({
+export const TextInput: React.FunctionComponent<
+    TextInputProps & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'>
+> = ({
     id: propsId,
     label,
     validate,

--- a/packages/website/src/demo-building-blocs/ExampleLayout.tsx
+++ b/packages/website/src/demo-building-blocs/ExampleLayout.tsx
@@ -1,6 +1,6 @@
 import '@demo-styling/example-layout.scss';
 
-import {SvgNames, TabContent, TabPaneConnected, TabSelectors, TabsHeader, Tile} from '@coveord/plasma-react';
+import {SvgNames, TabContent, TabPaneConnected, TabSelectors, TabsHeader, Tile, TileProps} from '@coveord/plasma-react';
 import * as React from 'react';
 import {useSelector} from 'react-redux';
 
@@ -9,14 +9,19 @@ import {GuidelinesTab} from './GuidelinesTab';
 import {PropsDoc} from './PropsDoc';
 import Sandbox from './Sandbox';
 
-export interface ExampleLayoutProps {
-    id: string;
+interface PlaygroundProps {
     title: string;
+    code: string;
+    layout?: 'horizontal' | 'vertical';
+}
+
+export interface ExampleLayoutProps extends PlaygroundProps {
+    id: string;
     icon?: SvgNames;
     description?: React.ReactNode;
     section: string;
-    code: string;
-    examples: Record<string, {code: string; title: string}>;
+    examples?: Record<string, PlaygroundProps>;
+    relatedComponents?: TileProps[];
     /**
      * Path to the component's source file from /packages/react/src/components
      *
@@ -32,8 +37,10 @@ export const ExampleLayout: React.FunctionComponent<ExampleLayoutProps> = ({
     icon,
     section,
     code,
+    layout = 'horizontal',
     examples,
     componentSourcePath,
+    relatedComponents,
 }) => {
     const isShowingCode = useSelector((state) =>
         TabSelectors.getIsTabSelected(state, {groupId: 'page', id: 'implementation'})
@@ -60,37 +67,61 @@ export const ExampleLayout: React.FunctionComponent<ExampleLayoutProps> = ({
             />
             <TabContent>
                 <TabPaneConnected id="implementation" groupId="page">
-                    {isShowingCode && <Content id={id} code={code} examples={examples} />}
+                    {isShowingCode && (
+                        <Content
+                            id={id}
+                            code={code}
+                            examples={examples}
+                            relatedComponents={relatedComponents}
+                            layout={layout}
+                        />
+                    )}
                 </TabPaneConnected>
-                <GuidelinesTab id={id} />
+                <div className="mod-header-padding mod-form-top-bottom-padding">
+                    <GuidelinesTab id={id} />
+                </div>
             </TabContent>
         </div>
     );
 };
-const Content: React.FunctionComponent<Pick<ExampleLayoutProps, 'code' | 'examples' | 'id'>> = ({
-    code,
-    examples,
-    id,
-}) => (
+const Content: React.FunctionComponent<Pick<
+    ExampleLayoutProps,
+    'code' | 'examples' | 'id' | 'relatedComponents' | 'layout'
+>> = ({code, examples, id, relatedComponents, layout}) => (
     <>
         <div className="example-layout__main-code example-layout__section">
-            <Sandbox id="main-code">{code}</Sandbox>
+            <Sandbox id="main-code" horizontal={layout === 'horizontal'}>
+                {code}
+            </Sandbox>
         </div>
         <div className="example-layout__props example-layout__section">
             <h4 className="h2 mb1">Props</h4>
             <PropsDoc componentName={id} />
         </div>
-        <div className="example-layout__examples example-layout__section">
-            <h4 className="h2 mb5">Examples</h4>
-            {Object.entries(examples).map(([exampleId, {code: exampleCode, title}]) => (
-                <Sandbox key={exampleId} id={exampleId} title={title}>
-                    {exampleCode}
-                </Sandbox>
-            ))}
-        </div>
-        <div className="example-layout__related example-layout__section">
-            <h4 className="h2 mb5">Related Components</h4>
-            <div>Insert related components here</div>
-        </div>
+        {examples && (
+            <div className="example-layout__examples example-layout__section">
+                <h4 className="h2 mb5">Examples</h4>
+                {Object.entries(examples).map(
+                    ([exampleId, {code: exampleCode, title, layout: exampleLayout = 'horizontal'}]) => (
+                        <Sandbox
+                            key={exampleId}
+                            id={exampleId}
+                            title={title}
+                            horizontal={exampleLayout === 'horizontal'}
+                        >
+                            {exampleCode}
+                        </Sandbox>
+                    )
+                )}
+            </div>
+        )}
+        {relatedComponents && relatedComponents.length > 0 && (
+            <div className="example-layout__related example-layout__section">
+                <h4 className="h2 mb5">Related Components</h4>
+                {relatedComponents.map((tileProps) => (
+                    <Tile key={tileProps.title} {...tileProps} />
+                ))}
+            </div>
+        )}
     </>
 );

--- a/packages/website/src/demo-building-blocs/Sandbox.tsx
+++ b/packages/website/src/demo-building-blocs/Sandbox.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import * as ts from 'typescript';
 import lzstring from 'lz-string';
 import {twoslasher} from '@typescript/twoslash';
+import classNames from 'classnames';
 import * as monaco from 'monaco-editor';
 import * as _ from 'underscore';
 import '@demo-styling/sandbox.scss';
@@ -11,10 +12,11 @@ import {useTypescriptServer} from './useTypescriptServer';
 // eslint-disable-next-line
 const prettierConfig = require('tsjs/prettier-config');
 
-export const Sandbox: React.FunctionComponent<{children: string; id: string; title?: string}> = ({
+export const Sandbox: React.FunctionComponent<{children: string; id: string; title?: string; horizontal?: boolean}> = ({
     id,
     title,
     children,
+    horizontal,
 }) => {
     const formattedCode = format(children as string, {
         ...prettierConfig,
@@ -29,9 +31,9 @@ export const Sandbox: React.FunctionComponent<{children: string; id: string; tit
             return;
         }
         const twoslash = twoslasher(editedCode, 'tsx', {
-            tsModule: ts as any,
+            tsModule: ts,
             defaultOptions: {noStaticSemanticInfo: false, showEmit: true, noErrorValidation: true},
-            defaultCompilerOptions: compilerOptions as any,
+            defaultCompilerOptions: compilerOptions,
             lzstringModule: lzstring,
             fsMap: fsMap,
         });
@@ -45,9 +47,9 @@ export const Sandbox: React.FunctionComponent<{children: string; id: string; tit
                     .replace('Object.defineProperty(exports, "__esModule", { value: true });', '')
                     .replace(/var .+ = require(.+);/g, '') // remove the require statements
                     .replace(/var .+ = __importStar\(require(.+)\);/g, '') // remove the import statements
-                    .replace(/exports\.default = (.+);/g, 'var Example = $1;') // change the default export to a component named Example
+                    .replace(/exports\.default = (.+)/g, 'var Example = $1') // change the default export to a component named Example
                     .replace(/plasma_react_\d+/g, 'PlasmaReact') + // use react-vapor from the window ReactVapor object
-                `;ReactDOM.render(React.createElement(ReactRedux.Provider, {store: Store}, React.createElement(Example)), document.getElementById('${id}'));`;
+                `ReactDOM.render(React.createElement(ReactRedux.Provider, {store: Store}, React.createElement(Example)), document.getElementById('${id}'));`;
 
             // eslint-disable-next-line no-eval
             eval(userCodeToEvaluate);
@@ -57,10 +59,12 @@ export const Sandbox: React.FunctionComponent<{children: string; id: string; tit
     }, [editedCode, fsMap]);
 
     return (
-        <div className="demo-sandbox">
+        <div className={classNames('demo-sandbox', {horizontal})}>
             <div className="demo-sandbox__preview" id={id} />
-            {title && <div className="demo-sandbox__title body-m-book">{title}</div>}
-            <Editor id={id} value={formattedCode} onChange={setEditedCode} />
+            <div>
+                {title && <div className="demo-sandbox__title body-m-book">{title}</div>}
+                <Editor id={id} value={formattedCode} onChange={setEditedCode} />
+            </div>
         </div>
     );
 };

--- a/packages/website/src/demo-styling/sandbox.scss
+++ b/packages/website/src/demo-styling/sandbox.scss
@@ -1,20 +1,28 @@
 .demo-sandbox {
     display: flex;
     flex-flow: column;
+    overflow: hidden;
+    border: 1px solid var(--default-border-color);
+    border-radius: 8px;
+
+    &.horizontal {
+        flex-flow: row;
+        & > * {
+            flex-grow: 1;
+            width: 50%;
+        }
+    }
 
     &__preview {
         box-sizing: border-box;
         min-height: 200px;
         padding: 2rem;
         background-color: #fff;
-        border: 1px solid var(--default-border-color);
-        border-radius: 8px 8px 0 0;
     }
 
     &__editor {
         width: 100%;
         height: 300px;
-        overflow: hidden;
     }
 
     &__title {

--- a/packages/website/src/plasma/routes/input/pages/ButtonV2.tsx
+++ b/packages/website/src/plasma/routes/input/pages/ButtonV2.tsx
@@ -6,19 +6,19 @@ export const ButtonV2: React.FunctionComponent = () => {
         import * as React from "react";
         import {Button} from "@coveord/plasma-react";
 
-        export default () => <Button>Hello World!</Button>
+        export default () => <Button>Hello World!</Button>;
     `;
     const primary = `
         import * as React from "react";
         import {Button} from "@coveord/plasma-react";
 
-        export default () => <Button primary>Hello World!</Button>
+        export default () => <Button primary>Hello World!</Button>;
     `;
     const small = `
         import * as React from "react";
         import {Button} from "@coveord/plasma-react";
 
-        export default () => <Button small>Hello World!</Button>
+        export default () => <Button small>Hello World!</Button>;
     `;
     return (
         <ExampleLayout

--- a/packages/website/src/plasma/routes/input/pages/TextInputExamples.tsx
+++ b/packages/website/src/plasma/routes/input/pages/TextInputExamples.tsx
@@ -1,105 +1,105 @@
 import * as React from 'react';
-import {Button, FormProvider, InputValidator, Section, TextInput, useTextInput} from '@coveord/plasma-react';
 
-import VaporComponent from '../../../../demo-building-blocs/VaporComponent';
+import {ExampleLayout} from '../../../../demo-building-blocs/ExampleLayout';
 
-const nonEmptyValidation: InputValidator = (value: string) => {
-    const isEmpty = !value;
-    const isWhiteSpace = !isEmpty && !value.trim();
-    if (isWhiteSpace) {
-        return {status: 'warning', message: 'A white space is not empty, but is not ideal.'};
-    } else if (isEmpty) {
-        return {status: 'invalid', message: 'Cannot be empty.'};
-    } else {
+const code = `
+    import * as React from 'react';
+    import {FormProvider, InputValidator, TextInput} from "@coveord/plasma-react";
+
+    const nonEmptyValidation: InputValidator = (value: string) => {
+        const isEmpty = !value;
+        const isWhiteSpace = !isEmpty && !value.trim();
+        
+        if (isWhiteSpace) {
+            return {status: 'warning', message: 'A white space is not empty, but is not ideal.'};
+        } 
+
+        if (isEmpty) {
+            return {status: 'invalid', message: 'Cannot be empty.'};
+        } 
+        
         return {status: 'valid'};
-    }
-};
+    };
+
+    export default () => (
+        <FormProvider>
+            <TextInput
+                required
+                showValidationOnBlur
+                validate={nonEmptyValidation}
+                type="text"
+                label="Label"
+                title="Title"
+                description="Description"
+                helpText="Help text"
+                tooltip="Tooltip"
+            />
+        </FormProvider>
+    );
+`;
+
+const hookUsage = `
+    import * as React from 'react';
+    import {Button, FormProvider, TextInput, useTextInput} from "@coveord/plasma-react";
+
+    const CurrentState: React.FunctionComponent = () => {
+        const {state} = useTextInput('favorite-dish');
+        return (
+            <div className="my1" style={{whiteSpace: 'pre-wrap'}}>
+                state = {JSON.stringify(state, null, 4)}
+            </div>
+        );
+    };
+
+    const InteractiveButtons: React.FunctionComponent = () => {
+        const {state, dispatch} = useTextInput('favorite-dish');
+        return (
+            <>
+                <Button
+                    name='Change dish for "sushis"'
+                    enabled={state.value !== 'sushis'}
+                    onClick={() => dispatch({type: 'change-value', payload: 'sushis'})}
+                />
+                <Button
+                    name="Show validation"
+                    onClick={() => dispatch({type: 'show-validation'})}
+                />
+                <Button
+                    name="Hide validation"
+                    onClick={() => dispatch({type: 'hide-validation'})}
+                />
+            </>
+        );
+    };
+
+    export default () => (
+        <FormProvider>
+            <TextInput
+                id="favorite-dish"
+                type="text"
+                label="Favorite Dish"
+                defaultValue="pizza"
+                validate={(value) =>
+                    /pizza/i.test(value)
+                        ? {status: 'valid'}
+                        : {status: 'warning', message: "Pizza is best but that's okay."}
+                }
+                showValidationOnBlur
+            />
+            <CurrentState />
+            <InteractiveButtons />
+        </FormProvider>
+    );
+`;
 
 // start-print
 export const TextInputExamples: React.FunctionComponent = () => (
-    <VaporComponent id="TextInput" title="Text Input" withSource>
-        <FormProvider>
-            <Section>
-                <TextInput
-                    required
-                    showValidationOnBlur
-                    validate={nonEmptyValidation}
-                    type="text"
-                    label="Label"
-                    title="Title"
-                    description="Description"
-                    helpText="Help text"
-                    tooltip="Tooltip"
-                />
-                <Section level={2} title="Disabled">
-                    <TextInput type="email" label="Email" disabled />
-                    <TextInput type="email" label="Email" defaultValue="123@abc.com" disabled />
-                </Section>
-                <Section level={2} title="useTextInput hook usage demo">
-                    <div className="flex space-around">
-                        <TextInput
-                            id="favorite-dish"
-                            type="text"
-                            label="Favorite Dish"
-                            defaultValue="pizza"
-                            validate={(value) =>
-                                /pizza/i.test(value)
-                                    ? {status: 'valid'}
-                                    : {status: 'warning', message: "Pizza is best but that's okay."}
-                            }
-                            showValidationOnBlur
-                        />
-                        <TextInput
-                            id="favorite-animal"
-                            type="text"
-                            label="Favorite Animal"
-                            defaultValue="Tiger"
-                            required
-                            validate={nonEmptyValidation}
-                            showValidationOnBlur
-                        />
-                    </div>
-                    <HookUsageDemo />
-                </Section>
-            </Section>
-        </FormProvider>
-    </VaporComponent>
+    <ExampleLayout
+        id="TextInput"
+        title="TextInput"
+        section="inputs"
+        componentSourcePath="/textInput/TextInput.tsx"
+        code={code}
+        examples={{hookUsage: {code: hookUsage, title: 'useTextInput hook usage'}}}
+    />
 );
-
-const HookUsageDemo: React.FunctionComponent = () => {
-    const favoriteDishInput = useTextInput('favorite-dish');
-    const favoriteAnimalInput = useTextInput('favorite-animal');
-
-    return (
-        <>
-            <div className="flex space-around">
-                <p style={{whiteSpace: 'pre-wrap'}}>state = {JSON.stringify(favoriteDishInput.state, null, 4)}</p>
-                <p style={{whiteSpace: 'pre-wrap'}}>state = {JSON.stringify(favoriteAnimalInput.state, null, 4)}</p>
-            </div>
-            <p>
-                The hook gives you full access to the state of the input that has the specified id. As you can see, they
-                are both independent, one doesn't influence the state of the other. The hook also exposes dispatch,
-                which allows to interract with TextInput however we need.
-            </p>
-            <Button
-                name='Change dish for "sushis"'
-                enabled={favoriteDishInput.state.value !== 'sushis'}
-                onClick={() => favoriteDishInput.dispatch({type: 'change-value', payload: 'sushis'})}
-            />
-            <Button
-                name="Show validation"
-                onClick={() => {
-                    favoriteDishInput.dispatch({type: 'show-validation'});
-                    favoriteAnimalInput.dispatch({type: 'show-validation'});
-                }}
-            />
-            <Button
-                name="Hide validation"
-                onClick={() => {
-                    favoriteDishInput.dispatch({type: 'hide-validation'});
-                    favoriteAnimalInput.dispatch({type: 'hide-validation'});
-                }}
-            />
-        </>
-    );
-};


### PR DESCRIPTION
### Proposed Changes

Applying the new example layout to the TextInput component examples.

To test, simply navigate to the `Text Input` section in the plasma website.

### Potential Breaking Changes

None, only affects the website

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
