### PR TITLE
fix(website): do not preload pages with Nextjs

### DIFF
--- a/packages/website/src/SideNavigation.tsx
+++ b/packages/website/src/SideNavigation.tsx
@@ -19,7 +19,7 @@ const NavLink: React.FunctionComponent<NavLinkProps> = ({href = '', label, disab
                     <span>{label}</span>
                 </div>
             ) : (
-                <Link href={href}>
+                <Link href={href} prefetch={false}>
                     <a className="navigation-menu-section-item-link">
                         <div className="navigation-menu-section">
                             <span>{label}</span>

--- a/packages/website/src/building-blocs/Tile.tsx
+++ b/packages/website/src/building-blocs/Tile.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import Link from 'next/link';
 import * as React from 'react';
 
 import actionButtonPng from '../../resources/thumbnail_ActionButton.png';
@@ -65,10 +66,12 @@ export const Tile: React.FunctionComponent<TileProps> = ({
 
     if (href && href.length > 0) {
         return (
-            <a className={className} href={href} onClick={sendAnalytics}>
-                {tileIcon}
-                {tileInfo}
-            </a>
+            <Link href={href} prefetch={false}>
+                <a className={className} onClick={sendAnalytics}>
+                    {tileIcon}
+                    {tileInfo}
+                </a>
+            </Link>
         );
     }
 

--- a/packages/website/src/building-blocs/useTypescriptServer.ts
+++ b/packages/website/src/building-blocs/useTypescriptServer.ts
@@ -14,13 +14,18 @@ export const compilerOptions: ts.CompilerOptions = {
     strict: false,
 };
 
-const typesFiles = require.context('!!raw-loader!@types', true, /\.d\.ts$/i, 'lazy');
-const plasmaTypes = require.context('!!raw-loader!@coveord/plasma-react/dist/definitions', true, /\.d\.ts$/i, 'lazy');
+const typesFiles = require.context('!!raw-loader!@types', true, /\.d\.ts$/i, 'lazy-once');
+const plasmaTypes = require.context(
+    '!!raw-loader!@coveord/plasma-react/dist/definitions',
+    true,
+    /\.d\.ts$/i,
+    'lazy-once'
+);
 const plasmaReactIconsTypes = require.context(
     '!!raw-loader!@coveord/plasma-react-icons/dist',
     true,
     /\.d\.ts$/i,
-    'lazy'
+    'lazy-once'
 );
 const load = async (path: string, ctx: any, root: string) => {
     const {default: content} = await ctx(path);

--- a/packages/website/src/pages/Search.tsx
+++ b/packages/website/src/pages/Search.tsx
@@ -50,7 +50,7 @@ const ResultListRenderer: FunctionComponent<ResultListProps> = (props) => {
                                 <Tile
                                     key={result.uniqueId}
                                     title={result.title}
-                                    href={result.clickUri.replace(/.+plasma\.coveo\.com\//, process.env.basePath)}
+                                    href={result.clickUri.replace(/.+plasma\.coveo\.com\//, '')}
                                     description={result.raw.description as string}
                                     thumbnail={result.raw.thumbnail as TileProps['thumbnail']}
                                     sendAnalytics={() => engine.dispatch(logDocumentOpen(result))}

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import * as PlasmaReact from '@coveord/plasma-react';
 import * as PlasmaReactIcons from '@coveord/plasma-react-icons';
 import type {AppProps} from 'next/app';
 import Head from 'next/head';
+import Link from 'next/link';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as ReactRedux from 'react-redux';
@@ -28,9 +29,11 @@ import {Store} from '../Store';
 
 const Header = () => (
     <div id="header" className="demo-header">
-        <a href="/#" className="header-logo-link">
-            <img src={logo} className="header-logo" alt="Plasma Design System" />
-        </a>
+        <Link href="/">
+            <a className="header-logo-link">
+                <img src={logo} className="header-logo" alt="Plasma Design System" />
+            </a>
+        </Link>
         <StandaloneSearchBar />
         <div className="right-side">
             <a href="https://github.com/coveo/plasma#readme" aria-label="README" target="_blank">


### PR DESCRIPTION
### Proposed Changes

By default Next preload all the pages accessible via a `Link` tag. Since we have all the pages in our menu it preloads everything which seem to cause issues for some people.
 
See https://web.dev/route-prefetching-in-nextjs/ for more details

### Potential Breaking Changes

Website might be a bit slower when navigating between pages

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
