### PR TITLE
UI tool 447/cleanup breadcrumbs examples

### DIFF
--- a/packages/react/src/components/breadcrumbs/Breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumbs/Breadcrumb.tsx
@@ -6,11 +6,11 @@ import {BreadcrumbLink, IBreadcrumbLinkProps} from './BreadcrumbLink';
 
 export interface IBreadcrumbProps extends React.ClassAttributes<Breadcrumb> {
     /**
-     * Array of links to navigate when clicking on a breadcrumbs
+     * Array of breadcrumb links to navigate to previous pages
      */
     links?: IBreadcrumbLinkProps[];
     /**
-     * The content of the breadcrumb
+     * The content of the current breadcrumb
      */
     title: ITitleProps;
 }

--- a/packages/react/src/components/breadcrumbs/Breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumbs/Breadcrumb.tsx
@@ -5,15 +5,19 @@ import {ITitleProps, Title} from '../title/Title';
 import {BreadcrumbLink, IBreadcrumbLinkProps} from './BreadcrumbLink';
 
 export interface IBreadcrumbProps extends React.ClassAttributes<Breadcrumb> {
+    /**
+     * Array of links to navigate when clicking on a breadcrumbs
+     */
     links?: IBreadcrumbLinkProps[];
-    defaultLinkPath?: string;
+    /**
+     * The content of the breadcrumb
+     */
     title: ITitleProps;
 }
 
 export class Breadcrumb extends React.Component<IBreadcrumbProps> {
     static defaultProps: Partial<IBreadcrumbProps> = {
         links: [],
-        defaultLinkPath: '',
     };
 
     private getLinks(): JSX.Element[] {
@@ -21,7 +25,7 @@ export class Breadcrumb extends React.Component<IBreadcrumbProps> {
             <BreadcrumbLink
                 key={link.name}
                 {..._.extend(link, {
-                    link: link?.link ? `${this.props.defaultLinkPath}${link.link}` : undefined,
+                    link: link?.link ? `${link.link}` : undefined,
                 })}
             />
         ));

--- a/packages/react/src/components/breadcrumbs/tests/Breadcrumb.spec.tsx
+++ b/packages/react/src/components/breadcrumbs/tests/Breadcrumb.spec.tsx
@@ -71,14 +71,5 @@ describe('<Breadcrumb/>', () => {
 
             expect(breadcrumbComponent.find(BreadcrumbLink).length).toBe(2);
         });
-
-        it('should render the BreadcrumbLink link with the defaultLinkPath before', () => {
-            renderBreadcrumb({
-                links: [defaultLink],
-                defaultLinkPath: 'test/',
-            });
-
-            expect(breadcrumbComponent.find(BreadcrumbLink).props().link).toContain('test/');
-        });
     });
 });

--- a/packages/react/src/components/headers/BreadcrumbHeader.tsx
+++ b/packages/react/src/components/headers/BreadcrumbHeader.tsx
@@ -6,7 +6,7 @@ import {HeaderWrapper, IHeaderWrapperProps} from './HeaderWrapper';
 
 export interface IBreadcrumbHeaderProps extends IHeaderWrapperProps {
     /**
-     * See Breadcrumb Component for details
+     * Allows to configure the breadcrumb shown in the header
      */
     breadcrumb: IBreadcrumbProps;
 }

--- a/packages/react/src/components/headers/BreadcrumbHeader.tsx
+++ b/packages/react/src/components/headers/BreadcrumbHeader.tsx
@@ -5,6 +5,9 @@ import {Breadcrumb, IBreadcrumbProps} from '../breadcrumbs/Breadcrumb';
 import {HeaderWrapper, IHeaderWrapperProps} from './HeaderWrapper';
 
 export interface IBreadcrumbHeaderProps extends IHeaderWrapperProps {
+    /**
+     * See Breadcrumb Component for details
+     */
     breadcrumb: IBreadcrumbProps;
 }
 

--- a/packages/react/src/components/headers/HeaderWrapper.tsx
+++ b/packages/react/src/components/headers/HeaderWrapper.tsx
@@ -6,10 +6,29 @@ import {Content, IContentProps} from '../content/Content';
 import {ITabsHeaderProps, TabsHeader} from './TabsHeader';
 
 export interface IHeaderWrapperProps extends ITabsHeaderProps {
+    /**
+     * Text that appears above the tabs in the header wrapper
+     */
     description?: string | React.ReactNode;
+    /**
+     * Add an action bar/ action button
+     */
     actions?: IContentProps[];
+    /**
+     * Additional CSS classes to set on the HeaderWrapper element
+     */
     classes?: string[];
+    /**
+     * If set to false, the line at the bottom of the HeaderWrapper disapear (only if there's no tabs)
+     *
+     * @default true
+     */
     hasBorderBottom?: boolean;
+    /**
+     * If set to false, the padding of the HeaderWrapper is removed
+     *
+     * @default true
+     */
     hasPadding?: boolean;
 }
 

--- a/packages/react/src/components/headers/HeaderWrapper.tsx
+++ b/packages/react/src/components/headers/HeaderWrapper.tsx
@@ -19,7 +19,7 @@ export interface IHeaderWrapperProps extends ITabsHeaderProps {
      */
     classes?: string[];
     /**
-     * If set to false, the line at the bottom of the HeaderWrapper disapear (only if there's no tabs)
+     * If set to false, the line at the bottom of the HeaderWrapper disappears (only if there's no tabs)
      *
      * @default true
      */

--- a/packages/react/src/components/headers/HeaderWrapper.tsx
+++ b/packages/react/src/components/headers/HeaderWrapper.tsx
@@ -11,7 +11,7 @@ export interface IHeaderWrapperProps extends ITabsHeaderProps {
      */
     description?: string | React.ReactNode;
     /**
-     * Add an action bar/ action button
+     * Action buttons displayed in the right portion of the header
      */
     actions?: IContentProps[];
     /**
@@ -19,13 +19,13 @@ export interface IHeaderWrapperProps extends ITabsHeaderProps {
      */
     classes?: string[];
     /**
-     * If set to false, the line at the bottom of the HeaderWrapper disappears (only if there's no tabs)
+     * Whether the header displays a border on the bottom
      *
      * @default true
      */
     hasBorderBottom?: boolean;
     /**
-     * If set to false, the padding of the HeaderWrapper is removed
+     * Whether the header has padding
      *
      * @default true
      */

--- a/packages/react/src/components/headers/TabsHeader.tsx
+++ b/packages/react/src/components/headers/TabsHeader.tsx
@@ -4,6 +4,9 @@ import {ITabProps, TabConnected} from '../tab/Tab';
 import {TabNavigation} from '../tab/TabNavigation';
 
 export interface ITabsHeaderProps {
+    /**
+     * Array of tabs, see Tab Component for details
+     */
     tabs?: ITabProps[];
 }
 

--- a/packages/website/src/pages/navigation/BreadcrumbsExamples.tsx
+++ b/packages/website/src/pages/navigation/BreadcrumbsExamples.tsx
@@ -3,26 +3,26 @@ import * as React from 'react';
 import {ExampleLayout} from '../../building-blocs/ExampleLayout';
 
 const code = `
-    import * as React from "react";
-    import {BreadcrumbHeader, IBreadcrumbProps} from '@coveord/plasma-react';
+    import * as React from 'react';
+    import {BreadcrumbHeader} from '@coveord/plasma-react';
 
-    const defaultBreadcrumb: IBreadcrumbProps = {
-        title: {
-            text: 'Charmeleon',
-        },
-        links: [{
-          name: 'Pikachu',
-          link: 'https://www.google.ca/?q=pikachu',
-        }],
-    };
-
-
-    export default () => 
-      <BreadcrumbHeader
-          breadcrumb={defaultBreadcrumb}
-          description="Simple description for the title"
-          hasBorderBottom={false}
-      />;
+    export default () => (
+        <BreadcrumbHeader
+            breadcrumb={{
+                title: {
+                    text: 'Charmeleon',
+                },
+                links: [
+                    {
+                        name: 'Pikachu',
+                        link: 'https://www.google.ca/?q=pikachu',
+                    },
+                ],
+            }}
+            description="Simple description for the title"
+            hasBorderBottom={false}
+        />
+    );
 `;
 
 const complex = `
@@ -70,7 +70,8 @@ export const BreadcrumbsExamples = () => (
         id="BreadcrumbHeader"
         componentSourcePath="/breadcrumbs/BreadcrumbHeader.tsx"
         title="Breadcrumbs"
-        section="navigation"
+        section="Navigation"
+
         thumbnail="breadcrumb"
         code={code}
         examples={{complex: {code: complex, title: 'With documentation link and tabs'}}}

--- a/packages/website/src/pages/navigation/BreadcrumbsExamples.tsx
+++ b/packages/website/src/pages/navigation/BreadcrumbsExamples.tsx
@@ -1,51 +1,78 @@
-import {BreadcrumbHeader, Button, Section, Svg} from '@coveord/plasma-react';
 import * as React from 'react';
 
-import PlasmaComponent from '../../building-blocs/PlasmaComponent';
-import {defaultBreadcrumb, link1, link2} from '../../utils/ExamplesUtils';
+import {ExampleLayout} from '../../building-blocs/ExampleLayout';
 
-// start-print
+const code = `
+    import * as React from "react";
+    import {BreadcrumbHeader, IBreadcrumbProps} from '@coveord/plasma-react';
 
-export const BreadcrumbsExamples: React.FunctionComponent = () => (
-    <PlasmaComponent id="breadcrumb" title="Breadcrumbs" withSource>
-        <Section level={2} title="Breadcrumb headers">
-            <Section level={3} title="Breadcrumb with a node as action and tabs">
-                <BreadcrumbHeader
-                    breadcrumb={defaultBreadcrumb}
-                    description="Simple description for the title"
-                    tabs={[
-                        {groupId: 'example2', id: 'tab1', title: 'Digimon'},
-                        {groupId: 'example2', id: 'tab2', title: 'Beyblade'},
-                        {groupId: 'example2', id: 'tab3', title: 'Pokemon'},
-                        {groupId: 'example2', id: 'tab4', title: 'Perdu', url: 'http://www.perdu.com'},
-                    ]}
-                    actions={[
-                        {
-                            content: (
-                                <Button>
-                                    <Svg svgName={'add'} className="icon mod-lg mod-align-with-text" />
-                                </Button>
-                            ),
-                        },
-                    ]}
-                />
-            </Section>
-            <Section level={3} title="Breadcrumb header without border bottom">
-                <BreadcrumbHeader
-                    breadcrumb={defaultBreadcrumb}
-                    description="Simple description for the title"
-                    hasBorderBottom={false}
-                />
-            </Section>
-            <Section level={3} title="Breadcrumb header with a section without link">
-                <BreadcrumbHeader
-                    breadcrumb={{...defaultBreadcrumb, links: [link1, {name: 'not a link'}, link2]}}
-                    description="Simple description for the title"
-                    hasBorderBottom={false}
-                >
-                    <Svg svgName="brain" svgClass="icon mod-20 ml1" className="flex" />
-                </BreadcrumbHeader>
-            </Section>
-        </Section>
-    </PlasmaComponent>
+    const defaultBreadcrumb: IBreadcrumbProps = {
+        title: {
+            text: 'Charmeleon',
+        },
+        links: [{
+          name: 'Pikachu',
+          link: 'https://www.google.ca/?q=pikachu',
+        }],
+    };
+
+
+    export default () => 
+      <BreadcrumbHeader
+          breadcrumb={defaultBreadcrumb}
+          description="Simple description for the title"
+          hasBorderBottom={false}
+      />;
+`;
+
+const complex = `
+    import * as React from "react";
+    import {BreadcrumbHeader, IBreadcrumbProps} from '@coveord/plasma-react';
+
+    const defaultBreadcrumb: IBreadcrumbProps = {
+        title: {
+          text: 'Charmeleon',
+          documentationLink: {
+          target: '_blank',
+          svg: {
+            svgName: 'help',
+            svgClass: 'documentation-link icon mod-20',
+            className: 'flex',
+          },
+          tooltip: {
+            title: "I'm a tooltip!",
+            placement: 'bottom',
+            container: 'body',
+          },
+        },
+        },
+        links: [{
+          name: 'Pikachu',
+          link: 'https://www.google.ca/?q=pikachu',
+        }],
+    };
+
+    export default () => (
+      <BreadcrumbHeader
+        breadcrumb={defaultBreadcrumb}
+        description="Simple description for the title"
+        tabs={[
+            {groupId: 'example2', id: 'tab1', title: 'Digimon'},
+            {groupId: 'example2', id: 'tab2', title: 'Beyblade'},
+            {groupId: 'example2', id: 'tab3', title: 'Pokemon'},
+        ]}
+      />
+    );
+`;
+
+export const BreadcrumbsExamples = () => (
+    <ExampleLayout
+        id="BreadcrumbHeader"
+        componentSourcePath="/breadcrumbs/BreadcrumbHeader.tsx"
+        title="Breadcrumbs"
+        section="navigation"
+        thumbnail="breadcrumb"
+        code={code}
+        examples={{complex: {code: complex, title: 'With documentation link and tabs'}}}
+    />
 );


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-447

### Potential Breaking Changes

BREAKING CHANGES: `defaultLinkPath` was removed from the Breadcrumb props

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
