### PR TITLE
feat(collapsible-container-connected): add optional onClick prop

### DIFF
--- a/packages/react/src/components/collapsible/CollapsibleContainerConnected.tsx
+++ b/packages/react/src/components/collapsible/CollapsibleContainerConnected.tsx
@@ -21,6 +21,7 @@ export interface ICollapsibleContainerOwnProps {
     collapsibleBodyClassName?: IClassName;
     withoutContentPadding?: boolean;
     disabled?: boolean;
+    onClick?: () => void;
 }
 
 const mapStateToProps = (state: PlasmaState, ownProps: ICollapsibleContainerOwnProps) => {
@@ -45,6 +46,7 @@ export const CollapsibleContainerDisconnected: React.FunctionComponent<
     expandedOnMount,
     collapsibleToggleIcon,
     disabled,
+    onClick,
 }) => {
     const contentClasses = classNames(
         {'collapsible-container content': !withoutContentPadding},
@@ -74,6 +76,7 @@ export const CollapsibleContainerDisconnected: React.FunctionComponent<
             collapsibleToggleIcon={collapsibleToggleIcon}
             withBorders
             disabled={disabled}
+            onClick={onClick}
         >
             <div className={contentClasses}>{children}</div>
         </CollapsibleConnected>

--- a/packages/react/src/components/collapsible/tests/CollapsibleContainerConnected.spec.tsx
+++ b/packages/react/src/components/collapsible/tests/CollapsibleContainerConnected.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {render, screen} from '@test-utils';
+import userEvent from '@testing-library/user-event';
 
 import {CollapsibleContainerConnected} from '../CollapsibleContainerConnected';
 
@@ -35,5 +36,19 @@ describe('CollapsibleContainerConnected', () => {
         );
 
         expect(screen.getByRole('img', {name: /info icon/i})).toBeInTheDocument();
+    });
+
+    it('calls the onClick event when the collapsible is clicked if the prop is set', () => {
+        const functionToBeCalled = jest.fn();
+
+        render(
+            <CollapsibleContainerConnected id="🆔" title="the title" onClick={functionToBeCalled}>
+                content
+            </CollapsibleContainerConnected>
+        );
+
+        userEvent.click(screen.getByText(/the title/i));
+
+        expect(functionToBeCalled).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
### Proposed Changes
Jira: https://coveord.atlassian.net/browse/SPAAS-1164

This update is simply to add the `onClick` property to the `CollapsibleContainerConnected` component, so it can be passed to the `CollapsibleConnected` connected after.

### Potential Breaking Changes
Because it's an optional property, I don't think it can create a breaking change.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
