### PR TITLE
fix(website): improve UX when switching between sandbox pages

### DIFF
--- a/packages/website/src/building-blocs/PropsDoc.tsx
+++ b/packages/website/src/building-blocs/PropsDoc.tsx
@@ -1,9 +1,10 @@
-import {Loading} from '@coveord/plasma-react';
 import {createSystem, createVirtualTypeScriptEnvironment} from '@typescript/vfs';
 import * as React from 'react';
 import * as ts from 'typescript';
+
 import '@styles/props-doc.scss';
 
+import {PlasmaLoading} from './PlasmaLoading';
 import {useTypescriptServer} from './useTypescriptServer';
 
 interface PropInfo {
@@ -63,7 +64,7 @@ const props: React.ComponentProps<typeof ${componentName}> = {`;
     }, [componentName, fsMap]);
 
     if (!propsList) {
-        return <Loading />;
+        return <PlasmaLoading />;
     }
 
     if (propsList.length < 1) {

--- a/packages/website/src/building-blocs/Sandbox.tsx
+++ b/packages/website/src/building-blocs/Sandbox.tsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 import * as monaco from 'monaco-editor';
 import * as _ from 'underscore';
 import '@styles/sandbox.scss';
+import {PlasmaLoading} from './PlasmaLoading';
 import {useTypescriptServer} from './useTypescriptServer';
 // eslint-disable-next-line
 const prettierConfig = require('tsjs/prettier-config');
@@ -67,11 +68,17 @@ export const Sandbox: React.FunctionComponent<{children: string; id: string; tit
 
     return (
         <div className={classNames('demo-sandbox', {horizontal})}>
-            <div className="demo-sandbox__preview" id={id} />
-            <div>
-                {title && <div className="demo-sandbox__title body-m-book">{title}</div>}
-                <Editor id={id} value={formattedCode} onChange={setEditedCode} />
-            </div>
+            {fsMap === null ? (
+                <PlasmaLoading />
+            ) : (
+                <>
+                    <div className="demo-sandbox__preview" id={id} />
+                    <div>
+                        {title && <div className="demo-sandbox__title body-m-book">{title}</div>}
+                        <Editor id={id} value={formattedCode} onChange={setEditedCode} />
+                    </div>
+                </>
+            )}
         </div>
     );
 };

--- a/packages/website/src/index.html
+++ b/packages/website/src/index.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <div id="App">
-            <div class="plasma-spinner">
+            <div class="plasma-spinner full-page">
                 <div class="bounce1"></div>
                 <div class="bounce2"></div>
                 <div class="bounce3"></div>

--- a/packages/website/src/styles/loading-screen.css
+++ b/packages/website/src/styles/loading-screen.css
@@ -1,10 +1,16 @@
 .plasma-spinner {
-    height: 90vh;
-    width: 100vw;
+    height: 100%;
+    width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
 }
+
+.plasma-spinner.full-page {
+    height: 90vh;
+    width: 100vw;
+}
+
 .plasma-spinner > div {
     display: inline-block;
     border-radius: 10% 100% 100% 10%;


### PR DESCRIPTION
### Proposed Changes

Instead of loading the plasma and typescript d.ts files each time we load a sandbox I changed the code to load them once and re-use the same promise. It makes the navigation between sandbox a lot smoother. I also added some loading indicators

### Potential Breaking Changes

None, only impacting the demo website

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
