### PR TITLE
fix(website): redirect to plasma when loading vapor

### DIFF
--- a/packages/website/src/Index.tsx
+++ b/packages/website/src/Index.tsx
@@ -16,6 +16,10 @@ window.ReactDOM = ReactDOM;
 (window as any).ReactRedux = ReactRedux;
 (window as any).PlasmaReact = PlasmaReact;
 
+if (window.location.host === 'vapor.coveo.com') {
+    window.location.href = window.location.href.replace('vapor.coveo.com', 'plasma.coveo.com');
+}
+
 ReactDOM.render(
     <HashRouter>
         <ReactRedux.Provider store={Store}>


### PR DESCRIPTION
### Proposed Changes

Simple js to redirect on `plasma.coveo.com` when loading the `vapor.coveo.com`. It should keep all the rest of the path

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
