### PR TITLE
fix(website): enable crawling of description on the new layout

### DIFF
--- a/packages/website/src/building-blocs/ExampleLayout.tsx
+++ b/packages/website/src/building-blocs/ExampleLayout.tsx
@@ -56,9 +56,11 @@ export const ExampleLayout: React.FunctionComponent<ExampleLayoutProps> = ({
                 >
                     View source
                 </GithubButton>
-                <h3 className="h1-light normal-white-space crawled-title">{title}</h3>
+                <h3 className="h1-light normal-white-space" data-coveo-field="title">
+                    {title}
+                </h3>
                 <Tile thumbnail={thumbnail} />
-                <div>{description}</div>
+                <div data-coveo-field="description">{description}</div>
             </div>
             <TabsHeader
                 tabs={[

--- a/packages/website/src/building-blocs/VaporComponent.tsx
+++ b/packages/website/src/building-blocs/VaporComponent.tsx
@@ -25,7 +25,7 @@ export const VaporComponent: React.FunctionComponent<VaporComponentProps & React
     return (
         <div id={id}>
             <BasicHeader
-                title={{text: title, classes: ['crawled-title']}}
+                title={{text: title}}
                 description={usage}
                 tabs={[
                     {groupId: 'page', id: 'usage', title: 'Usage'},


### PR DESCRIPTION
### Proposed Changes

Setup `data-coveo-field` attributes on elements of the page just for the new layout. I figured we could create field mapping that map multiple metadata to the same field, making it easy to have different selectors for the old and the new layout.

The new webscraping configuration will look like this
```json
"metadata": {
    "description": {
        "type": "CSS",
        "path": "[data-coveo-field='description']"
    },
    "title": {
        "type": "CSS",
        "path": "[data-coveo-field='title']"
    },
    "legacy_description": {
        "type": "CSS",
        "path": "h4.admin-description::text"
    },
    "legacy_title": {
      "type": "CSS",
      "path": ".panel-header h4.bolder::text"
    }
}
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
