### PR TITLE
fix(deploy): remove gzip content enconding phase

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -29,30 +29,12 @@
     },
     "ordered_phases": [
         {
-            "id": "deploy-minified-files",
+            "id": "deploy-plasma-website",
             "s3": {
                 "disabled": true,
                 "bucket": "coveo-nrd-jsadmin",
                 "directory": "react-vapor",
                 "parameters": {
-                    "include": "*.min.*",
-                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
-                    "content-encoding": "gzip"
-                },
-                "source": "packages/website/dist",
-                "rd": {
-                    "disabled": false
-                }
-            }
-        },
-        {
-            "id": "deploy-non-minified-files",
-            "s3": {
-                "disabled": true,
-                "bucket": "coveo-nrd-jsadmin",
-                "directory": "react-vapor",
-                "parameters": {
-                    "exclude": "*.min.*",
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
                 "source": "packages/website/dist",


### PR DESCRIPTION
### Proposed Changes

> If you configure CloudFront to compress objects and the origin also compresses objects, the origin should include a Content-Encoding header, which indicates to CloudFront that the object is already compressed. When a response from an origin includes the Content-Encoding header, CloudFront does not compress the object, regardless of the header’s value. CloudFront sends the response to the viewer and caches the object in the edge location.
-- [AWS Docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html)

When setting content-encoding to `gzip` ourselves on the s3 files (the origin), it tells CloudFront to send the file to the viewer directly without handling compression. That seems counter productive, and it simplifies our deployment process to remove that additional step. Let's try pushing everything at once.

### Potential Breaking Changes

In worst case, it will make plasma website unavailable, but we can always revert.
