### PR TITLE
fix(website): remove broken urls from home page

### DIFF
--- a/packages/website/src/pages/Home.tsx
+++ b/packages/website/src/pages/Home.tsx
@@ -73,8 +73,8 @@ const LayoutPages: React.FC = () => (
             <Tile title="Collapsible" description="Collapsible" href="#/layout/Collapsible" />
             <Tile title="Icon Card" description="Icon Card" href="#/layout/IconCard" />
             <Tile title="Info Box" description="Info Box" href="#/layout/InfoBox" />
-            <Tile title="Labelled Value" description="Labelled Value" href="#/layout/LabelledValue" />
-            <Tile title="Limit Card" description="Limit Card" href="#/layout/LimitCard" />
+            <Tile title="Labelled Value" description="Labelled Value" href="#/layout/LabeledValue" />
+            <Tile title="Limit Card" description="Limit Card" href="#/layout/Limit" />
             <Tile
                 title="Modal Window"
                 description="Modal windows appear in front of the main page and disable it while they are visible. They act as a zoom in on an element of the main page that allows additionnal interaction or configuration. They make possible for users to focus on their content whilst avoiding leaving the context from which they have been called."
@@ -89,7 +89,7 @@ const LayoutPages: React.FC = () => (
                 href="#/layout/Section"
             />
             <Tile title="Split Layout" description="Split Layout" href="#/layout/SplitLayout" />
-            <Tile title="Table" description="Table" href="#/layout/Table" />
+            <Tile title="Table" description="Table" href="#/layout/TableHOC" />
             <Tile title="Table HOC Loading" description="Table HOC Loading" href="#/layout/TableHOCLoading" />
             <Tile title="Table HOC Server" description="Table HOC Server" href="#/layout/TableHOCServer" />
             <Tile
@@ -164,11 +164,6 @@ const FormPages: React.FC = () => (
                 description="Display an inline validation message when the user is done interacting with the input."
                 href="#/form/TextInput"
                 thumbnail="textInput"
-            />
-            <Tile
-                title="Value Popup"
-                description="This is the filter picker control used to define a filter on a field."
-                href="#/form/ValuePopup"
             />
         </div>
     </Section>


### PR DESCRIPTION
### Proposed Changes

I noticed while looking into the content browser that the crawler had found some broken routes. Those routes could be returned by the search which is not something we want.

![image](https://user-images.githubusercontent.com/35579930/152043216-02307ef0-fd18-450a-ba82-a1c16669fba6.png)

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
