### PR TITLE
feat(analytics): add analytics on noResult and documentOpen

### DIFF
--- a/packages/website/src/building-blocs/Tile.tsx
+++ b/packages/website/src/building-blocs/Tile.tsx
@@ -37,9 +37,16 @@ export interface TileProps {
     description?: string;
     href?: string;
     thumbnail?: keyof typeof thumbnails;
+    sendAnalytics?: () => void;
 }
 
-export const Tile: React.FunctionComponent<TileProps> = ({title, description, href, thumbnail = 'placeholder'}) => {
+export const Tile: React.FunctionComponent<TileProps> = ({
+    title,
+    description,
+    href,
+    thumbnail = 'placeholder',
+    sendAnalytics,
+}) => {
     const tileIcon = (
         <img
             src={thumbnails[thumbnail]}
@@ -58,7 +65,7 @@ export const Tile: React.FunctionComponent<TileProps> = ({title, description, hr
 
     if (href && href.length > 0) {
         return (
-            <a className={className} href={href}>
+            <a className={className} href={href} onClick={sendAnalytics}>
                 {tileIcon}
                 {tileInfo}
             </a>

--- a/packages/website/src/pages/Search.tsx
+++ b/packages/website/src/pages/Search.tsx
@@ -1,10 +1,10 @@
 import {
     buildResultList,
+    loadClickAnalyticsActions,
     loadPaginationActions,
     loadQueryActions,
     loadSearchActions,
     loadSearchAnalyticsActions,
-    Result,
     ResultList as HeadlessResultList,
     SearchEngine,
 } from '@coveo/headless';
@@ -27,8 +27,10 @@ interface ResultListProps {
 const ResultListRenderer: FunctionComponent<ResultListProps> = (props) => {
     const {controller, engine, query} = props;
     const [state, setState] = useState(controller.state);
+    const {logDocumentOpen} = loadClickAnalyticsActions(engine);
 
     useEffect(() => controller.subscribe(() => setState(controller.state)), [controller]);
+
     return (
         <>
             {!state.hasResults && !state.isLoading ? (
@@ -44,14 +46,14 @@ const ResultListRenderer: FunctionComponent<ResultListProps> = (props) => {
                             {state.results.length === 1 ? ' result' : ' results'}
                         </p>
                         <div className="tile-grid">
-                            {state.results.map(({title, raw, uniqueId, clickUri}: Result) => (
+                            {state.results.map((result) => (
                                 <Tile
-                                    key={uniqueId}
-                                    title={title}
-                                    // href={clickUri.replace(/.+plasma\.coveo\.com\//, process.env.basePath)}
-                                    href={clickUri.replace(/.+\/PR-2454\//, process.env.basePath)}
-                                    description={raw.description as string}
-                                    thumbnail={raw.thumbnail as TileProps['thumbnail']}
+                                    key={result.uniqueId}
+                                    title={result.title}
+                                    href={result.clickUri.replace(/.+plasma\.coveo\.com\//, process.env.basePath)}
+                                    description={result.raw.description as string}
+                                    thumbnail={result.raw.thumbnail as TileProps['thumbnail']}
+                                    sendAnalytics={() => engine.dispatch(logDocumentOpen(result))}
                                 />
                             ))}
                         </div>

--- a/packages/website/src/search/NoSearchResultTemplate.tsx
+++ b/packages/website/src/search/NoSearchResultTemplate.tsx
@@ -1,7 +1,7 @@
-import {loadQueryActions, SearchEngine} from '@coveo/headless';
+import {buildHistoryManager, HistoryManager, loadQueryActions, SearchEngine} from '@coveo/headless';
 import {Button} from '@coveord/plasma-react';
 
-import {FunctionComponent} from 'react';
+import {FunctionComponent, useEffect, useState} from 'react';
 import React from 'react';
 
 import results_empty_state from '../../resources/results_empty_state.png';
@@ -13,6 +13,11 @@ interface NoResultTemplateProps {
 
 export const NoSearchResultTemplate: FunctionComponent<NoResultTemplateProps> = (props) => {
     const {engine, query} = props;
+
+    const historyManager: HistoryManager = buildHistoryManager(engine);
+    const [state, setState] = useState(historyManager.state);
+
+    useEffect(() => historyManager.subscribe(() => setState(historyManager.state)), []);
 
     const resetSearch = () => {
         const {updateQuery} = loadQueryActions(engine);
@@ -30,7 +35,16 @@ export const NoSearchResultTemplate: FunctionComponent<NoResultTemplateProps> = 
                 <span className="h6-subdued mb3 nowrap">
                     You may want to try using different keywords, or checking for spelling mistakes.
                 </span>
-                <Button primary onClick={() => resetSearch()}>
+                <Button
+                    primary
+                    onClick={() => {
+                        if (state.past.length !== 0) {
+                            historyManager.backOnNoResults();
+                        } else {
+                            resetSearch();
+                        }
+                    }}
+                >
                     Clear search
                 </Button>
             </div>

--- a/packages/website/src/search/NoSearchResultTemplate.tsx
+++ b/packages/website/src/search/NoSearchResultTemplate.tsx
@@ -1,4 +1,10 @@
-import {buildHistoryManager, HistoryManager, loadQueryActions, SearchEngine} from '@coveo/headless';
+import {
+    buildHistoryManager,
+    HistoryManager,
+    HistoryManagerState,
+    loadQueryActions,
+    SearchEngine,
+} from '@coveo/headless';
 import {Button} from '@coveord/plasma-react';
 
 import {FunctionComponent, useEffect, useState} from 'react';
@@ -15,7 +21,7 @@ export const NoSearchResultTemplate: FunctionComponent<NoResultTemplateProps> = 
     const {engine, query} = props;
 
     const historyManager: HistoryManager = buildHistoryManager(engine);
-    const [state, setState] = useState(historyManager.state);
+    const [state, setState] = useState<HistoryManagerState>(historyManager.state);
 
     useEffect(() => historyManager.subscribe(() => setState(historyManager.state)), []);
 


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-402

Adding analytics on No result after using the search bar and on document open in the search results.

More analytics will come in another pr when I change the search bar for the Atomic one :eyes: 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
