### PR TITLE
refactor(react): remove Svg from CollapsibleInfoBox

### DIFF
--- a/packages/react/src/components/collapsible/CollapsibleInfoBox.tsx
+++ b/packages/react/src/components/collapsible/CollapsibleInfoBox.tsx
@@ -1,7 +1,7 @@
+import {InfoSize24Px} from '@coveord/plasma-react-icons';
 import classNames from 'classnames';
 import * as React from 'react';
 
-import {Svg} from '../svg/Svg';
 import {CollapsibleConnected} from './CollapsibleConnected';
 
 export interface CollapsibleInfoBoxProps {
@@ -34,7 +34,7 @@ export const CollapsibleInfoBox: React.FC<CollapsibleInfoBoxProps> = ({
             </div>
         ) : (
             <div className="flex">
-                <Svg svgName="info" className="icon mod-20 mx1 js-info-svg" />
+                <InfoSize24Px height={24} className="mx1" />
                 <h6>{title}</h6>
             </div>
         );

--- a/packages/react/src/components/collapsible/tests/CollapsibleInfoBox.spec.tsx
+++ b/packages/react/src/components/collapsible/tests/CollapsibleInfoBox.spec.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import {Provider} from 'react-redux';
 
 import {TestUtils} from '../../../utils/tests/TestUtils';
-import {Svg} from '../../svg/Svg';
 import {CollapsibleConnected} from '../CollapsibleConnected';
 import {CollapsibleInfoBox, CollapsibleInfoBoxProps} from '../CollapsibleInfoBox';
 
@@ -41,13 +40,13 @@ describe('CollapsibleInfoBox', () => {
 
         it('should render a <h6 /> and <svg /> in header', () => {
             expect(component.find('h6').exists()).toBe(true);
-            expect(component.find(Svg).length).toBe(1);
+            expect(component.find('svg').length).toBe(2);
         });
 
         it('should not render a <svg /> in header if isSection', () => {
             mountComponent({isSection: true});
             expect(component.find('h6').exists()).toBe(true);
-            expect(component.find(Svg).length).toBe(0);
+            expect(component.find('svg').length).toBe(1);
         });
 
         it('should display the sectionAdditionalContent if there is any and it is a section', () => {


### PR DESCRIPTION
### Proposed Changes

Switch out the `Svg` component for the icon from `plasma-react-icons` in `CollapsibleInfoBox`

Before
![image](https://user-images.githubusercontent.com/35579930/157478049-0e8271dd-dde7-43a7-a22f-f5ce25f63e78.png)

After
![image](https://user-images.githubusercontent.com/35579930/157477981-59d3a27d-a98a-42ab-b98c-836bc064cccc.png)


### Potential Breaking Changes

none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
