### PR TITLE
fix: remove loading glitch

### DIFF
--- a/packages/website/src/pages/SearchResultPage.tsx
+++ b/packages/website/src/pages/SearchResultPage.tsx
@@ -32,7 +32,7 @@ const ResultListRenderer: FunctionComponent<ResultListProps> = (props) => {
 
     return (
         <>
-            {!state.hasResults ? (
+            {!state.hasResults && !state.isLoading ? (
                 <NoSearchResultTemplate engine={engine} query={query} />
             ) : (
                 <Section className="home flex-auto overflow-auto demo-content">


### PR DESCRIPTION
### Proposed Changes

There is sometime a small glitch after doing a search (see gif). I added a condition to render the "NoSearchResultTemplate" only when the state has finished loading.
![glitch](https://user-images.githubusercontent.com/12199712/154098369-4b9b934f-bfed-484f-ac5e-5a165602f0e7.gif)


### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
