### PR TITLE
feat(react): use react-icons in CollapsibleToggle

### DIFF
--- a/packages/react-icons/bin/index.js
+++ b/packages/react-icons/bin/index.js
@@ -41,6 +41,8 @@ const convertVariant = async (file) => {
                 template,
                 expandProps: false,
                 svgProps: {
+                    'aria-label': iconName,
+                    role: 'img',
                     height: '{height || width || "1em"}',
                     width: '{width || height || "1em"}',
                 },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,6 +35,7 @@
         "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"src/**/*.{ts,tsx}\" --fix"
     },
     "dependencies": {
+        "@coveord/plasma-react-icons": "workspace:*",
         "@coveord/plasma-style": "workspace:*",
         "@loadable/component": "5.15.2",
         "@types/codemirror": "0.0.109",

--- a/packages/react/src/components/badge/Badge.tsx
+++ b/packages/react/src/components/badge/Badge.tsx
@@ -1,7 +1,7 @@
-import {SvgName} from '@coveord/plasma-style';
 import classNames from 'classnames';
 import * as React from 'react';
-import {Svg} from '../svg';
+
+import {Icon} from '@coveord/plasma-react-icons';
 
 export const DEFAULT_BADGE_CLASSNAME = 'badge';
 
@@ -13,7 +13,7 @@ interface BadgeWithLabelProps extends BadgeBasicProps {
     label: string;
 }
 interface BadgeWithIconProps extends BadgeBasicProps {
-    icon: SvgName;
+    icon: Icon;
 }
 
 export type IBadgeProps = BadgeWithLabelProps | BadgeWithIconProps | (BadgeWithLabelProps & BadgeWithIconProps);
@@ -35,9 +35,8 @@ export class Badge extends React.Component<IBadgeProps> {
         return (
             <span className={this.className} aria-label="badge">
                 {'icon' in this.props ? (
-                    <Svg
-                        svgName={this.props.icon}
-                        svgClass={classNames('icon', {'mod-16': !this.isSmall, 'mod-12': this.isSmall})}
+                    <this.props.icon
+                        height={this.isSmall ? 14 : 18}
                         className={classNames({mr1: 'label' in this.props && this.props.label})}
                     />
                 ) : null}

--- a/packages/react/src/components/badge/tests/Badge.spec.tsx
+++ b/packages/react/src/components/badge/tests/Badge.spec.tsx
@@ -1,3 +1,4 @@
+import {LockSize16Px} from '@coveord/plasma-react-icons';
 import {render, screen, within} from '@test-utils';
 import * as React from 'react';
 
@@ -5,16 +6,16 @@ import {Badge} from '../Badge';
 
 describe('Badge', () => {
     it('renders a badge', () => {
-        render(<Badge label="label" icon="lock" />);
+        render(<Badge label="label" icon={LockSize16Px} />);
 
         const badge = screen.getByLabelText('badge');
         expect(badge).toBeInTheDocument();
         expect(within(badge).getByText('label')).toBeInTheDocument();
-        expect(within(badge).getByRole('img', {name: 'lock icon'})).toBeInTheDocument();
+        expect(within(badge).getByRole('img', {name: 'lock'})).toBeInTheDocument();
     });
 
     it('makes the icon smaller in small badges', () => {
-        render(<Badge label="label" icon="lock" extraClasses={['mod-small']} />);
-        expect(screen.getByRole('img', {name: 'lock icon'})).toHaveClass('mod-12');
+        render(<Badge label="label" icon={LockSize16Px} extraClasses={['mod-small']} />);
+        expect(screen.getByRole('img', {name: 'lock'})).toHaveAttribute('height', '14');
     });
 });

--- a/packages/react/src/components/collapsible/CollapsibleConnected.tsx
+++ b/packages/react/src/components/collapsible/CollapsibleConnected.tsx
@@ -2,12 +2,12 @@ import classNames from 'classnames';
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {findWhere} from 'underscore';
+import {CollapsibleToggle} from './CollapsibleToggle';
 
 import {SlideY} from '../../animations/SlideY';
 import {PlasmaState} from '../../PlasmaState';
 import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
 import {addCollapsible, removeCollapsible, setCollapsibleExpanded} from './CollapsibleActions';
-import {CollapsibleToggle} from './CollapsibleToggle';
 
 export interface CollapsibleOwnProps {
     id: string;
@@ -86,8 +86,7 @@ export const CollapsibleDisconnected: React.FunctionComponent<
                 {collapsibleToggleIcon || (
                     <CollapsibleToggle
                         expanded={expanded}
-                        svgClassName={classNames(toggleIconClassName, {disabled})}
-                        className="mr2"
+                        className={classNames('mr2', toggleIconClassName, {disabled})}
                     />
                 )}
             </div>

--- a/packages/react/src/components/collapsible/CollapsibleToggle.tsx
+++ b/packages/react/src/components/collapsible/CollapsibleToggle.tsx
@@ -1,24 +1,14 @@
-import classNames from 'classnames';
+import {ArrowHeadDownSize16Px, ArrowHeadUpSize16Px} from '@coveord/plasma-react-icons';
 import * as React from 'react';
-
-import {Svg} from '../svg/Svg';
 
 export interface CollapsibleToggleProps {
     expanded: boolean;
-    className?: string;
-    svgClassName?: string;
 }
 
-export const CollapsibleToggle: React.SFC<CollapsibleToggleProps & React.HTMLAttributes<HTMLSpanElement>> = ({
+export const CollapsibleToggle: React.FunctionComponent<CollapsibleToggleProps & React.SVGProps<SVGSVGElement>> = ({
     expanded,
-    className,
-    svgClassName,
-    ...rest
-}) => (
-    <Svg
-        svgName={expanded ? 'arrowTopRounded' : 'arrowBottomRounded'}
-        svgClass={classNames('icon', svgClassName)}
-        className={className}
-        {...rest}
-    />
-);
+    ...svgProps
+}) => {
+    const Icon = expanded ? ArrowHeadUpSize16Px : ArrowHeadDownSize16Px;
+    return Icon ? <Icon height={16} {...svgProps} /> : null;
+};

--- a/packages/react/src/components/collapsible/tests/CollapsibleConnected.spec.tsx
+++ b/packages/react/src/components/collapsible/tests/CollapsibleConnected.spec.tsx
@@ -111,7 +111,7 @@ describe('<CollapsibleConnected />', () => {
             it('should set the class disabled on collapsible if disabled', () => {
                 mountComponentWithProps({disabled: true});
 
-                expect(wrapper.find(CollapsibleToggle).props().svgClassName).toContain('disabled');
+                expect(wrapper.find(CollapsibleToggle).props().className).toContain('disabled');
             });
         });
     });

--- a/packages/react/src/components/collapsible/tests/CollapsibleInfoBox.spec.tsx
+++ b/packages/react/src/components/collapsible/tests/CollapsibleInfoBox.spec.tsx
@@ -41,13 +41,13 @@ describe('CollapsibleInfoBox', () => {
 
         it('should render a <h6 /> and <svg /> in header', () => {
             expect(component.find('h6').exists()).toBe(true);
-            expect(component.find(Svg).length).toBe(2);
+            expect(component.find(Svg).length).toBe(1);
         });
 
         it('should not render a <svg /> in header if isSection', () => {
             mountComponent({isSection: true});
             expect(component.find('h6').exists()).toBe(true);
-            expect(component.find(Svg).length).toBe(1);
+            expect(component.find(Svg).length).toBe(0);
         });
 
         it('should display the sectionAdditionalContent if there is any and it is a section', () => {

--- a/packages/react/src/components/collapsible/tests/CollapsibleToggle.spec.tsx
+++ b/packages/react/src/components/collapsible/tests/CollapsibleToggle.spec.tsx
@@ -1,21 +1,16 @@
-import {shallow} from 'enzyme';
+import {render, screen} from '@test-utils';
 import * as React from 'react';
 
-import {Svg} from '../../svg/Svg';
 import {CollapsibleToggle} from '../CollapsibleToggle';
 
 describe('CollapsibleToggle', () => {
-    it('should render a Svg component with the icon "arrowBottomRounded" when expanded is false', () => {
-        const toggle = shallow(<CollapsibleToggle expanded={false} />);
-
-        expect(toggle.find(Svg).exists()).toBe(true);
-        expect(toggle.find(Svg).props().svgName).toBe('arrowBottomRounded');
+    it('should render a Svg component with the icon "arrowHeadDown" when expanded is false', () => {
+        render(<CollapsibleToggle expanded={false} />);
+        expect(screen.getByRole('img', {name: 'arrowHeadDown'})).toBeInTheDocument();
     });
 
     it('should render a Svg component with the icon "arrowTopRounded" when expanded is false', () => {
-        const toggle = shallow(<CollapsibleToggle expanded={true} />);
-
-        expect(toggle.find(Svg).exists()).toBe(true);
-        expect(toggle.find(Svg).props().svgName).toBe('arrowTopRounded');
+        render(<CollapsibleToggle expanded />);
+        expect(screen.getByRole('img', {name: 'arrowHeadUp'})).toBeInTheDocument();
     });
 });

--- a/packages/react/src/components/table-hoc/TableRowConnected.tsx
+++ b/packages/react/src/components/table-hoc/TableRowConnected.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
+import {Button} from '../button/Button';
 
 import {SlideY} from '../../animations/SlideY';
 import {PlasmaState} from '../../PlasmaState';
@@ -166,12 +167,9 @@ class TableRowConnected extends React.PureComponent<
                             'mod-no-border-bottom': this.props.collapsible.noBorderBottom,
                         })}
                     >
-                        <CollapsibleToggle
-                            onClick={this.onToggleCollapsible}
-                            expanded={this.props.opened}
-                            svgClassName="mod-12"
-                            className={'btn mod-no-border right px1'}
-                        />
+                        <Button onClick={this.onToggleCollapsible} classes="mod-no-border right px1">
+                            <CollapsibleToggle expanded={this.props.opened} />
+                        </Button>
                     </td>
                 );
             }
@@ -228,10 +226,7 @@ class TableRowConnected extends React.PureComponent<
             });
     };
 
-    private onToggleCollapsible = (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-
+    private onToggleCollapsible = () => {
         this.props.onCollapsibleClick(this.props.opened);
     };
 }

--- a/packages/react/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/packages/react/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -12,6 +12,7 @@ import {CollapsibleToggle} from '../../collapsible/CollapsibleToggle';
 import {TableHOCRowActions} from '../actions/TableHOCRowActions';
 import {ITableRowConnectedProps, TableRowConnected} from '../TableRowConnected';
 import {TableSelectors} from '../TableSelectors';
+import {Button} from '../../button/Button';
 
 describe('Table HOC', () => {
     describe('TableRowConnected', () => {
@@ -437,10 +438,7 @@ describe('Table HOC', () => {
                 shallowComponent();
                 const expectedAction = TableHOCRowActions.toggleCollapsible(defaultProps.id);
 
-                wrapper.find(CollapsibleToggle).simulate('click', {
-                    preventDefault: jest.fn(),
-                    stopPropagation: jest.fn(),
-                });
+                wrapper.find(Button).simulate('click');
 
                 expect(store.getActions()).toContainEqual(expectedAction);
             });
@@ -579,10 +577,7 @@ describe('Table HOC', () => {
                 .dive()
                 .dive();
 
-            row.find(CollapsibleToggle).simulate('click', {
-                preventDefault: jest.fn(),
-                stopPropagation: jest.fn(),
-            });
+            row.find(Button).simulate('click');
 
             expect(spy).toHaveBeenCalledWith(true);
         });
@@ -614,10 +609,7 @@ describe('Table HOC', () => {
                 .dive()
                 .dive();
 
-            row.find(CollapsibleToggle).simulate('click', {
-                preventDefault: jest.fn(),
-                stopPropagation: jest.fn(),
-            });
+            row.find(Button).simulate('click');
 
             expect(spy).toHaveBeenCalledWith(false);
         });

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -8,5 +8,6 @@
             "@test-utils": ["jest/utils.tsx"],
             "*": ["types/*", "*"]
         }
-    }
+    },
+    "exclude": ["dist", "node_modules"]
 }

--- a/packages/style/scss/components/navigation.scss
+++ b/packages/style/scss/components/navigation.scss
@@ -101,10 +101,6 @@
                     }
                 }
 
-                .navigation-menu-section-toggle {
-                    fill: var(--navy-blue-80);
-                }
-
                 .navigation-menu-section-items {
                     overflow-x: visible;
 

--- a/packages/website/src/pages/feedback/Badge.tsx
+++ b/packages/website/src/pages/feedback/Badge.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import {Badge, Section} from '@coveord/plasma-react';
+import {LockSize16Px} from '@coveord/plasma-react-icons';
+import * as React from 'react';
 
 import PlasmaComponent from '../../building-blocs/PlasmaComponent';
 
@@ -19,9 +20,9 @@ export const BadgeExamples: React.FunctionComponent = () => (
                 <Badge label="Critical" extraClasses={['mod-critical ml1']} />
                 <Badge label="New" extraClasses={['mod-warning ml1']} />
                 <Badge label="Beta" extraClasses={['mod-beta ml1']} />
-                <Badge icon="lock" extraClasses={['ml1']} />
-                <Badge icon="lock" label="Label" extraClasses={['ml1']} />
-                <Badge icon="lock" label="tag" extraClasses={['mod-tag ml1']} />
+                <Badge icon={LockSize16Px} extraClasses={['ml1']} />
+                <Badge icon={LockSize16Px} label="Label" extraClasses={['ml1']} />
+                <Badge icon={LockSize16Px} label="tag" extraClasses={['mod-tag ml1']} />
             </Section>
             <Section level={2} title="Small">
                 <Badge label="Default" extraClasses={['mod-small']} />
@@ -30,9 +31,9 @@ export const BadgeExamples: React.FunctionComponent = () => (
                 <Badge label="Critical" extraClasses={['mod-small mod-critical ml1']} />
                 <Badge label="New" extraClasses={['mod-small mod-warning ml1']} />
                 <Badge label="Beta" extraClasses={['mod-small mod-beta ml1']} />
-                <Badge icon="lock" extraClasses={['mod-small ml1']} />
-                <Badge icon="lock" label="Label" extraClasses={['mod-small ml1']} />
-                <Badge icon="lock" label="tag" extraClasses={['mod-small mod-tag ml1']} />
+                <Badge icon={LockSize16Px} extraClasses={['mod-small ml1']} />
+                <Badge icon={LockSize16Px} label="Label" extraClasses={['mod-small ml1']} />
+                <Badge icon={LockSize16Px} label="tag" extraClasses={['mod-small mod-tag ml1']} />
             </Section>
         </Section>
     </PlasmaComponent>

--- a/packages/website/src/pages/layout/Collapsible.tsx
+++ b/packages/website/src/pages/layout/Collapsible.tsx
@@ -1,5 +1,3 @@
-import {svg} from '@coveord/plasma-style';
-import * as React from 'react';
 import {
     Badge,
     Button,
@@ -13,8 +11,9 @@ import {
     Label,
     Section,
     setCollapsibleExpanded,
-    Svg,
 } from '@coveord/plasma-react';
+import {AddSize16Px} from '@coveord/plasma-react-icons';
+import * as React from 'react';
 import * as _ from 'underscore';
 
 import PlasmaComponent from '../../building-blocs/PlasmaComponent';
@@ -141,7 +140,7 @@ export const CollapsibleExamples: React.FunctionComponent = () => {
                             }}
                             collapsibleToggleIcon={
                                 <span className="flex space-between center-align">
-                                    <Svg svgName={svg.add.name} svgClass="icon" />
+                                    <AddSize16Px height={16} />
                                 </span>
                             }
                         >

--- a/packages/website/src/pages/layout/IconCard.tsx
+++ b/packages/website/src/pages/layout/IconCard.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import {IconCard, Section, Svg} from '@coveord/plasma-react';
+import {LockSize16Px} from '@coveord/plasma-react-icons';
+import * as React from 'react';
 
 import PlasmaComponent from '../../building-blocs/PlasmaComponent';
 
@@ -65,7 +66,7 @@ export const IconCardExamples: React.FunctionComponent = () => (
                         title="Web"
                         svgName="sourceWeb"
                         disabled
-                        badges={[{icon: 'lock', extraClasses: ['mod-small']}]}
+                        badges={[{icon: LockSize16Px, extraClasses: ['mod-small']}]}
                         tooltip={{title: 'This source is not included in your license'}}
                         style={{width: '368px'}}
                     />

--- a/packages/website/src/styles/main.scss
+++ b/packages/website/src/styles/main.scss
@@ -82,54 +82,6 @@
     }
 }
 
-// Icons
-.sg-icons-html {
-    code {
-        white-space: pre-line;
-    }
-}
-
-.sg-icons-list {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    font-family: var(--main-font);
-
-    li {
-        display: inline-flex;
-        justify-content: center;
-        width: 100px;
-        height: 120px;
-        margin: 2px;
-        word-break: break-all;
-
-        &:hover {
-            background-color: var(--deprecated-grey-3);
-        }
-
-        a {
-            display: flex;
-            flex-direction: column-reverse;
-            justify-content: center;
-            height: 100%;
-            text-align: center;
-
-            svg {
-                width: 45px;
-                height: 45px;
-            }
-        }
-
-        label {
-            display: block;
-            margin-top: 10px;
-            font-size: 12px;
-            text-align: center;
-            word-wrap: break-word;
-        }
-    }
-}
-
 .progress-bar-example-container {
     display: flex;
     padding: 30px 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,7 @@ importers:
 
   packages/react:
     specifiers:
+      '@coveord/plasma-react-icons': workspace:*
       '@coveord/plasma-style': workspace:*
       '@helpers/enzyme-redux': workspace:*
       '@hot-loader/react-dom': 17.0.2
@@ -160,6 +161,7 @@ importers:
       underscore.string: 3.3.5
       unidiff: 0.0.4
     dependencies:
+      '@coveord/plasma-react-icons': link:../react-icons
       '@coveord/plasma-style': link:../style
       '@loadable/component': 5.15.2_react@16.14.0
       '@types/codemirror': 0.0.109


### PR DESCRIPTION
### Proposed Changes

Switch out the Svg component for the icons from plasma-react-icons in the CollapsibleToggle
component

### Potential Breaking Changes

`CollapsibleToggleProps` changed, `svgClassName` is no longer a prop.

### How to test

Open the demo and look at the collapsible sections of the nav, also navigate to `Collapsible` component.
