### PR TITLE
fix(website): remove click uri workaround on search results

### DIFF
--- a/packages/website/src/pages/Search.tsx
+++ b/packages/website/src/pages/Search.tsx
@@ -48,8 +48,7 @@ const ResultListRenderer: FunctionComponent<ResultListProps> = (props) => {
                                 <Tile
                                     key={uniqueId}
                                     title={title}
-                                    // href={clickUri.replace(/.+plasma\.coveo\.com\//, process.env.basePath)}
-                                    href={clickUri.replace(/.+\/PR-2454\//, process.env.basePath)}
+                                    href={clickUri.replace(/.+plasma\.coveo\.com\//, process.env.basePath)}
                                     description={raw.description as string}
                                     thumbnail={raw.thumbnail as TileProps['thumbnail']}
                                 />


### PR DESCRIPTION
### Proposed Changes

The plasma.coveo.com was reindex and now to make the search work we need to remove that workaround on the click uri.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
