### PR TITLE
UITOOL-397/implement simple feature flags

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -31,6 +31,7 @@
         "codemirror": "5.63.3",
         "d3": "3.5.17",
         "faker": "4.1.0",
+        "flagg": "1.1.2",
         "jquery": "3.6.0",
         "lorem-ipsum": "2.0.4",
         "lz-string": "^1.4.4",

--- a/packages/website/src/FeatureFlags.tsx
+++ b/packages/website/src/FeatureFlags.tsx
@@ -1,0 +1,10 @@
+import {flagg, sessionStore} from 'flagg';
+
+export const FeatureFlags = flagg({
+    store: sessionStore(),
+    definitions: {
+        'plasma-search-bar': {
+            default: false,
+        },
+    },
+});

--- a/packages/website/src/OneDemoToRuleThemAll.tsx
+++ b/packages/website/src/OneDemoToRuleThemAll.tsx
@@ -26,7 +26,7 @@ const Header = () => (
         </a>
         <div className="flex space-around search">
             {/*
-                To toggle the feature flag, copy and paste this command in the dev tool console:
+                To toggle the feature flag, copy and paste those commands in the dev tool console:
                 sessionStorage.setItem('ff_plasma-search-bar', true) to show the bar
                 sessionStorage.setItem('ff_plasma-search-bar', false) to hide the bar
                 You need to reload the page for it to take effect.

--- a/packages/website/src/OneDemoToRuleThemAll.tsx
+++ b/packages/website/src/OneDemoToRuleThemAll.tsx
@@ -2,6 +2,7 @@ import '@styles/main.scss';
 
 import * as React from 'react';
 import {Outlet, Route, Routes} from 'react-router-dom';
+import {FeatureFlags} from './FeatureFlags';
 
 import logo from '../resources/plasma-logo.svg';
 import ScrollToTop from './building-blocs/ScrollTop';
@@ -24,9 +25,17 @@ const Header = () => (
             <img src={logo} className="header-logo" />
         </a>
         <div className="flex space-around search">
-            <EngineProvider>
-                <StandaloneSearchBar id="header" />
-            </EngineProvider>
+            {/*
+                To toggle the feature flag, copy and paste this command in the dev tool console:
+                sessionStorage.setItem('ff_plasma-search-bar', true) to show the bar
+                sessionStorage.setItem('ff_plasma-search-bar', false) to hide the bar
+                You need to reload the page for it to take effect.
+             */}
+            {FeatureFlags.get('plasma-search-bar') && (
+                <EngineProvider>
+                    <StandaloneSearchBar id="header" />
+                </EngineProvider>
+            )}
         </div>
         <div className="right-side"></div>
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,7 @@ importers:
       d3: 3.5.17
       faker: 4.1.0
       file-loader: 5.1.0
+      flagg: 1.1.2
       html-webpack-plugin: 4.5.2
       html-webpack-tags-plugin: 2.0.17
       jquery: 3.6.0
@@ -429,6 +430,7 @@ importers:
       codemirror: 5.63.3
       d3: 3.5.17
       faker: 4.1.0
+      flagg: 1.1.2
       jquery: 3.6.0
       lorem-ipsum: 2.0.4
       lz-string: 1.4.4
@@ -7799,6 +7801,10 @@ packages:
       object.pick: 1.3.0
       parse-filepath: 1.0.2
     dev: true
+
+  /flagg/1.1.2:
+    resolution: {integrity: sha512-GxSy2SGJWlQ+ZScy7hKRQoSsIoSUIWw8YvPJhKd7AOjzZMbIE2mBRzRUUkUB3gXhrrBPLKtG8KZC68ri8omReQ==}
+    dev: false
 
   /flagged-respawn/1.0.1:
     resolution: {integrity: sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==}


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-397

Using this ---> https://github.com/jamesmfriedman/flagg

This is a simple implementation for feature flags in Plasma, using the sessionStorage for the browser.

The need for Feature flags in Plasma is coming from the Search Bar development. The process is long and we want the possibility of splitting the work in multiple prs without showing the bar during it's development.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
