### PR TITLE
feat(react-icons): create the react-icons package

### DIFF
--- a/packages/react-icons/.gitignore
+++ b/packages/react-icons/.gitignore
@@ -1,0 +1,3 @@
+generated
+node_modules
+dist

--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -1,0 +1,23 @@
+# @coveord/plasma-react-icons
+
+This package exposes the Plasma design system's entire iconography in the shape of individual React components.
+
+## Insall
+
+```bash
+npm install @coveord/plasma-react-icons
+```
+
+The packages provides its own TypeScript declaration files.
+
+## Usage
+
+```ts
+import {CloudSize32Px} from '@coveord/plasma-react-icons';
+
+<CloudSize32Px />
+```
+
+## Available Icons
+
+Please refer to the [iconography page](https://plasma.coveo.com/foundations/Iconography) on the Plasma website to see all the available icons.

--- a/packages/react-icons/bin/index.js
+++ b/packages/react-icons/bin/index.js
@@ -1,0 +1,53 @@
+const fs = require('fs-extra');
+const glob = require('glob');
+const svgr = require('@svgr/core');
+const groupBy = require('lodash.groupby');
+const upperFirst = require('lodash.upperfirst');
+const {rmSync} = require('fs-extra');
+
+const iconsSourceDirPath = 'node_modules/@coveord/plasma-tokens/icons';
+
+const convertIcon = async ([iconName, variants]) =>
+    Promise.all([
+        fs.appendFile('./generated/index.ts', `export * from './${iconName}';\n`),
+        ...variants.map(convertVariant),
+    ]);
+
+const convertVariant = async (file) => {
+    try {
+        const iconName = findIconName(file);
+        const variantName = findVariantName(file);
+        const componentName = `${upperFirst(iconName)}${upperFirst(variantName)}`;
+        const fileContent = await fs.readFile(file);
+        const tsCode = await svgr.transform(
+            fileContent.toString('utf8'),
+            {typescript: true, exportType: 'named', namedExport: componentName},
+            {componentName}
+        );
+        await fs.ensureDir(`./generated/${iconName}`);
+        return Promise.all([
+            fs.appendFile(`./generated/${iconName}/index.ts`, `export * from './${variantName}';\n`),
+            fs.outputFile(`./generated/${iconName}/${variantName}.tsx`, tsCode),
+        ]);
+    } catch (err) {
+        console.error(`Error: could not convert svg at "${file}" into a React component.`);
+        console.error(err);
+    }
+};
+
+const findIconName = (filename) => filename.replace(iconsSourceDirPath, '').substring(1).split('/')[0];
+const findVariantName = (filename) => filename.replace(iconsSourceDirPath, '').split('/').pop().replace('.svg', '');
+
+const handleSvgFiles = (err, files) => {
+    if (err) {
+        console.error(err);
+    }
+
+    const grouped = groupBy(files, findIconName);
+    Promise.all(Object.entries(grouped).map(convertIcon));
+};
+
+rmSync('./generated', {recursive: true, force: true});
+rmSync('./dist', {recursive: true, force: true});
+fs.ensureDirSync('./generated');
+glob(`${iconsSourceDirPath}/**/*.svg`, handleSvgFiles);

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@coveord/plasma-react-icons",
+    "version": "1.0.0",
+    "description": "Plasma iconography exposed as react components",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "scripts": {
+        "build": "node ./bin/index.js && tsc --project tsconfig.json"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/coveo/plasma.git",
+        "directory": "packages/react-icons"
+    },
+    "keywords": [
+        "plasma",
+        "icons",
+        "react"
+    ],
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/coveo/plasma/issues"
+    },
+    "homepage": "https://github.com/coveo/plasma/packages/react-icons#readme",
+    "files": [
+        "dist"
+    ],
+    "devDependencies": {
+        "@coveord/plasma-tokens": "workspace:*",
+        "@svgr/core": "6.2.1",
+        "fs-extra": "10.0.0",
+        "glob": "7.2.0",
+        "lodash.groupby": "4.6.0",
+        "lodash.upperfirst": "4.3.1",
+        "typescript": "4.5.4"
+    }
+}

--- a/packages/react-icons/tsconfig.json
+++ b/packages/react-icons/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../tsconfig-base.json",
+    "compilerOptions": {
+        "module": "es6",
+        "outDir": "./dist",
+    },
+    "include": ["generated"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,24 @@ importers:
       underscore: 1.13.1
       underscore.string: 3.3.5
 
+  packages/react-icons:
+    specifiers:
+      '@coveord/plasma-tokens': workspace:*
+      '@svgr/core': 6.2.1
+      fs-extra: 10.0.0
+      glob: 7.2.0
+      lodash.groupby: 4.6.0
+      lodash.upperfirst: 4.3.1
+      typescript: 4.5.4
+    devDependencies:
+      '@coveord/plasma-tokens': link:../tokens
+      '@svgr/core': 6.2.1
+      fs-extra: 10.0.0
+      glob: 7.2.0
+      lodash.groupby: 4.6.0
+      lodash.upperfirst: 4.3.1
+      typescript: 4.5.4
+
   packages/style:
     specifiers:
       ansi-colors: 4.1.1
@@ -541,7 +559,7 @@ packages:
       '@babel/parser': 7.16.4
       '@babel/template': 7.16.0
       '@babel/traverse': 7.16.3
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
       convert-source-map: 1.8.0
       debug: 4.3.3
       gensync: 1.0.0-beta.2
@@ -556,7 +574,7 @@ packages:
     resolution: {integrity: sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: true
@@ -608,7 +626,7 @@ packages:
     resolution: {integrity: sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
 
   /@babel/helper-module-transforms/7.16.0:
     resolution: {integrity: sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==}
@@ -621,7 +639,7 @@ packages:
       '@babel/helper-validator-identifier': 7.16.7
       '@babel/template': 7.16.0
       '@babel/traverse': 7.16.3
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -650,7 +668,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.16.0
       '@babel/helper-optimise-call-expression': 7.16.0
       '@babel/traverse': 7.16.3
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -659,14 +677,14 @@ packages:
     resolution: {integrity: sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/helper-split-export-declaration/7.16.0:
     resolution: {integrity: sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/helper-validator-identifier/7.15.7:
@@ -689,7 +707,7 @@ packages:
     dependencies:
       '@babel/template': 7.16.0
       '@babel/traverse': 7.16.3
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -860,7 +878,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.16.7
       '@babel/parser': 7.16.4
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/traverse/7.16.3:
@@ -873,7 +891,7 @@ packages:
       '@babel/helper-hoist-variables': 7.16.0
       '@babel/helper-split-export-declaration': 7.16.0
       '@babel/parser': 7.16.4
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
       debug: 4.3.3
       globals: 11.12.0
     transitivePeerDependencies:
@@ -886,6 +904,7 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types/7.17.0:
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
@@ -893,7 +912,6 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
       to-fast-properties: 2.0.0
-    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -1784,6 +1802,129 @@ packages:
       postcss-syntax: 0.36.2_postcss@7.0.39
       remark: 13.0.0
       unist-util-find-all-after: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@svgr/babel-plugin-add-jsx-attribute/6.0.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+    dev: true
+
+  /@svgr/babel-plugin-remove-jsx-attribute/6.0.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-aVdtfx9jlaaxc3unA6l+M9YRnKIZjOhQPthLKqmTXC8UVkBLDRGwPKo+r8n3VZN8B34+yVajzPTZ+ptTSuZZCw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+    dev: true
+
+  /@svgr/babel-plugin-remove-jsx-empty-expression/6.0.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-Ccj42ApsePD451AZJJf1QzTD1B/BOU392URJTeXFxSK709i0KUsGtbwyiqsKu7vsYxpTM0IA5clAKDyf9RCZyA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+    dev: true
+
+  /@svgr/babel-plugin-replace-jsx-attribute-value/6.0.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-88V26WGyt1Sfd1emBYmBJRWMmgarrExpKNVmI9vVozha4kqs6FzQJ/Kp5+EYli1apgX44518/0+t9+NU36lThQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+    dev: true
+
+  /@svgr/babel-plugin-svg-dynamic-title/6.0.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-F7YXNLfGze+xv0KMQxrl2vkNbI9kzT9oDK55/kUuymh1ACyXkMV+VZWX1zEhSTfEKh7VkHVZGmVtHg8eTZ6PRg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+    dev: true
+
+  /@svgr/babel-plugin-svg-em-dimensions/6.0.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-+rghFXxdIqJNLQK08kwPBD3Z22/0b2tEZ9lKiL/yTfuyj1wW8HUXu4bo/XkogATIYuXSghVQOOCwURXzHGKyZA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+    dev: true
+
+  /@svgr/babel-plugin-transform-react-native-svg/6.0.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-VaphyHZ+xIKv5v0K0HCzyfAaLhPGJXSk2HkpYfXIOKb7DjLBv0soHDxNv6X0vr2titsxE7klb++u7iOf7TSrFQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+    dev: true
+
+  /@svgr/babel-plugin-transform-svg-component/6.2.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-bhYIpsORb++wpsp91fymbFkf09Z/YEKR0DnFjxvN+8JHeCUD2unnh18jIMKnDJTWtvpTaGYPXELVe4OOzFI0xg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+    dev: true
+
+  /@svgr/babel-preset/6.2.0_@babel+core@7.16.0:
+    resolution: {integrity: sha512-4WQNY0J71JIaL03DRn0vLiz87JXx0b9dYm2aA8XHlQJQoixMl4r/soYHm8dsaJZ3jWtkCiOYy48dp9izvXhDkQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.0
+      '@svgr/babel-plugin-add-jsx-attribute': 6.0.0_@babel+core@7.16.0
+      '@svgr/babel-plugin-remove-jsx-attribute': 6.0.0_@babel+core@7.16.0
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 6.0.0_@babel+core@7.16.0
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.0.0_@babel+core@7.16.0
+      '@svgr/babel-plugin-svg-dynamic-title': 6.0.0_@babel+core@7.16.0
+      '@svgr/babel-plugin-svg-em-dimensions': 6.0.0_@babel+core@7.16.0
+      '@svgr/babel-plugin-transform-react-native-svg': 6.0.0_@babel+core@7.16.0
+      '@svgr/babel-plugin-transform-svg-component': 6.2.0_@babel+core@7.16.0
+    dev: true
+
+  /@svgr/core/6.2.1:
+    resolution: {integrity: sha512-NWufjGI2WUyrg46mKuySfviEJ6IxHUOm/8a3Ph38VCWSp+83HBraCQrpEM3F3dB6LBs5x8OElS8h3C0oOJaJAA==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@svgr/plugin-jsx': 6.2.1_@svgr+core@6.2.1
+      camelcase: 6.2.0
+      cosmiconfig: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@svgr/hast-util-to-babel-ast/6.2.1:
+    resolution: {integrity: sha512-pt7MMkQFDlWJVy9ULJ1h+hZBDGFfSCwlBNW1HkLnVi7jUhyEXUaGYWi1x6bM2IXuAR9l265khBT4Av4lPmaNLQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@babel/types': 7.17.0
+      entities: 3.0.1
+    dev: true
+
+  /@svgr/plugin-jsx/6.2.1_@svgr+core@6.2.1:
+    resolution: {integrity: sha512-u+MpjTsLaKo6r3pHeeSVsh9hmGRag2L7VzApWIaS8imNguqoUwDq/u6U/NDmYs/KAsrmtBjOEaAAPbwNGXXp1g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@svgr/core': ^6.0.0
+    dependencies:
+      '@babel/core': 7.16.0
+      '@svgr/babel-preset': 6.2.0_@babel+core@7.16.0
+      '@svgr/core': 6.2.1
+      '@svgr/hast-util-to-babel-ast': 6.2.1
+      svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3874,7 +4015,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001283
+      caniuse-lite: 1.0.30001312
       electron-to-chromium: 1.4.1
       escalade: 3.1.1
       node-releases: 2.0.1
@@ -4050,7 +4191,6 @@ packages:
 
   /caniuse-lite/1.0.30001312:
     resolution: {integrity: sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==}
-    dev: false
 
   /ccount/1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
@@ -5673,6 +5813,11 @@ packages:
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
+  /entities/3.0.1:
+    resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
+    engines: {node: '>=0.12'}
+    dev: true
+
   /enzyme-adapter-react-16/1.15.6_4f82faf5e8cab057bc46d4d95079ec42:
     resolution: {integrity: sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==}
     peerDependencies:
@@ -6806,7 +6951,7 @@ packages:
     resolution: {integrity: sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==}
     engines: {node: '>=12'}
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
@@ -9344,6 +9489,10 @@ packages:
     resolution: {integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=}
     dev: true
 
+  /lodash.groupby/4.6.0:
+    resolution: {integrity: sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=}
+    dev: true
+
   /lodash.isarguments/3.1.0:
     resolution: {integrity: sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=}
     dev: true
@@ -9429,6 +9578,10 @@ packages:
 
   /lodash.uniq/4.5.0:
     resolution: {integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=}
+    dev: true
+
+  /lodash.upperfirst/4.3.1:
+    resolution: {integrity: sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=}
     dev: true
 
   /lodash/4.17.21:
@@ -14129,6 +14282,10 @@ packages:
     dependencies:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.3
+    dev: true
+
+  /svg-parser/2.0.4:
+    resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
     dev: true
 
   /svg-tags/1.0.0:


### PR DESCRIPTION
### Proposed Changes

Create a new package called [`@coveord/plasma-react-icons`](https://github.com/coveo/plasma/tree/UITOOL-463/plasma-react-icons/packages/react-icons#readme). This package aims to replace the `Svg` component of `@coveord/plasma-react`.

Example of usage

```ts
import {ZombieSize32Px} from '@coveord/plasma-react-icons';

<ZombieSize32Px className="icon mod-stroke mod-black mod-72" />
```

![image](https://user-images.githubusercontent.com/35579930/155187960-9fa6520f-0b18-48e7-85a9-320594d36374.png)


### Potential Breaking Changes

None for now
