### PR TITLE
fix(website): remove invalid character for css class

### DIFF
--- a/packages/website/src/building-blocs/ExampleLayout.tsx
+++ b/packages/website/src/building-blocs/ExampleLayout.tsx
@@ -56,7 +56,7 @@ export const ExampleLayout: React.FunctionComponent<ExampleLayoutProps> = ({
                 >
                     View source
                 </GithubButton>
-                <h3 className="h1-light normal-white-space @crawled-title">{title}</h3>
+                <h3 className="h1-light normal-white-space crawled-title">{title}</h3>
                 <Tile />
                 <div>{description}</div>
             </div>

--- a/packages/website/src/building-blocs/VaporComponent.tsx
+++ b/packages/website/src/building-blocs/VaporComponent.tsx
@@ -25,7 +25,7 @@ export const VaporComponent: React.FunctionComponent<VaporComponentProps & React
     return (
         <div id={id}>
             <BasicHeader
-                title={{text: title, classes: ['@crawled-title']}}
+                title={{text: title, classes: ['crawled-title']}}
                 description={usage}
                 tabs={[
                     {groupId: 'page', id: 'usage', title: 'Usage'},


### PR DESCRIPTION
### Proposed Changes

The `@` is an invalid character for a css class, the web crawler cannot access it.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
