### PR TITLE
fix(slider): prevent slider selectors to throw when sliders is not defined

### DIFF
--- a/packages/react/src/components/slider/SliderSelectors.ts
+++ b/packages/react/src/components/slider/SliderSelectors.ts
@@ -3,7 +3,7 @@ import {createSelector} from 'reselect';
 import {PlasmaState} from '../../PlasmaState';
 import {ISliderState} from './SliderReducers';
 
-const getSlider = (state: PlasmaState, {id}: {id: string}): ISliderState => state.sliders[id];
+const getSlider = (state: PlasmaState, {id}: {id: string}): ISliderState => state.sliders?.[id];
 
 const getSliderValue = createSelector(getSlider, (slider: ISliderState): number => slider?.value);
 

--- a/packages/react/src/components/slider/tests/SliderSelectors.spec.tsx
+++ b/packages/react/src/components/slider/tests/SliderSelectors.spec.tsx
@@ -5,11 +5,13 @@ describe('SliderSelectors', () => {
     describe('getSliderValue', () => {
         it('should not throw when no slider exist at the specified id', () => {
             expect(() => {
+                SliderSelectors.getSliderValue({}, {id: '🥔'});
                 SliderSelectors.getSliderValue({sliders: {}}, {id: '🥔'});
             }).not.toThrow();
         });
 
         it('should return undefined when the slider does not exist in the state', () => {
+            expect(SliderSelectors.getSliderValue({}, {id: '🥔'})).toBeUndefined();
             expect(SliderSelectors.getSliderValue({sliders: {}}, {id: '🥔'})).toBeUndefined();
         });
 


### PR DESCRIPTION
### Proposed Changes

Fix getSlider selector: prevent it from throwing an error when `sliders` key is undefined in the state (happens in the unit tests of the admin-ui).

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
