### PR TITLE
fix: autofocus for filterbox

### DIFF
--- a/packages/react/src/components/filterBox/FilterBox.tsx
+++ b/packages/react/src/components/filterBox/FilterBox.tsx
@@ -89,7 +89,13 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
                     title={this.filterInput && this.props.withTitleOnInput ? this.filterInput.value : undefined}
                 >
                     <input
-                        ref={(filterInput: HTMLInputElement) => (this.filterInput = filterInput)}
+                        ref={(filterInput: HTMLInputElement) => {
+                            this.filterInput = filterInput;
+
+                            if (this.props.isAutoFocus) {
+                                this.filterInput?.focus?.();
+                            }
+                        }}
                         type="text"
                         className={filterInputClasses}
                         placeholder={filterPlaceholder}
@@ -101,7 +107,6 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
                         onKeyDown={this.props.onKeyDown}
                         onKeyUp={this.props.onKeyUp}
                         style={inputMaxWidth}
-                        autoFocus={this.props.isAutoFocus}
                     />
                     <Svg
                         svgName="clear"


### PR DESCRIPTION
### Proposed Changes

[ADUI-7861](https://coveord.atlassian.net/browse/ADUI-7861)

This fixes an issue where dropdowns with filters when opened would not auto focus on the filter.  It is not quite clear how it broke but it appears to be from a change in this [commit](https://github.com/coveo/plasma/commit/4b5a7cc1d67352f4490f53296b6d5bde91c6eb8f).  After some discussion, if this fixes it in the demo link, it should be merged.  Afterwards, I will create a PR to update the release branch.  

I will be creating a JIRA with more details on my findings that will later be used to assess and we can figure out what changes we'll make later.

How to test this:

- On the demo branch go to the "Select - Single" page
- Open up the "A single select with filter" dropdown
- Confirm that the Filter input is focused on

### Potential Breaking Changes

None.  It should fix an auto focus issue

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
