### PR TITLE
Remove Svg from Badge

### DIFF
--- a/packages/react-icons/bin/index.js
+++ b/packages/react-icons/bin/index.js
@@ -41,6 +41,8 @@ const convertVariant = async (file) => {
                 template,
                 expandProps: false,
                 svgProps: {
+                    'aria-label': iconName,
+                    role: 'img',
                     height: '{height || width || "1em"}',
                     width: '{width || height || "1em"}',
                 },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,6 +35,7 @@
         "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"src/**/*.{ts,tsx}\" --fix"
     },
     "dependencies": {
+        "@coveord/plasma-react-icons": "workspace:*",
         "@coveord/plasma-style": "workspace:*",
         "@loadable/component": "5.15.2",
         "@types/codemirror": "0.0.109",

--- a/packages/react/src/components/badge/Badge.tsx
+++ b/packages/react/src/components/badge/Badge.tsx
@@ -1,7 +1,7 @@
-import {SvgName} from '@coveord/plasma-style';
 import classNames from 'classnames';
 import * as React from 'react';
-import {Svg} from '../svg';
+
+import {Icon} from '@coveord/plasma-react-icons';
 
 export const DEFAULT_BADGE_CLASSNAME = 'badge';
 
@@ -13,7 +13,7 @@ interface BadgeWithLabelProps extends BadgeBasicProps {
     label: string;
 }
 interface BadgeWithIconProps extends BadgeBasicProps {
-    icon: SvgName;
+    icon: Icon;
 }
 
 export type IBadgeProps = BadgeWithLabelProps | BadgeWithIconProps | (BadgeWithLabelProps & BadgeWithIconProps);
@@ -35,9 +35,8 @@ export class Badge extends React.Component<IBadgeProps> {
         return (
             <span className={this.className} aria-label="badge">
                 {'icon' in this.props ? (
-                    <Svg
-                        svgName={this.props.icon}
-                        svgClass={classNames('icon', {'mod-16': !this.isSmall, 'mod-12': this.isSmall})}
+                    <this.props.icon
+                        height={this.isSmall ? 14 : 18}
                         className={classNames({mr1: 'label' in this.props && this.props.label})}
                     />
                 ) : null}

--- a/packages/react/src/components/badge/tests/Badge.spec.tsx
+++ b/packages/react/src/components/badge/tests/Badge.spec.tsx
@@ -1,3 +1,4 @@
+import {LockSize16Px} from '@coveord/plasma-react-icons';
 import {render, screen, within} from '@test-utils';
 import * as React from 'react';
 
@@ -5,16 +6,16 @@ import {Badge} from '../Badge';
 
 describe('Badge', () => {
     it('renders a badge', () => {
-        render(<Badge label="label" icon="lock" />);
+        render(<Badge label="label" icon={LockSize16Px} />);
 
         const badge = screen.getByLabelText('badge');
         expect(badge).toBeInTheDocument();
         expect(within(badge).getByText('label')).toBeInTheDocument();
-        expect(within(badge).getByRole('img', {name: 'lock icon'})).toBeInTheDocument();
+        expect(within(badge).getByRole('img', {name: 'lock'})).toBeInTheDocument();
     });
 
     it('makes the icon smaller in small badges', () => {
-        render(<Badge label="label" icon="lock" extraClasses={['mod-small']} />);
-        expect(screen.getByRole('img', {name: 'lock icon'})).toHaveClass('mod-12');
+        render(<Badge label="label" icon={LockSize16Px} extraClasses={['mod-small']} />);
+        expect(screen.getByRole('img', {name: 'lock'})).toHaveAttribute('height', '14');
     });
 });

--- a/packages/website/src/pages/feedback/Badge.tsx
+++ b/packages/website/src/pages/feedback/Badge.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import {Badge, Section} from '@coveord/plasma-react';
+import {LockSize16Px} from '@coveord/plasma-react-icons';
+import * as React from 'react';
 
 import PlasmaComponent from '../../building-blocs/PlasmaComponent';
 
@@ -19,9 +20,9 @@ export const BadgeExamples: React.FunctionComponent = () => (
                 <Badge label="Critical" extraClasses={['mod-critical ml1']} />
                 <Badge label="New" extraClasses={['mod-warning ml1']} />
                 <Badge label="Beta" extraClasses={['mod-beta ml1']} />
-                <Badge icon="lock" extraClasses={['ml1']} />
-                <Badge icon="lock" label="Label" extraClasses={['ml1']} />
-                <Badge icon="lock" label="tag" extraClasses={['mod-tag ml1']} />
+                <Badge icon={LockSize16Px} extraClasses={['ml1']} />
+                <Badge icon={LockSize16Px} label="Label" extraClasses={['ml1']} />
+                <Badge icon={LockSize16Px} label="tag" extraClasses={['mod-tag ml1']} />
             </Section>
             <Section level={2} title="Small">
                 <Badge label="Default" extraClasses={['mod-small']} />
@@ -30,9 +31,9 @@ export const BadgeExamples: React.FunctionComponent = () => (
                 <Badge label="Critical" extraClasses={['mod-small mod-critical ml1']} />
                 <Badge label="New" extraClasses={['mod-small mod-warning ml1']} />
                 <Badge label="Beta" extraClasses={['mod-small mod-beta ml1']} />
-                <Badge icon="lock" extraClasses={['mod-small ml1']} />
-                <Badge icon="lock" label="Label" extraClasses={['mod-small ml1']} />
-                <Badge icon="lock" label="tag" extraClasses={['mod-small mod-tag ml1']} />
+                <Badge icon={LockSize16Px} extraClasses={['mod-small ml1']} />
+                <Badge icon={LockSize16Px} label="Label" extraClasses={['mod-small ml1']} />
+                <Badge icon={LockSize16Px} label="tag" extraClasses={['mod-small mod-tag ml1']} />
             </Section>
         </Section>
     </PlasmaComponent>

--- a/packages/website/src/pages/layout/IconCard.tsx
+++ b/packages/website/src/pages/layout/IconCard.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import {IconCard, Section, Svg} from '@coveord/plasma-react';
+import {LockSize16Px} from '@coveord/plasma-react-icons';
+import * as React from 'react';
 
 import PlasmaComponent from '../../building-blocs/PlasmaComponent';
 
@@ -65,7 +66,7 @@ export const IconCardExamples: React.FunctionComponent = () => (
                         title="Web"
                         svgName="sourceWeb"
                         disabled
-                        badges={[{icon: 'lock', extraClasses: ['mod-small']}]}
+                        badges={[{icon: LockSize16Px, extraClasses: ['mod-small']}]}
                         tooltip={{title: 'This source is not included in your license'}}
                         style={{width: '368px'}}
                     />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,7 @@ importers:
 
   packages/react:
     specifiers:
+      '@coveord/plasma-react-icons': workspace:*
       '@coveord/plasma-style': workspace:*
       '@helpers/enzyme-redux': workspace:*
       '@hot-loader/react-dom': 17.0.2
@@ -160,6 +161,7 @@ importers:
       underscore.string: 3.3.5
       unidiff: 0.0.4
     dependencies:
+      '@coveord/plasma-react-icons': link:../react-icons
       '@coveord/plasma-style': link:../style
       '@loadable/component': 5.15.2_react@16.14.0
       '@types/codemirror': 0.0.109


### PR DESCRIPTION
### Proposed Changes

- created the `Icon` type in plasma-react-icons
- added `img` ARIA role on all icons with a label
- switch out Svg for plasma-react-icon in badge component

### Potential Breaking Changes

Badge icon prop now expects an Icon from plasma-react-icons

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
