### PR TITLE
feat(props): display deprecated and default props

### DIFF
--- a/packages/react/src/components/toast/Toast.tsx
+++ b/packages/react/src/components/toast/Toast.tsx
@@ -15,7 +15,9 @@ export interface IToastProps {
      */
     title?: React.ReactNode;
     /**
-     * The type of the toast (default is "success")
+     * The type of the toast
+     *
+     * @default "success"
      */
     type?: 'success' | 'warning' | 'error' | 'info' | 'download';
     /**
@@ -43,7 +45,7 @@ export interface IToastProps {
      */
     onClose?: () => void;
     /**
-     * @deprecated use children instead
+     * @deprecated Use children instead
      */
     content?: React.ReactNode;
     /**
@@ -51,7 +53,7 @@ export interface IToastProps {
      */
     onRender?: () => void;
     /**
-     * @deprecated - Use onClose instead
+     * @deprecated Use onClose instead
      */
     onDestroy?: () => void;
 }

--- a/packages/website/src/pages/Home.tsx
+++ b/packages/website/src/pages/Home.tsx
@@ -195,12 +195,6 @@ const FeedbackPages: React.FC = () => (
                 href="#/feedback/Toast"
             />
             <Tile
-                title="Toast Connected"
-                description="Only include information that is relevant to the performed action."
-                href="#/feedback/ToastConnected"
-            />
-            <Tile title="Toast Content" href="#/feedback/ToastContent" />
-            <Tile
                 title="Tooltip"
                 description="Tooltips are short descriptions that appear when hovering an element. They are used to provide explanations that do not require nor allow user interaction, like tips and tricks."
                 href="#/feedback/Tooltip"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5321,7 +5321,7 @@ packages:
 
   /chokidar/2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
-    deprecated: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
+    deprecated: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
     dependencies:
       anymatch: 2.0.0
       async-each: 1.0.3
@@ -5357,7 +5357,6 @@ packages:
   /chokidar/3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
-    requiresBuild: true
     dependencies:
       anymatch: 3.1.2
       braces: 3.0.2
@@ -18713,7 +18712,7 @@ packages:
       graceful-fs: 4.2.8
       neo-async: 2.6.2
     optionalDependencies:
-      chokidar: 3.5.3
+      chokidar: 3.5.2
       watchpack-chokidar2: 2.0.1
     dev: true
 


### PR DESCRIPTION
### Proposed Changes

Inside of the props table, 
1. display the default value when it is in the jsdoc
2. display the deprecated props with the associated comment

![image](https://user-images.githubusercontent.com/260007/152870106-98e091a7-2ac2-4677-a2a8-86116611d8bf.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
