### PR TITLE
feat(blankslate, icon-card): allow usage of custom svgs

### DIFF
--- a/packages/react/src/components/blankSlate/BlankSlate.tsx
+++ b/packages/react/src/components/blankSlate/BlankSlate.tsx
@@ -1,13 +1,12 @@
-import {SvgName} from '@coveord/plasma-style';
 import classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
 
 import {IBaseActionOptions} from '../actions/Action';
 import {Button} from '../button/Button';
-import {Svg} from '../svg';
+import {OptionalSvgChildProps, SvgChild} from '../svg/SvgChild';
 
-export interface IBlankSlateProps extends React.ClassAttributes<BlankSlate> {
+export interface IBlankSlateProps extends React.ClassAttributes<BlankSlate>, Omit<OptionalSvgChildProps, 'title'> {
     title?: React.ReactNode;
     description?: React.ReactNode;
     additionalSection?: React.ReactNode;
@@ -17,8 +16,6 @@ export interface IBlankSlateProps extends React.ClassAttributes<BlankSlate> {
     containerClasses?: string[];
     descriptionClassName?: string;
     buttonClasses?: string[];
-    svgName?: SvgName;
-    svgClass?: string;
 }
 
 export class BlankSlate extends React.Component<IBlankSlateProps> {
@@ -31,13 +28,16 @@ export class BlankSlate extends React.Component<IBlankSlateProps> {
         classes: [],
         containerClasses: [],
         descriptionClassName: '',
-        svgClass: '',
     };
 
     private getSvgTemplate() {
-        return this.props.svgName ? (
-            <Svg svgName={this.props.svgName} svgClass={`icon mod-4x ${this.props.svgClass}`} />
-        ) : null;
+        return (
+            <SvgChild
+                svgName={this.props.svgName}
+                svgClass={`icon mod-4x ${this.props.svgClass}`}
+                svgChild={this.props.svgChild}
+            />
+        );
     }
 
     private getDescriptionTemplate(): JSX.Element {

--- a/packages/react/src/components/blankSlate/tests/BlankSlate.spec.tsx
+++ b/packages/react/src/components/blankSlate/tests/BlankSlate.spec.tsx
@@ -1,8 +1,8 @@
+import {render, screen} from '@test-utils';
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
 
-import {Svg} from '../../svg/Svg';
 import {BlankSlate, IBlankSlateProps} from '../BlankSlate';
 
 describe('BlankSlate', () => {
@@ -115,10 +115,49 @@ describe('BlankSlate', () => {
             expect(blankSlateComponent.find('button').length).toBe(2);
         });
 
-        it('should render the icon', () => {
-            renderBlankSlate();
+        it('should render the svg', () => {
+            render(
+                <BlankSlate
+                    title="title"
+                    description="description test"
+                    buttons={[
+                        {
+                            name: 'test',
+                            primary: true,
+                            enabled: true,
+                        },
+                    ]}
+                    withModal={false}
+                    svgName="tips"
+                />
+            );
 
-            expect(blankSlateComponent.find(Svg).length).toBe(1);
+            expect(screen.getByRole('img', {name: /tips icon/i})).toBeVisible();
+        });
+
+        it('should render custom svg', () => {
+            const svgChild = (
+                <div role="img" aria-label="shrug icon">
+                    🤷
+                </div>
+            );
+            render(
+                <BlankSlate
+                    title="title"
+                    description="description test"
+                    buttons={[
+                        {
+                            name: 'test',
+                            primary: true,
+                            enabled: true,
+                        },
+                    ]}
+                    withModal={false}
+                    svgChild={svgChild}
+                />
+            );
+
+            expect(screen.getByRole('img', {name: /shrug icon/i})).toBeVisible();
         });
     });
 });

--- a/packages/react/src/components/iconCard/IconCard.tsx
+++ b/packages/react/src/components/iconCard/IconCard.tsx
@@ -6,10 +6,10 @@ import {slugify} from 'underscore.string';
 import {SlideY} from '../../animations';
 import {TooltipPlacement} from '../../utils';
 import {Badge, IBadgeProps} from '../badge/Badge';
-import {Svg} from '../svg';
+import {SvgChild, SvgChildCustomProps, SvgChildProps} from '../svg/SvgChild';
 import {ITooltipProps, Tooltip} from '../tooltip';
 
-export interface IconCardChoice {
+export interface IconCardChoice extends Partial<SvgChildCustomProps> {
     value: string;
     label: string;
     icon?: SvgName;
@@ -18,7 +18,6 @@ export interface IconCardChoice {
 
 export interface IconCardProps {
     title: string;
-    svgName: SvgName;
     badges?: IBadgeProps[];
     description?: string;
     onClick?: (choice?: string) => void;
@@ -28,13 +27,17 @@ export interface IconCardProps {
     animateOnHover?: boolean;
 }
 
-export const IconCard: React.FunctionComponent<IconCardProps & Omit<React.HTMLProps<HTMLDivElement>, 'onClick'>> = ({
+export const IconCard: React.FunctionComponent<
+    IconCardProps & SvgChildProps & Omit<React.HTMLProps<HTMLDivElement>, 'onClick'>
+> = ({
     title,
     badges = [],
     description,
     disabled = false,
     onClick,
     svgName,
+    svgClass,
+    svgChild,
     tooltip,
     choices,
     animateOnHover,
@@ -88,12 +91,17 @@ export const IconCard: React.FunctionComponent<IconCardProps & Omit<React.HTMLPr
                     onClick={handleCardClick}
                     aria-expanded={isOpen}
                 >
-                    <Svg
+                    <SvgChild
+                        svgChild={svgChild}
                         svgName={svgName}
-                        svgClass={classNames('logo overflow-hidden mod-rounded-border-4 icon mr3', {
-                            'mod-72': !small,
-                            'mod-40': !!small,
-                        })}
+                        svgClass={classNames(
+                            'logo overflow-hidden mod-rounded-border-4 icon mr3',
+                            {
+                                'mod-72': !small,
+                                'mod-40': !!small,
+                            },
+                            svgClass
+                        )}
                     />
                     <div className="flex flex-column flex-auto justify-center">
                         <h6 className="title">{title}</h6>
@@ -115,18 +123,32 @@ export const IconCard: React.FunctionComponent<IconCardProps & Omit<React.HTMLPr
                             'mod-small': !!small,
                         })}
                     >
-                        {choices.map(({icon, label, value, disabled: choiceDisabled}: IconCardChoice) => (
-                            <li key={value} className="icon-card-drawer-choice">
-                                <button
-                                    className={classNames('inline-flex center-align link', {disabled: choiceDisabled})}
-                                    onClick={() => onClick?.(value)}
-                                    disabled={choiceDisabled}
-                                >
-                                    {icon ? <Svg svgClass="icon mod-24 mod-stroke mr1" svgName={icon} /> : null}
-                                    {label}
-                                </button>
-                            </li>
-                        ))}
+                        {choices.map(
+                            ({
+                                icon,
+                                svgChild: choiceSvgChild,
+                                label,
+                                value,
+                                disabled: choiceDisabled,
+                            }: IconCardChoice) => (
+                                <li key={value} className="icon-card-drawer-choice">
+                                    <button
+                                        className={classNames('inline-flex center-align link', {
+                                            disabled: choiceDisabled,
+                                        })}
+                                        onClick={() => onClick?.(value)}
+                                        disabled={choiceDisabled}
+                                    >
+                                        <SvgChild
+                                            svgChild={choiceSvgChild}
+                                            svgName={icon}
+                                            svgClass={'icon mod-24 mod-stroke mr1'}
+                                        />
+                                        {label}
+                                    </button>
+                                </li>
+                            )
+                        )}
                     </ul>
                 </SlideY>
             ) : null}

--- a/packages/react/src/components/iconCard/tests/IconCard.spec.tsx
+++ b/packages/react/src/components/iconCard/tests/IconCard.spec.tsx
@@ -13,6 +13,17 @@ describe('IconCard', () => {
         expect(screen.getByRole('heading', {name: /the title/i})).toBeVisible();
     });
 
+    it('renders custom icons', () => {
+        const svgChild = (
+            <div role="img" aria-label="shrug icon">
+                🤷
+            </div>
+        );
+        render(<IconCard title="The Title" svgChild={svgChild} />);
+
+        expect(screen.getByRole('img', {name: /shrug icon/i})).toBeVisible();
+    });
+
     it('renders a description underneath the title when specified', () => {
         render(<IconCard title="Title" svgName="home" description="the description" />);
 
@@ -77,7 +88,7 @@ describe('IconCard', () => {
             />
         );
 
-        const card = screen.getByRole('button', {name: /title/i});
+        const card = screen.getByRole('button', {name: /home icon title/i});
         expect(card).toHaveClass('cursor-pointer');
         userEvent.click(card);
         expect(card).not.toHaveClass('cursor-pointer');
@@ -99,6 +110,30 @@ describe('IconCard', () => {
         expect(card).toHaveAttribute('aria-expanded', 'false');
         userEvent.click(card);
         expect(card).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('shows icons in the drawer when clicking on it', () => {
+        const svgChild = (
+            <div role="img" aria-label="shrug icon">
+                🤷
+            </div>
+        );
+        render(
+            <IconCard
+                title="Title"
+                svgName="home"
+                choices={[
+                    {label: '🍌', value: 'banana', svgChild},
+                    {label: '🍎', value: 'apple', icon: 'add'},
+                ]}
+            />
+        );
+
+        const card = screen.getByRole('button', {name: /title/i});
+        userEvent.click(card);
+
+        expect(screen.getByRole('img', {name: /add icon/i})).toBeVisible();
+        expect(screen.getByRole('img', {name: /shrug icon/i})).toBeVisible();
     });
 
     it('collapses the drawer when the mouse leaves the icon card', () => {

--- a/packages/react/src/components/svg/SvgChild.tsx
+++ b/packages/react/src/components/svg/SvgChild.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import {ISvgProps, Svg} from './Svg';
+
+export interface SvgChildStandardProps extends ISvgProps {
+    svgChild?: never;
+}
+
+export interface SvgChildCustomProps {
+    svgChild: React.ReactNode;
+    svgName?: never;
+    svgClass?: never;
+}
+
+/**
+ * Extend this type when you want to have either a svgChild or a svgName (and other svg props)
+ */
+export type SvgChildProps = SvgChildStandardProps | SvgChildCustomProps;
+
+/**
+ * Use this interface instead of SvgChildProps when the Svg in your component is optional
+ */
+export interface OptionalSvgChildProps extends Partial<ISvgProps> {
+    svgChild?: React.ReactNode;
+}
+
+export const isCustomSvgChild = (x: SvgChildProps): x is SvgChildCustomProps =>
+    (x as SvgChildCustomProps).svgChild !== undefined;
+
+export const SvgChild: React.FunctionComponent<OptionalSvgChildProps> = ({
+    svgChild,
+    svgName,
+    svgClass,
+    ...svgProps
+}) => {
+    if (!svgChild && !svgName) {
+        return null;
+    }
+
+    if (isCustomSvgChild({svgChild})) {
+        return <>{svgChild}</>;
+    }
+
+    return <Svg svgName={svgName} svgClass={svgClass} {...svgProps} />;
+};


### PR DESCRIPTION
### Proposed Changes

We currently have an issue that prevents us from putting some SVG in the plasma repository because it is open source.

By allowing the use of custom `<svg>` tags in the components that previously allowed only svgNames we can keep those icon in a private repository.

I created a generic component that allow us to re-use the same logic in multiple components

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
