### PR TITLE
fix(plasma-style): expose d.ts files in the npm packages

### DIFF
--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -78,7 +78,9 @@
         "lib",
         "resources",
         "gulpfile.js",
-        "LICENSE"
+        "LICENSE",
+        "index.d.ts",
+        "SvgName.d.ts"
     ],
     "browserslist": [
         "cover 90%",


### PR DESCRIPTION
### Proposed Changes

The `d.ts` files are not exposed to the npm package so there is no types when using the package from outside the plasma mono-repo

![image](https://user-images.githubusercontent.com/35579930/153274752-42c27578-3f64-49c4-99cd-60f6dfc8c23e.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
