### PR TITLE
UITOOL-401/make search work from results page

### DIFF
--- a/packages/react/src/components/itemBox/ItemBox.tsx
+++ b/packages/react/src/components/itemBox/ItemBox.tsx
@@ -85,6 +85,7 @@ export class ItemBox extends React.Component<IItemBoxProps> {
                     data-value={this.props.value}
                     aria-hidden={this.props.hidden}
                     role="option"
+                    onMouseDown={(event) => event.preventDefault()}
                 >
                     {this.props.prepend ? <Content {...this.props.prepend} /> : null}
                     <PartialStringMatch partialMatch={this.props.highlight} caseInsensitive>

--- a/packages/website/src/pages/plasma-search/ResultPage.tsx
+++ b/packages/website/src/pages/plasma-search/ResultPage.tsx
@@ -1,4 +1,4 @@
-import {FunctionComponent, useContext, useEffect, useRef, useState} from 'react';
+import {FunctionComponent, useContext, useEffect, useState} from 'react';
 import React from 'react';
 
 import {
@@ -6,7 +6,8 @@ import {
     ResultList as HeadlessResultList,
     loadQueryActions,
     Result,
-    SearchEngine,
+    loadSearchAnalyticsActions,
+    loadSearchActions,
 } from '@coveo/headless';
 import {Section, Tile} from '@coveord/plasma-react';
 import {useSearchParams} from 'react-router-dom';
@@ -14,31 +15,13 @@ import {EngineContext} from '../../search/engine/EngineContext';
 
 interface ResultListProps {
     controller: HeadlessResultList;
-    query: string;
-    engine: SearchEngine;
 }
 
 const ResultListRenderer: FunctionComponent<ResultListProps> = (props) => {
-    const {controller, engine, query} = props;
+    const {controller} = props;
     const [state, setState] = useState(controller.state);
-    // const previousSearchId = useRef('');
-
-    // const isNewSearchEvent = () => {
-    //     const currentSearchId = state.searchResponseId;
-
-    //     if (currentSearchId !== previousSearchId.current) {
-    //         previousSearchId.current = currentSearchId;
-    //         return true;
-    //     }
-    //     return false;
-    // };
 
     useEffect(() => controller.subscribe(() => setState(controller.state)), [controller]);
-    useEffect(() => {
-        const {updateQuery} = loadQueryActions(engine);
-        engine.dispatch(updateQuery({q: query}));
-        engine.executeFirstSearch();
-    }, [query]);
 
     return (
         <>
@@ -48,7 +31,7 @@ const ResultListRenderer: FunctionComponent<ResultListProps> = (props) => {
                     <div className="body-l-book plasma-description">Patate King!</div>
                     <div className="tile-grid">
                         {state.results.map((result: Result) =>
-                            result.title !== 'Vapor Design System' ? (
+                            result.title !== 'Plasma Design System' ? (
                                 <Tile
                                     title={result.title}
                                     href={result.clickUri}
@@ -68,8 +51,14 @@ const ResultPage = () => {
     const engine = useContext(EngineContext);
     const [searchParams] = useSearchParams();
     const query = searchParams.get('query');
+    const {updateQuery} = loadQueryActions(engine);
+    const {logInterfaceLoad} = loadSearchAnalyticsActions(engine);
+    const {executeSearch} = loadSearchActions(engine);
+    engine.dispatch(updateQuery({q: query}));
+    engine.dispatch(executeSearch(logInterfaceLoad()));
     const controller = buildResultList(engine);
-    return <ResultListRenderer controller={controller} query={query} engine={engine} />;
+
+    return <ResultListRenderer controller={controller} />;
 };
 
 export default ResultPage;

--- a/packages/website/src/search/StandaloneSearchBar.tsx
+++ b/packages/website/src/search/StandaloneSearchBar.tsx
@@ -15,6 +15,7 @@ interface SearchBarProps {
 const SearchBoxRerender: FunctionComponent<SearchBarProps> = (props) => {
     const {controller} = props;
     const [state, setState] = useState(controller.state);
+    const [focused, setFocused] = useState(false);
 
     useEffect(() => controller.subscribe(() => setState(controller.state)), [controller]);
 
@@ -51,7 +52,7 @@ const SearchBoxRerender: FunctionComponent<SearchBarProps> = (props) => {
 
         return (
             <>
-                {(state.suggestions.length > 0 || state.isLoadingSuggestions) && (
+                {focused && (state.suggestions.length > 0 || state.isLoadingSuggestions) && (
                     <ListBox
                         classes={['search-results-container']}
                         isLoading={state.isLoadingSuggestions}
@@ -80,6 +81,8 @@ const SearchBoxRerender: FunctionComponent<SearchBarProps> = (props) => {
                     value={state.value}
                     onChange={(event) => controller.updateText(event.target.value)}
                     onKeyDown={(event) => event.key === 'Enter' && controller.submit()}
+                    onFocus={() => setFocused(true)}
+                    onBlur={() => setFocused(false)}
                 />
                 <ClearButton />
                 <SearchButton />

--- a/packages/website/src/search/StandaloneSearchBar.tsx
+++ b/packages/website/src/search/StandaloneSearchBar.tsx
@@ -45,9 +45,9 @@ const SearchBoxRerender: FunctionComponent<SearchBarProps> = (props) => {
     );
 
     const SuggestionListBox = () => {
-        const results: IItemBoxProps[] = state.suggestions.map((s) => ({
-            value: s.rawValue,
-            displayValue: s.highlightedValue,
+        const results: IItemBoxProps[] = state.suggestions.map((result) => ({
+            value: result.rawValue,
+            displayValue: result.highlightedValue,
         }));
 
         return (
@@ -57,9 +57,7 @@ const SearchBoxRerender: FunctionComponent<SearchBarProps> = (props) => {
                         classes={['search-results-container']}
                         isLoading={state.isLoadingSuggestions}
                         items={results}
-                        onOptionClick={(item) => {
-                            controller.selectSuggestion(item.value);
-                        }}
+                        onOptionClick={(item) => controller.selectSuggestion(item.value)}
                     />
                 )}
             </>
@@ -68,19 +66,21 @@ const SearchBoxRerender: FunctionComponent<SearchBarProps> = (props) => {
 
     return (
         <div className="plasmaSearchBar">
-            <form
-                autoComplete="off"
-                onSubmit={(e) => {
-                    e.preventDefault();
-                }}
-            >
+            <form autoComplete="off" onSubmit={(event) => event.preventDefault()}>
                 <input
                     className="search-bar"
                     type="search"
                     placeholder={'Find a component...'}
                     value={state.value}
                     onChange={(event) => controller.updateText(event.target.value)}
-                    onKeyDown={(event) => event.key === 'Enter' && controller.submit()}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                            controller.submit();
+                        } else if (event.key === 'Escape') {
+                            controller.clear();
+                            (event.target as HTMLInputElement).blur();
+                        }
+                    }}
                     onFocus={() => setFocused(true)}
                     onBlur={() => setFocused(false)}
                 />

--- a/packages/website/src/search/StandaloneSearchBar.tsx
+++ b/packages/website/src/search/StandaloneSearchBar.tsx
@@ -1,7 +1,7 @@
 import '@styles/plasmaSearchBar.scss';
 
 import {useEffect, useState, FunctionComponent, useContext} from 'react';
-import {buildSearchBox, SearchBox} from '@coveo/headless';
+import {buildSearchBox, SearchBox, SearchBoxState} from '@coveo/headless';
 import React from 'react';
 import {Button, IItemBoxProps, ListBox, Svg} from '@coveord/plasma-react';
 
@@ -14,7 +14,7 @@ interface SearchBarProps {
 }
 const SearchBoxRerender: FunctionComponent<SearchBarProps> = (props) => {
     const {controller} = props;
-    const [state, setState] = useState(controller.state);
+    const [state, setState] = useState<SearchBoxState>(controller.state);
     const [focused, setFocused] = useState(false);
 
     useEffect(() => controller.subscribe(() => setState(controller.state)), [controller]);


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-401

The search is now working from anywhere in Plasma!!

I've also added a focus and blur to hide the listbox when the input is not in focus.


> /*
> * To toggle the feature flag, copy and paste those commands in the dev tool console:
> * sessionStorage.setItem('ff_plasma-search-bar', true) to show the bar
> * sessionStorage.setItem('ff_plasma-search-bar', false) to hide the bar
> * You need to reload the page for it to take effect.
> */

### Potential Breaking Changes

should be none!

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
