### PR TITLE
style(prop): remove calendar color prop

### DIFF
--- a/packages/react/src/components/calendar/Calendar.tsx
+++ b/packages/react/src/components/calendar/Calendar.tsx
@@ -225,7 +225,6 @@ export class Calendar extends React.Component<ICalendarProps, any> {
             day.isLowerLimit =
                 (calendarSelection.isRange && day.date.isSame(selectionStart, 'day')) || day.isLowerLimit;
             day.isUpperLimit = (calendarSelection.isRange && day.date.isSame(selectionEnd, 'day')) || day.isUpperLimit;
-            day.color = isSelected ? calendarSelection.color : day.color;
             day.isCountdown = !!this.props.countdown;
 
             _.each(this.props.selectionRules, (rule: ICalendarSelectionRule) => {

--- a/packages/react/src/components/calendar/CalendarDay.tsx
+++ b/packages/react/src/components/calendar/CalendarDay.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import {Moment} from 'moment';
 import * as React from 'react';
-
 export interface IDay {
     // eslint-disable-next-line id-blacklist
     number: number;
@@ -11,7 +10,6 @@ export interface IDay {
     isSelected?: boolean;
     isLowerLimit?: boolean;
     isUpperLimit?: boolean;
-    color?: string;
     isSelectable?: boolean;
     isCountdown?: boolean;
 }

--- a/packages/react/src/components/calendar/tests/Calendar.spec.tsx
+++ b/packages/react/src/components/calendar/tests/Calendar.spec.tsx
@@ -165,7 +165,6 @@ describe('Calendar', () => {
                     {
                         id: 'id',
                         calendarId: 'any',
-                        color: 'any',
                         lowerLimit: now,
                         upperLimit: now,
                         isRange: true,
@@ -180,7 +179,6 @@ describe('Calendar', () => {
                     {
                         id: 'id',
                         calendarId: 'any',
-                        color: 'any',
                         lowerLimit: now,
                         upperLimit: now,
                         isRange: true,
@@ -222,7 +220,6 @@ describe('Calendar', () => {
                         {
                             id: 'id1',
                             calendarId: 'any',
-                            color: 'any',
                             lowerLimit: null,
                             upperLimit: null,
                             isRange: true,
@@ -237,7 +234,6 @@ describe('Calendar', () => {
                         {
                             id: 'id2',
                             calendarId: 'any',
-                            color: 'any',
                             lowerLimit: null,
                             upperLimit: null,
                             isRange: true,
@@ -276,7 +272,6 @@ describe('Calendar', () => {
                     {
                         id: 'id',
                         calendarId: 'any',
-                        color: 'any',
                         lowerLimit: now,
                         upperLimit: now,
                         isRange: true,
@@ -298,7 +293,6 @@ describe('Calendar', () => {
                     {
                         id: 'id',
                         calendarId: 'any',
-                        color: 'any',
                         lowerLimit: now,
                         upperLimit: now,
                         isRange: true,
@@ -328,7 +322,6 @@ describe('Calendar', () => {
             const CALENDAR_SELECTION: IDatePickerState = {
                 id: 'id',
                 calendarId: 'any',
-                color: 'any',
                 lowerLimit: moment().subtract(1, 'day').toDate(),
                 upperLimit: moment().add(1, 'day').toDate(),
                 isRange: true,
@@ -380,15 +373,6 @@ describe('Calendar', () => {
                 beforeSelectionDay = calendarInstance.fillInDayInfos(beforeSelectionDay);
 
                 expect(beforeSelectionDay.isSelected).toBeFalsy();
-            });
-
-            it('should return the day color if the day is between the lower and upper limit', () => {
-                expect(day.color).toBe(CALENDAR_SELECTION.color);
-
-                let beforeSelectionDay: IDay = _.extend({}, DAY, {date: moment(now).subtract(3, 'day')});
-                beforeSelectionDay = calendarInstance.fillInDayInfos(beforeSelectionDay);
-
-                expect(beforeSelectionDay.color).toBeUndefined();
             });
 
             it('should return day isLowerLimit if the selection is a range and starts on that day', () => {
@@ -450,7 +434,6 @@ describe('Calendar', () => {
                 expect(day.isSelected).toBe(true);
                 expect(day.isLowerLimit).toBe(true);
                 expect(day.isUpperLimit).toBe(true);
-                expect(day.color).toBe(selectionAll.color);
 
                 calendar.setProps({
                     calendarSelection: [selectionAll, selectionNone],
@@ -461,7 +444,6 @@ describe('Calendar', () => {
                 expect(day.isSelected).toBe(true);
                 expect(day.isLowerLimit).toBe(true);
                 expect(day.isUpperLimit).toBe(true);
-                expect(day.color).toBe(selectionAll.color);
             });
 
             it('should return day isSelectable if the day comes after today', () => {

--- a/packages/react/src/components/calendar/tests/CalendarConnected.spec.tsx
+++ b/packages/react/src/components/calendar/tests/CalendarConnected.spec.tsx
@@ -26,8 +26,8 @@ import {CalendarConnected} from '../CalendarConnected';
 describe('Calendar', () => {
     const CALENDAR_ID: string = 'calendar';
     const PICKER_ID: string = 'some-picker';
-    const DEFAULT_ADD_DATE_PICKER_WITHOUT_RANGE = addDatePicker(PICKER_ID, false, undefined, 'any', CALENDAR_ID);
-    const DEFAULT_ADD_DATE_PICKER_WITH_RANGE = addDatePicker(PICKER_ID, true, undefined, 'any', CALENDAR_ID);
+    const DEFAULT_ADD_DATE_PICKER_WITHOUT_RANGE = addDatePicker(PICKER_ID, false, undefined, CALENDAR_ID);
+    const DEFAULT_ADD_DATE_PICKER_WITH_RANGE = addDatePicker(PICKER_ID, true, undefined, CALENDAR_ID);
 
     describe('<CalendarConnected />', () => {
         let wrapper: ReactWrapper<any, any>;
@@ -103,7 +103,7 @@ describe('Calendar', () => {
             expect(calendarSelectionProp).toBeDefined();
             expect(calendarSelectionProp).toEqual([]);
 
-            store.dispatch(addDatePicker('any', false, undefined, 'any', CALENDAR_ID));
+            store.dispatch(addDatePicker('any', false, undefined, CALENDAR_ID));
             wrapper.update();
 
             expect(wrapper.find(Calendar).props().calendarSelection.length).toBe(1);

--- a/packages/react/src/components/datePicker/DatePickerActions.ts
+++ b/packages/react/src/components/datePicker/DatePickerActions.ts
@@ -1,5 +1,4 @@
 import {IReduxAction} from '../../utils/ReduxUtils';
-import {DEFAULT_DATE_PICKER_COLOR} from './DatePickerConstants';
 import {DatePickerDateRange} from './DatePickerConstants';
 import {IRangeLimit} from './DatesSelection';
 
@@ -19,7 +18,6 @@ export interface IDatePickerPayload {
 }
 
 export interface IAddDatePickerPayload extends IDatePickerPayload {
-    color: string;
     calendarId: string;
     isRange: boolean;
     rangeLimit?: IRangeLimit;
@@ -47,7 +45,6 @@ export const addDatePicker = (
     id: string,
     isRange: boolean,
     rangeLimit: IRangeLimit = undefined,
-    color: string = DEFAULT_DATE_PICKER_COLOR,
     calendarId: string = '',
     initiallyUnselected = false,
     isClearable = false,
@@ -58,7 +55,6 @@ export const addDatePicker = (
     type: DatePickerActions.add,
     payload: {
         id,
-        color,
         calendarId,
         isRange,
         rangeLimit,

--- a/packages/react/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react/src/components/datePicker/DatePickerBox.tsx
@@ -156,7 +156,6 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
                 isClearable: this.props.isClearable,
                 rangeLimit: datesSelectionBox.rangeLimit,
                 minimalRangeLimit: datesSelectionBox.minimalRangeLimit,
-                color: datesSelectionBox.color,
                 calendarId: DatePickerBox.getCalendarId(this.props.id),
                 lowerLimitPlaceholder: this.props.lowerLimitPlaceholder,
                 upperLimitPlaceholder: this.props.upperLimitPlaceholder,

--- a/packages/react/src/components/datePicker/DatePickerReducers.ts
+++ b/packages/react/src/components/datePicker/DatePickerReducers.ts
@@ -8,7 +8,6 @@ import {IRangeLimit} from './DatesSelection';
 export interface IDatePickerState {
     id: string;
     calendarId: string;
-    color: string;
     lowerLimit: Date;
     upperLimit: Date;
     inputLowerLimit: Date;
@@ -26,7 +25,6 @@ export interface IDatePickerState {
 export const datePickerInitialState: IDatePickerState = {
     id: undefined,
     calendarId: undefined,
-    color: undefined,
     isRange: false,
     isClearable: false,
     simple: false,
@@ -48,7 +46,6 @@ const addDatePicker = (state: IDatePickerState, action: IReduxAction<IAddDatePic
     return {
         id: action.payload.id,
         calendarId: action.payload.calendarId,
-        color: action.payload.color,
         isRange: action.payload.isRange,
         rangeLimit: action.payload.rangeLimit,
         minimalRangeLimit: action.payload.minimalRangeLimit,

--- a/packages/react/src/components/datePicker/DatesSelectionConnected.tsx
+++ b/packages/react/src/components/datePicker/DatesSelectionConnected.tsx
@@ -44,7 +44,6 @@ const mapDispatchToProps = (
                 ownProps.id,
                 ownProps.isRange,
                 ownProps.rangeLimit,
-                ownProps.color,
                 ownProps.calendarId,
                 ownProps.initiallyUnselected,
                 ownProps.isClearable,

--- a/packages/react/src/components/datePicker/tests/DatePickerActions.spec.ts
+++ b/packages/react/src/components/datePicker/tests/DatePickerActions.spec.ts
@@ -31,7 +31,6 @@ describe('Date picker', () => {
                 type: DatePickerActions.add,
                 payload: {
                     id: DATE_PICKER_ID,
-                    color: COLOR,
                     calendarId: CALENDAR_ID,
                     isRange: IS_RANGE,
                     rangeLimit: undefined,
@@ -42,9 +41,7 @@ describe('Date picker', () => {
                 },
             };
 
-            expect(addDatePicker(DATE_PICKER_ID, IS_RANGE, undefined, COLOR, CALENDAR_ID, true, true)).toEqual(
-                expectedAction
-            );
+            expect(addDatePicker(DATE_PICKER_ID, IS_RANGE, undefined, CALENDAR_ID, true, true)).toEqual(expectedAction);
         });
 
         it('should create an action to add the date picker with default values if optional values are not specified', () => {
@@ -52,7 +49,6 @@ describe('Date picker', () => {
                 type: DatePickerActions.add,
                 payload: {
                     id: DATE_PICKER_ID,
-                    color: DEFAULT_DATE_PICKER_COLOR,
                     calendarId: '',
                     isRange: IS_RANGE,
                     rangeLimit: undefined,

--- a/packages/react/src/components/datePicker/tests/DatePickerDropdownConnected.spec.tsx
+++ b/packages/react/src/components/datePicker/tests/DatePickerDropdownConnected.spec.tsx
@@ -209,7 +209,7 @@ describe('Date picker', () => {
 
             it('should clear the selected limits of the dropdown when calling onClear prop', () => {
                 const pickerId: string = DATE_PICKER_DROPDOWN_BASIC_PROPS.id + '6868';
-                store.dispatch(addDatePicker(pickerId, true, undefined, '', 'some-calendar-id', undefined, true));
+                store.dispatch(addDatePicker(pickerId, true, undefined, 'some-calendar-id', undefined, true));
 
                 datePickerDropdown.props().onClear();
                 const datePickerState: IDatePickerState = _.findWhere(store.getState().datePickers, {id: pickerId});

--- a/packages/react/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/packages/react/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -29,7 +29,6 @@ describe('Date picker', () => {
     const BASE_DATE_PICKER_STATE: IDatePickerState = {
         id: 'some-date-picker',
         calendarId: 'some-calendar',
-        color: 'teal',
         isRange: false,
         lowerLimit: new Date(new Date().setHours(2, 1, 2, 1)),
         upperLimit: new Date(new Date().setHours(3, 2, 1, 2)),
@@ -64,7 +63,6 @@ describe('Date picker', () => {
                     id: 'some-date-picker',
                     isRange: true,
                     calendarId: 'calendar-321',
-                    color: 'magenta',
                 },
             };
 
@@ -341,7 +339,6 @@ describe('Date picker', () => {
                 payload: {
                     id: 'some-date-picker',
                     isRange: true,
-                    color: 'rainbow',
                     calendarId: 'radnelac',
                 },
             };
@@ -349,7 +346,6 @@ describe('Date picker', () => {
 
             expect(newDatePicker.id).toBe(action.payload.id);
             expect(newDatePicker.isRange).toBe(action.payload.isRange);
-            expect(newDatePicker.color).toBe(action.payload.color);
             expect(newDatePicker.calendarId).toBe(action.payload.calendarId);
         });
 
@@ -364,7 +360,6 @@ describe('Date picker', () => {
                         id: 'some-date-picker',
                         isRange: true,
                         calendarId: 'calendar-321',
-                        color: 'green',
                         initiallyUnselected: true,
                     },
                 };
@@ -393,7 +388,6 @@ describe('Date picker', () => {
                     id: 'some-date-picker',
                     isRange: true,
                     rangeLimit,
-                    color: 'rainbow',
                     calendarId: 'radnelac',
                 },
             };

--- a/packages/style/scss/components/calendar.scss
+++ b/packages/style/scss/components/calendar.scss
@@ -89,6 +89,10 @@
             background-color: var(--digital-blue-60);
         }
 
+        .selected-date.comparison-date {
+            background-color: var(--digital-blue-80);
+        }
+
         .lower-limit,
         .upper-limit {
             width: calc(#{$calendar-cell-dimensions} - #{$selected-date-offset} - #{$calendar-limit-border-width});


### PR DESCRIPTION

### Proposed Changes

<!-- Explain what are your changes. -->
Remove un-used color prop in the calendar component and added CSS class for the selected comparison date for the UA date picker

### Potential Breaking Changes

Removed the `color` prop from calendar.tsx component (not used since rebranding)

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
