### PR TITLE
fix(tablepagination): -default value of totalPages

### DIFF
--- a/packages/react/src/components/pagination/TablePagination.tsx
+++ b/packages/react/src/components/pagination/TablePagination.tsx
@@ -32,9 +32,9 @@ export const TablePagination: FunctionComponent<ITablePaginationProps> = ({
         <div className="flex-auto" />
         <PaginationPagesNumber
             id={TableHOCUtils.getPaginationId(id)}
-            totalPages={totalPages || 1}
+            totalPages={totalPages}
             disabled={disabled}
-            hidden={totalPages === 1}
+            hidden={!totalPages || totalPages === 1}
         />
     </div>
 );

--- a/packages/react/src/components/table-hoc/TableWithNewPagination.tsx
+++ b/packages/react/src/components/table-hoc/TableWithNewPagination.tsx
@@ -59,7 +59,7 @@ export const tableWithNewPagination = (
             pageNb,
             perPage,
             totalEntries: length,
-            totalPages: Math.max(Math.ceil(length / perPage), 1),
+            totalPages: length ? Math.max(Math.ceil(length / perPage), 1) : undefined,
             data: isServer ? ownProps.data : ownProps.data && sliceData(ownProps.data, startingIndex, endingIndex),
         };
     };


### PR DESCRIPTION
### Proposed Changes

Remove the default totalPage value from 1 to undefined, since it was causing a bug in the _i think_ only TableWithUrlState table of the admin. That way, a user can copy-paste an url to a specific date and page in the activity browser table.

If you want to test it, you will have to link plasma/react to the admin repo (please do and verify that the other tables are not broken that way) :) 

will fix https://coveord.atlassian.net/browse/ADUI-7800

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
