### PR TITLE
refactor(react): remove Svg from BrowserPreview

### DIFF
--- a/packages/react/src/components/browserPreview/BrowserPreview.tsx
+++ b/packages/react/src/components/browserPreview/BrowserPreview.tsx
@@ -1,8 +1,8 @@
+import {InfoSize16Px} from '@coveord/plasma-react-icons';
 import * as React from 'react';
 import {truncate} from 'underscore.string';
 
 import {TooltipPlacement} from '../../utils';
-import {Svg} from '../svg';
 import {Tooltip} from '../tooltip';
 
 export interface BrowserPreviewProps {
@@ -22,10 +22,10 @@ const BrowserPreviewHeader: React.FunctionComponent<{tooltipTitle: string; title
     tooltipTitle,
 }) => (
     <div className="browser-preview__header flex space-between px2 py1">
-        <div>
+        <div className="inline-flex">
             <span className="bolder">Preview</span>
             <Tooltip title={tooltipTitle} placement={TooltipPlacement.Right}>
-                <Svg svgName="info" svgClass="icon mod-14 ml1" />
+                <InfoSize16Px height={16} className="ml1" />
             </Tooltip>
         </div>
         <div>

--- a/packages/react/src/components/browserPreview/BrowserPreviewEmpty.tsx
+++ b/packages/react/src/components/browserPreview/BrowserPreviewEmpty.tsx
@@ -15,7 +15,7 @@ export const BrowserPreviewEmpty: React.FunctionComponent<BrowserPreviewEmptyPro
             'cursor-pointer': onClick,
         })}
     >
-        {image ?? <Svg svgName="arrowLeftReturn" className="block" />}
+        {image ?? <Svg svgName="arrowLeftReturn" svgClass="icon mod-info" className="block" />}
         <p className="medium-title-text mt2 flex flex-column center-align center">{children}</p>
     </div>
 );

--- a/packages/react/src/components/browserPreview/tests/BrowserPreview.spec.tsx
+++ b/packages/react/src/components/browserPreview/tests/BrowserPreview.spec.tsx
@@ -8,11 +8,7 @@ describe('BrowserPreview', () => {
     it('renders the specified header description as tooltip title', async () => {
         const headerDescription = '🥰';
         render(<BrowserPreview headerDescription={headerDescription} />);
-        userEvent.hover(
-            screen.getByRole('img', {
-                name: /info icon/i,
-            })
-        );
+        userEvent.hover(screen.getByRole('img', {name: /info/i}));
 
         expect(await screen.findByText(headerDescription)).toBeVisible();
     });

--- a/packages/style/scss/components/browser-preview.scss
+++ b/packages/style/scss/components/browser-preview.scss
@@ -10,10 +10,6 @@
         background-color: var(--navy-blue-60);
         border-radius: $big-border-radius $big-border-radius 0px 0px;
 
-        svg {
-            fill: currentColor;
-        }
-
         .white-dot {
             display: inline-block;
             width: 10px;
@@ -34,7 +30,6 @@
         svg {
             width: 220px;
             height: 220px;
-            fill: #5f619e;
         }
 
         .medium-title-text {

--- a/packages/website/src/pages/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/layout/BrowserPreview.tsx
@@ -1,12 +1,6 @@
+import {BrowserPreview, BrowserPreviewEmpty, BrowserPreviewError, Section, SplitLayout} from '@coveord/plasma-react';
+import {ArrowUpSize32Px} from '@coveord/plasma-react-icons';
 import * as React from 'react';
-import {
-    BrowserPreview,
-    BrowserPreviewEmpty,
-    BrowserPreviewError,
-    Section,
-    SplitLayout,
-    Svg,
-} from '@coveord/plasma-react';
 
 import PlasmaComponent from '../../building-blocs/PlasmaComponent';
 
@@ -87,10 +81,7 @@ export const BrowserPreviewExamples: React.FunctionComponent = () => (
                     rightChildren={
                         <div className="p3">
                             <BrowserPreview>
-                                <BrowserPreviewEmpty
-                                    onClick={() => alert('Wow!')}
-                                    image={<Svg svgName="arrowTopSlim" className="block" />}
-                                >
+                                <BrowserPreviewEmpty onClick={() => alert('Wow!')} image={<ArrowUpSize32Px />}>
                                     <span>Look at this browser-like header!</span>
                                 </BrowserPreviewEmpty>
                             </BrowserPreview>


### PR DESCRIPTION
### Proposed Changes

Switch out the `Svg` for `plasma-react-icons` in `BrowserPreview` component where I could (the `arrowLeftReturn` icon does not exist yet in the new iconography)

Before
![image](https://user-images.githubusercontent.com/35579930/157490355-be72d5ad-7eb7-4531-a212-db9e9371a7c4.png)

After
![image](https://user-images.githubusercontent.com/35579930/157491012-79ed54ad-7431-4e3c-80ad-ea49c4295d65.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
