### PR TITLE
feat(website): crawl thumbnails and display them in search results

### DIFF
--- a/packages/website/src/building-blocs/Tile.tsx
+++ b/packages/website/src/building-blocs/Tile.tsx
@@ -41,7 +41,14 @@ export interface TileProps {
 }
 
 export const Tile: React.FunctionComponent<TileProps> = ({title, description, href, thumbnail = 'placeholder'}) => {
-    const tileIcon = <img src={thumbnails[thumbnail]} className="full-content-x" />;
+    const tileIcon = (
+        <img
+            src={thumbnails[thumbnail]}
+            className="full-content-x"
+            data-coveo-field="thumbnail"
+            data-thumbnail-name={thumbnail}
+        />
+    );
     const tileInfo = (title || description) && (
         <div className="tile-information">
             {title && <div className="tile-title h6-subdued">{title}</div>}

--- a/packages/website/src/pages/SearchResultPage.tsx
+++ b/packages/website/src/pages/SearchResultPage.tsx
@@ -12,7 +12,7 @@ import {FunctionComponent, useContext, useEffect, useState} from 'react';
 import React from 'react';
 import {useSearchParams} from 'react-router-dom';
 
-import {Tile} from '../building-blocs/Tile';
+import {Tile, TileProps} from '../building-blocs/Tile';
 import {EngineContext} from '../search/engine/EngineContext';
 
 interface ResultListProps {
@@ -32,13 +32,14 @@ const ResultListRenderer: FunctionComponent<ResultListProps> = (props) => {
                     <h2>Search Results:</h2>
                     <div className="body-l-book plasma-description">Patate King!</div>
                     <div className="tile-grid">
-                        {state.results.map(({title, clickUri, excerpt, uniqueId}: Result) =>
+                        {state.results.map(({title, raw, uniqueId, clickUri}: Result) =>
                             title !== 'Plasma Design System' ? (
                                 <Tile
                                     key={uniqueId}
                                     title={title}
                                     href={clickUri.slice(clickUri.indexOf('#'))}
-                                    description={excerpt}
+                                    description={raw.description as string}
+                                    thumbnail={raw.thumbnail as TileProps['thumbnail']}
                                 />
                             ) : null
                         )}

--- a/packages/website/src/search/engine/EngineProvider.tsx
+++ b/packages/website/src/search/engine/EngineProvider.tsx
@@ -10,7 +10,7 @@ export const EngineProvider: React.FunctionComponent = ({children}) => {
     React.useEffect(() => {
         const newEngine = headlessEngine();
         const {registerFieldsToInclude} = loadFieldActions(newEngine);
-        newEngine.dispatch(registerFieldsToInclude(['componentname']));
+        newEngine.dispatch(registerFieldsToInclude(['description', 'thumbnail']));
         setEngine(newEngine);
     }, []);
 


### PR DESCRIPTION
### Proposed Changes

Make sure thumbnails are crawled and that they can be used when rendering search results.

![image](https://user-images.githubusercontent.com/35579930/152038455-10efeafc-dfb4-4663-9a3d-2ebde8e3cd8e.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
