### PR TITLE
ci: fix publish

### DIFF
--- a/build/publishNewVersion.mjs
+++ b/build/publishNewVersion.mjs
@@ -108,8 +108,10 @@ const outputProcess = (process) => {
                     outputProcess(gitPushTags());
 
                     console.log(`Publishing version ${versionTag}`);
-                    const forcePackagesWithoutRoot = options.force.filter((packageName) => packageName !== 'root');
-                    outputProcess(pnpmPublish(since, options.tag, options.branch, forcePackagesWithoutRoot, ['root']));
+                    const changedPackagesWithoutRoot = changedPackages.filter((packageName) => packageName !== 'root');
+                    outputProcess(
+                        pnpmPublish(since, options.tag, options.branch, changedPackagesWithoutRoot, ['root'])
+                    );
                 }
             }
         }


### PR DESCRIPTION
### Proposed Changes

There is this error when publishing from master

```bash
10:56:36  Bumping root, @coveord/plasma-react-icons, @coveord/plasma-website to version 38.13.0
10:56:39  Pushing version v38.13.0
10:56:40  
10:56:41  
10:56:41  Publishing version v38.13.0
10:56:42  No projects matched the filters in "/home/jenkins/slaves/workspace/plasma_master"
[Pipeline] sh
10:56:43  + node -p -e require(`./package.json`).version;
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
