### PR TITLE
build(react): @swc/helpers is a dependency not a devDependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@coveord/plasma-style": "workspace:*",
         "@loadable/component": "5.15.2",
+        "@swc/helpers": "0.3.3",
         "@types/codemirror": "0.0.109",
         "chosen-js": "1.8.7",
         "classnames": "2.3.1",
@@ -76,7 +77,6 @@
         "@hot-loader/react-dom": "17.0.2",
         "@swc/cli": "0.1.55",
         "@swc/core": "1.2.136",
-        "@swc/helpers": "0.3.3",
         "@swc/jest": "0.2.20",
         "@testing-library/dom": "8.11.1",
         "@testing-library/jest-dom": "5.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,7 @@ importers:
     dependencies:
       '@coveord/plasma-style': link:../style
       '@loadable/component': 5.15.2_react@16.14.0
+      '@swc/helpers': 0.3.3
       '@types/codemirror': 0.0.109
       chosen-js: 1.8.7
       classnames: 2.3.1
@@ -189,7 +190,6 @@ importers:
       '@hot-loader/react-dom': 17.0.2_react@16.14.0
       '@swc/cli': 0.1.55_@swc+core@1.2.136
       '@swc/core': 1.2.136
-      '@swc/helpers': 0.3.3
       '@swc/jest': 0.2.20_@swc+core@1.2.136
       '@testing-library/dom': 8.11.1
       '@testing-library/jest-dom': 5.16.1
@@ -2102,7 +2102,7 @@ packages:
 
   /@swc/helpers/0.3.3:
     resolution: {integrity: sha512-NdRQSjcceaXsQDNYyK0wWyRvrn5rsvugK8vnTiRB2i0UCaD2slUFUq28tmojILW5A04oF+sZRMxd0Cy7xS/y0A==}
-    dev: true
+    dev: false
 
   /@swc/jest/0.2.20_@swc+core@1.2.136:
     resolution: {integrity: sha512-5qSUBYY1wyIMn7p0Vl9qqV4hMI69oJwZCIPUpBsTFWN2wlwn6RDugzdgCn+bLXVYh+Cxi8bJcZ1uumDgsoL+FA==}


### PR DESCRIPTION
### Proposed Changes

When trying to import plasma-react in a package that doesn't have `@swc/helpers` as a dependency it breaks.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
