### PR TITLE
fix(tooltip): add back css rules that were removed

### DIFF
--- a/packages/style/scss/components/tooltip.scss
+++ b/packages/style/scss/components/tooltip.scss
@@ -9,10 +9,12 @@
 
     opacity: 0;
 
-    &.show {
+    &.show,
+    &.in {
         opacity: 1;
     }
 
+    &.top,
     &[data-popper-placement='top'] {
         margin-top: -3px;
         padding: 5px 0;
@@ -27,6 +29,7 @@
         }
     }
 
+    &.right,
     &[data-popper-placement='right'] {
         margin-left: 3px;
         padding: 0 5px;
@@ -41,6 +44,7 @@
         }
     }
 
+    &.bottom,
     &[data-popper-placement='bottom'] {
         margin-top: 3px;
         padding: 5px 0;
@@ -55,6 +59,7 @@
         }
     }
 
+    &.left,
     &[data-popper-placement='left'] {
         margin-left: -3px;
         padding: 0 5px;
@@ -74,20 +79,32 @@
             background-color: var(--critical-70);
         }
 
-        &[data-popper-placement='left'] .tooltip-arrow {
-            border-left-color: var(--critical-70);
+        &.left,
+        &[data-popper-placement='left'] {
+            .tooltip-arrow {
+                border-left-color: var(--critical-70);
+            }
         }
 
-        &[data-popper-placement='bottom'] .tooltip-arrow {
-            border-bottom-color: var(--critical-70);
+        &.bottom,
+        &[data-popper-placement='bottom'] {
+            .tooltip-arrow {
+                border-bottom-color: var(--critical-70);
+            }
         }
 
-        &[data-popper-placement='top'] .tooltip-arrow {
-            border-top-color: var(--critical-70);
+        &.top,
+        &[data-popper-placement='top'] {
+            .tooltip-arrow {
+                border-top-color: var(--critical-70);
+            }
         }
 
-        &[data-popper-placement='right'] .tooltip-arrow {
-            border-right-color: var(--critical-70);
+        &.right,
+        &[data-popper-placement='right'] {
+            .tooltip-arrow {
+                border-right-color: var(--critical-70);
+            }
         }
     }
 


### PR DESCRIPTION
### Proposed Changes

Some tooltips in backbone interfaces were not showing up anymore because [these classes](https://github.com/coveo/plasma/commit/c751484c1f5bf6fbefae18d731bf5ed691fcf6d7#diff-cfad190c5bb5ee6429a91470b346ce72104e004b7d2bf0f6fdcab7f47531cd56L12) were removed. See https://coveord.atlassian.net/browse/ADUI-7803

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
