### PR TITLE
refactor(website): remove drawer behaviour on tile without description

### DIFF
--- a/packages/website/src/building-blocs/Tile.tsx
+++ b/packages/website/src/building-blocs/Tile.tsx
@@ -1,15 +1,16 @@
 import '@styles/tile.scss';
 
+import classNames from 'classnames';
 import * as React from 'react';
 
 import actionButtonPng from '../../resources/thumbnail_ActionButton.png';
 import codeEditorPng from '../../resources/thumbnail_CodeEditor.png';
-import placeholderPng from '../../resources/thumbnail_Placeholder.png';
 import filterBoxPng from '../../resources/thumbnail_FilterBox.png';
 import iconographyPng from '../../resources/thumbnail_Iconography.png';
 import linksPng from '../../resources/thumbnail_Link.png';
 import headerPng from '../../resources/thumbnail_PageHeader.png';
 import breadcrumbPng from '../../resources/thumbnail_PageTitle.png';
+import placeholderPng from '../../resources/thumbnail_Placeholder.png';
 import progressBarPng from '../../resources/thumbnail_ProgressBar.png';
 import sideNavPng from '../../resources/thumbnail_SideNav.png';
 import tabPng from '../../resources/thumbnail_Tab.png';
@@ -55,10 +56,11 @@ export const Tile: React.FunctionComponent<TileProps> = ({title, description, hr
             {description && <div className="tile-description body-m-book-subdued">{description}</div>}
         </div>
     );
+    const className = classNames('tile card', {'mod-drawer': description});
 
     if (href && href.length > 0) {
         return (
-            <a className="tile card" href={href}>
+            <a className={className} href={href}>
                 {tileIcon}
                 {tileInfo}
             </a>
@@ -66,7 +68,7 @@ export const Tile: React.FunctionComponent<TileProps> = ({title, description, hr
     }
 
     return (
-        <div className="tile card">
+        <div className={className}>
             {tileIcon}
             {tileInfo}
         </div>

--- a/packages/website/src/pages/Home.tsx
+++ b/packages/website/src/pages/Home.tsx
@@ -51,8 +51,8 @@ const FoundationsPages: React.FC = () => (
                 href="#/foundations/Headings"
                 thumbnail="typekit"
             />
-            <Tile title="Links" description="Links examples" href="#/foundations/Links" thumbnail="links" />
-            <Tile title="Whitespace" description="Whitespace" href="/#/foundations/Whitespace" />
+            <Tile title="Links" href="#/foundations/Links" thumbnail="links" />
+            <Tile title="Whitespace" href="/#/foundations/Whitespace" />
         </div>
     </Section>
 );
@@ -61,42 +61,38 @@ const LayoutPages: React.FC = () => (
     <Section className="section">
         <h2>Layout</h2>
         <div className="tile-grid">
-            <Tile title="Banner" description="Banner" href="#/layout/Banner" />
+            <Tile title="Banner" href="#/layout/Banner" />
             <Tile
                 title="Blank Slate"
                 description="Use blankSlate to show information and some actions after an event."
                 href="#/layout/BlankSlate"
             />
-            <Tile title="Bordered Line" description="Bordered Line" href="#/layout/BorderedLine" />
-            <Tile title="Browser Preview" description="Browser Preview" href="#/layout/BrowserPreview" />
-            <Tile title="Chart" description="Chart" href="#/layout/Chart" />
-            <Tile title="Collapsible" description="Collapsible" href="#/layout/Collapsible" />
-            <Tile title="Icon Card" description="Icon Card" href="#/layout/IconCard" />
-            <Tile title="Info Box" description="Info Box" href="#/layout/InfoBox" />
-            <Tile title="Labelled Value" description="Labelled Value" href="#/layout/LabeledValue" />
-            <Tile title="Limit Card" description="Limit Card" href="#/layout/Limit" />
+            <Tile title="Bordered Line" href="#/layout/BorderedLine" />
+            <Tile title="Browser Preview" href="#/layout/BrowserPreview" />
+            <Tile title="Chart" href="#/layout/Chart" />
+            <Tile title="Collapsible" href="#/layout/Collapsible" />
+            <Tile title="Icon Card" href="#/layout/IconCard" />
+            <Tile title="Info Box" href="#/layout/InfoBox" />
+            <Tile title="Labelled Value" href="#/layout/LabeledValue" />
+            <Tile title="Limit Card" href="#/layout/Limit" />
             <Tile
                 title="Modal Window"
                 description="Modal windows appear in front of the main page and disable it while they are visible. They act as a zoom in on an element of the main page that allows additionnal interaction or configuration. They make possible for users to focus on their content whilst avoiding leaving the context from which they have been called."
                 href="#/layout/ModalWindow"
             />
-            <Tile title="Modal Wizard" description="Modal Wizard" href="#/layout/ModalWizard" />
-            <Tile title="Page Header" description="Page Header" href="#/layout/PageHeader" thumbnail="header" />
-            <Tile title="Footer" description="Footer" href="#/layout/Footer" />
+            <Tile title="Modal Wizard" href="#/layout/ModalWizard" />
+            <Tile title="Page Header" href="#/layout/PageHeader" thumbnail="header" />
+            <Tile title="Footer" href="#/layout/Footer" />
             <Tile
                 title="Section"
                 description="Customizing the display and behavior of the interface displayed."
                 href="#/layout/Section"
             />
-            <Tile title="Split Layout" description="Split Layout" href="#/layout/SplitLayout" />
-            <Tile title="Table" description="Table" href="#/layout/TableHOC" />
-            <Tile title="Table HOC Loading" description="Table HOC Loading" href="#/layout/TableHOCLoading" />
-            <Tile title="Table HOC Server" description="Table HOC Server" href="#/layout/TableHOCServer" />
-            <Tile
-                title="Table HOC with Blank Slate"
-                description="Table HOC with Blank Slate"
-                href="#/layout/TableHOCwithBlankSlate"
-            />
+            <Tile title="Split Layout" href="#/layout/SplitLayout" />
+            <Tile title="Table" href="#/layout/TableHOC" />
+            <Tile title="Table HOC Loading" href="#/layout/TableHOCLoading" />
+            <Tile title="Table HOC Server" href="#/layout/TableHOCServer" />
+            <Tile title="Table HOC with Blank Slate" href="#/layout/TableHOCwithBlankSlate" />
         </div>
     </Section>
 );
@@ -105,7 +101,7 @@ const FormPages: React.FC = () => (
     <Section className="section">
         <h2>Form</h2>
         <div className="tile-grid">
-            <Tile title="Actionable Item" description="Actionable Item" href="#/form/ActionableItem" />
+            <Tile title="Actionable Item" href="#/form/ActionableItem" />
             <Tile
                 title="Button"
                 description="Buttons communicate actions, and, when clicked, initialize those actions"
@@ -122,16 +118,16 @@ const FormPages: React.FC = () => (
                 description="Try to display only one Child Form at a time in a given option set."
                 href="#/form/ChildForm"
             />
-            <Tile title="Code Editor" description="Code Editor" href="#/form/CodeEditor" thumbnail="codeEditor" />
-            <Tile title="Color Picker" description="Code Picker" href="#/form/ColorPicker" />
-            <Tile title="Date Picker" description="Date Picker" href="#/form/DatePicker" />
-            <Tile title="Diff Viewer" description="Diff Viewer" href="#/form/DiffViewer" />
-            <Tile title="Facet" description="Facet" href="#/form/Facet" />
-            <Tile title="File Picker" description="File Picker" href="#/form/Filepicker" />
-            <Tile title="Filter Box" description="Filter Box" href="#/form/FilterBox" thumbnail="filterBox" />
-            <Tile title="Flat Select" description="Flat Select" href="#/form/FlatSelect" />
-            <Tile title="JSON Editor" description="JSON Editor" href="#/form/JSONEditor" />
-            <Tile title="Multiline Box" description="Multiline Box" href="#/form/MultilineBox" />
+            <Tile title="Code Editor" href="#/form/CodeEditor" thumbnail="codeEditor" />
+            <Tile title="Color Picker" href="#/form/ColorPicker" />
+            <Tile title="Date Picker" href="#/form/DatePicker" />
+            <Tile title="Diff Viewer" href="#/form/DiffViewer" />
+            <Tile title="Facet" href="#/form/Facet" />
+            <Tile title="File Picker" href="#/form/Filepicker" />
+            <Tile title="Filter Box" href="#/form/FilterBox" thumbnail="filterBox" />
+            <Tile title="Flat Select" href="#/form/FlatSelect" />
+            <Tile title="JSON Editor" href="#/form/JSONEditor" />
+            <Tile title="Multiline Box" href="#/form/MultilineBox" />
             <Tile
                 title="Numeric Inputs"
                 description="The input field should be large enough to display all the user input in most cases."
@@ -142,7 +138,7 @@ const FormPages: React.FC = () => (
                 description="Radio button requires the selection of exactly one option from a list of mutually exclusive options."
                 href="#/form/RadioButton"
             />
-            <Tile title="Search Bar" description="Search Bar" href="#/form/SearchBar" />
+            <Tile title="Search Bar" href="#/form/SearchBar" />
             <Tile
                 title="Single Select"
                 description="If space allows, and there are no more than 7 options to choose from, consider using radio buttons instead."
@@ -158,7 +154,7 @@ const FormPages: React.FC = () => (
                 description="For binary settings, use a slide toggle, toggle, or checkbox instead."
                 href="#/form/Slider"
             />
-            <Tile title="Text Area" description="Text Area" href="#/form/TextArea" />
+            <Tile title="Text Area" href="#/form/TextArea" />
             <Tile
                 title="Text Input"
                 description="Display an inline validation message when the user is done interacting with the input."
@@ -173,20 +169,10 @@ const NavigationPages: React.FC = () => (
     <Section className="section">
         <h2>Navigation</h2>
         <div className="tile-grid">
-            <Tile
-                title="Breadcrumbs"
-                description="Breadcrumbs"
-                href="#/navigation/Breadcrumbs"
-                thumbnail="breadcrumb"
-            />
-            <Tile
-                title="Sidebar Navigation"
-                description="Sidebar Navigation"
-                href="#/navigation/SideNavigation"
-                thumbnail="sideNav"
-            />
-            <Tile title="SubNavigation" description="SubNavigation" href="#/navigation/SubNavigation" />
-            <Tile title="Tabs" description="Tabs" href="#/navigation/Tabs" thumbnail="tab" />
+            <Tile title="Breadcrumbs" href="#/navigation/Breadcrumbs" thumbnail="breadcrumb" />
+            <Tile title="Sidebar Navigation" href="#/navigation/SideNavigation" thumbnail="sideNav" />
+            <Tile title="SubNavigation" href="#/navigation/SubNavigation" />
+            <Tile title="Tabs" href="#/navigation/Tabs" thumbnail="tab" />
         </div>
     </Section>
 );
@@ -195,14 +181,14 @@ const FeedbackPages: React.FC = () => (
     <Section className="section">
         <h2>Feedback</h2>
         <div className="tile-grid">
-            <Tile title="Badge" description="Badge" href="#/feedback/Badge" thumbnail="badge" />
-            <Tile title="Color Bar" description="Color Bar" href="#/feedback/ColorBar" thumbnail="progressBar" />
-            <Tile title="Color Dot" description="Color Dot" href="#/feedback/ColorDot" />
-            <Tile title="Icon Badge" description="Icon Badge" href="#/feedback/IconBadge" />
-            <Tile title="Last Updated" description="Last Updated" href="#/feedback/LastUpdated" />
+            <Tile title="Badge" href="#/feedback/Badge" thumbnail="badge" />
+            <Tile title="Color Bar" href="#/feedback/ColorBar" thumbnail="progressBar" />
+            <Tile title="Color Dot" href="#/feedback/ColorDot" />
+            <Tile title="Icon Badge" href="#/feedback/IconBadge" />
+            <Tile title="Last Updated" href="#/feedback/LastUpdated" />
             <Tile title="Loading Spinner" description="Animated loading spinner" href="#/feedback/Loading" />
-            <Tile title="Step Progress Bar" description="Step Progress Bar" href="#/feedback/StepProgressBar" />
-            <Tile title="Sync Feedback" description="Sync Feedback" href="#/feedback/SyncFeedback" />
+            <Tile title="Step Progress Bar" href="#/feedback/StepProgressBar" />
+            <Tile title="Sync Feedback" href="#/feedback/SyncFeedback" />
             <Tile
                 title="Toast"
                 description="Only include information that is relevant to the performed action."
@@ -213,7 +199,7 @@ const FeedbackPages: React.FC = () => (
                 description="Only include information that is relevant to the performed action."
                 href="#/feedback/ToastConnected"
             />
-            <Tile title="Toast Content" description="Toast Content" href="#/feedback/ToastContent" />
+            <Tile title="Toast Content" href="#/feedback/ToastContent" />
             <Tile
                 title="Tooltip"
                 description="Tooltips are short descriptions that appear when hovering an element. They are used to provide explanations that do not require nor allow user interaction, like tips and tricks."

--- a/packages/website/src/styles/tile.scss
+++ b/packages/website/src/styles/tile.scss
@@ -22,7 +22,7 @@ a.tile:hover {
     transition: height 300ms;
 }
 
-.tile:hover > .tile-information {
+.tile.mod-drawer:hover > .tile-information {
     height: 131.75px;
     box-shadow: 0px -6px 41px rgba(142, 149, 157, 0.29);
 


### PR DESCRIPTION
### Proposed Changes

When a tile has no description, it should not have any vertical slide behaviour because there is nothing to show in there anyway.

Before

https://user-images.githubusercontent.com/35579930/152229940-bfe61c8e-b2dd-48d1-b521-6542d8019fe1.mp4

After

https://user-images.githubusercontent.com/35579930/152229953-ea52ef93-c02d-4d16-90c7-1e1d6870c64d.mp4



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
