### PR TITLE
feat(tokens): handle jenkins job parameter for libraries

### DIFF
--- a/TokensExtraction.groovy
+++ b/TokensExtraction.groovy
@@ -66,7 +66,11 @@ pipeline {
     stage('Fetch tokens') {
       steps {
         script {
-          sh "pnpm run tokens:fetch --filter @coveord/plasma-tokens"
+          if (params.LIBRARIES.length() > 0) {
+            sh "pnpm run tokens:fetch --filter @coveord/plasma-tokens -- --libraries ${params.LIBRARIES}"
+          } else {
+            sh "pnpm run tokens:fetch --filter @coveord/plasma-tokens"
+          }
         }
       }
     }

--- a/TokensExtraction.groovy
+++ b/TokensExtraction.groovy
@@ -20,6 +20,19 @@ pipeline {
 
   agent { label "build && docker && linux" }
 
+   parameters {
+      extendedChoice(
+        name: 'LIBRARIES', 
+        description: 'Name of the Figma libraries to extract tokens from (leave all unchecked to extract them all)', 
+        type: 'PT_CHECKBOX', 
+        value: 'ICONS', 
+        multiSelectDelimiter: ' ', 
+        quoteValue: false, 
+        saveJSONParameterToFile: false, 
+        visibleItemCount: 50
+      )
+  }
+
   environment {
     NPM_TOKEN = credentials("npmjs_com_token")
     GIT = credentials("github-commit-token")


### PR DESCRIPTION
### Proposed Changes

Added a `LIBRARIES` parameter to the tokens extraction job to target specific figma libraries

When triggering the tokens extraction job, you will be prompted with this interface, which allows to choose only specific figma libraries to extract design tokens from.
![image](https://user-images.githubusercontent.com/35579930/154717633-8948d4fc-0f65-4fc4-acbe-0a6b867d6300.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
