### PR TITLE
fix(actionableitem): editing component to hide active on actionableitem component

### DIFF
--- a/packages/react/src/components/actionable-item/ActionableItem.tsx
+++ b/packages/react/src/components/actionable-item/ActionableItem.tsx
@@ -50,7 +50,7 @@ export class ActionableItem extends React.Component<IActionableItemProps & React
                         )}
                         {...(this.props.dropProps || {})}
                     >
-                        <ListBox items={this.props.actions} />
+                        <ListBox items={this.props.actions} noActive />
                     </Drop>
                 ) : null}
             </div>

--- a/packages/react/src/components/actionable-item/tests/ActionableItem.spec.tsx
+++ b/packages/react/src/components/actionable-item/tests/ActionableItem.spec.tsx
@@ -61,6 +61,13 @@ describe('ActionableItem', () => {
                 expect(screen.getByText('hello world')).toBeVisible();
             });
 
+            it('should not highlight dropdown options', () => {
+                const children = <div className="children">hello world</div>;
+                render(<ActionableItem {...basicProps}>{children}</ActionableItem>);
+
+                expect(screen.getByText('some action')).not.toHaveClass('active');
+            });
+
             it('should render the moreAppend svg in the Drop', () => {
                 shallowWithProps();
 


### PR DESCRIPTION
The `ActionableItem` component contains the `ListBox` component which has the noActive prop but we cannot access this to remove the highlight on the first item in the ActionableItem.

### Proposed Changes

Setting the the ListBox component to have noActive will fix this problem.

Without this change, the item looks like it's already selected on mount (this is not what we want when using the ActionableItem)


**Before (when action clicked)**
![image](https://user-images.githubusercontent.com/66333175/149559621-e6463a02-d09f-40c1-b92b-4ea07c22a6df.png)


**After (when action clicked)**
![image](https://user-images.githubusercontent.com/66333175/149559667-e9ec1a80-35e5-4392-a30c-3115929d6455.png)

The highlighted of the first item will no longer be there

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
