### PR TITLE
fix(svg): export SvgChild

### DIFF
--- a/packages/react/src/components/svg/index.ts
+++ b/packages/react/src/components/svg/index.ts
@@ -1,2 +1,3 @@
 export * from './LinkSvg';
 export * from './Svg';
+export * from './SvgChild';


### PR DESCRIPTION
### Proposed Changes

There was a little oversight when adding the SVGChilds, nothing is exported from Plasma so you can't use the interfaces outside of Plasma

### Potential Breaking Changes

No

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
