### PR TITLE
refactor(react): use plasma-react-icons in InfoToken

### DIFF
--- a/packages/react/src/components/info-token/InfoToken.tsx
+++ b/packages/react/src/components/info-token/InfoToken.tsx
@@ -1,8 +1,26 @@
+import {
+    CheckmarkSize16Px,
+    CheckmarkSize24Px,
+    CheckmarkSize32Px,
+    CriticalSize16Px,
+    CriticalSize24Px,
+    CriticalSize32Px,
+    Icon,
+    InfoSize16Px,
+    InfoSize24Px,
+    InfoSize32Px,
+    QuestionSize16Px,
+    QuestionSize24Px,
+    QuestionSize32Px,
+    TipSize16Px,
+    TipSize24Px,
+    TipSize32Px,
+    WarningSize16Px,
+    WarningSize24Px,
+    WarningSize32Px,
+} from '@coveord/plasma-react-icons';
 import classNames from 'classnames';
-import {svg, SvgName} from '@coveord/plasma-style';
 import * as React from 'react';
-
-import {Svg} from '../svg';
 
 export enum InfoTokenType {
     Information,
@@ -31,40 +49,46 @@ export interface InfoTokenProps {
     className?: string;
 }
 
-const SvgMapping: Record<InfoTokenType, Record<InfoTokenSize, SvgName>> = {
+const IconMapping: Record<InfoTokenType, Record<InfoTokenSize, Icon>> = {
     [InfoTokenType.Information]: {
-        [InfoTokenSize.Small]: svg.infoStrokedSmall.name,
-        [InfoTokenSize.Medium]: svg.infoStrokedMedium.name,
-        [InfoTokenSize.Large]: svg.infoStrokedLarge.name,
+        [InfoTokenSize.Small]: InfoSize16Px,
+        [InfoTokenSize.Medium]: InfoSize24Px,
+        [InfoTokenSize.Large]: InfoSize32Px,
     },
     [InfoTokenType.Success]: {
-        [InfoTokenSize.Small]: svg.checkStrokedSmall.name,
-        [InfoTokenSize.Medium]: svg.checkStrokedMedium.name,
-        [InfoTokenSize.Large]: svg.checkStrokedLarge.name,
+        [InfoTokenSize.Small]: CheckmarkSize16Px,
+        [InfoTokenSize.Medium]: CheckmarkSize24Px,
+        [InfoTokenSize.Large]: CheckmarkSize32Px,
     },
     [InfoTokenType.Warning]: {
-        [InfoTokenSize.Small]: svg.warningStrokedSmall.name,
-        [InfoTokenSize.Medium]: svg.warningStrokedMedium.name,
-        [InfoTokenSize.Large]: svg.warningStrokedLarge.name,
+        [InfoTokenSize.Small]: WarningSize16Px,
+        [InfoTokenSize.Medium]: WarningSize24Px,
+        [InfoTokenSize.Large]: WarningSize32Px,
     },
     [InfoTokenType.Critical]: {
-        [InfoTokenSize.Small]: svg.criticalStrokedSmall.name,
-        [InfoTokenSize.Medium]: svg.criticalStrokedMedium.name,
-        [InfoTokenSize.Large]: svg.criticalStrokedLarge.name,
+        [InfoTokenSize.Small]: CriticalSize16Px,
+        [InfoTokenSize.Medium]: CriticalSize24Px,
+        [InfoTokenSize.Large]: CriticalSize32Px,
     },
     [InfoTokenType.Tip]: {
-        [InfoTokenSize.Small]: svg.ideaStrokedSmall.name,
-        [InfoTokenSize.Medium]: svg.ideaStrokedMedium.name,
-        [InfoTokenSize.Large]: svg.ideaStrokedLarge.name,
+        [InfoTokenSize.Small]: TipSize16Px,
+        [InfoTokenSize.Medium]: TipSize24Px,
+        [InfoTokenSize.Large]: TipSize32Px,
     },
     [InfoTokenType.Question]: {
-        [InfoTokenSize.Small]: svg.questionStrokedSmall.name,
-        [InfoTokenSize.Medium]: svg.questionStrokedMedium.name,
-        [InfoTokenSize.Large]: svg.questionStrokedLarge.name,
+        [InfoTokenSize.Small]: QuestionSize16Px,
+        [InfoTokenSize.Medium]: QuestionSize24Px,
+        [InfoTokenSize.Large]: QuestionSize32Px,
     },
 };
 
-const TypeColorMapping: Record<InfoTokenType, string> = {
+const SizeMapping: Record<InfoTokenSize, number> = {
+    [InfoTokenSize.Small]: 16,
+    [InfoTokenSize.Medium]: 24,
+    [InfoTokenSize.Large]: 32,
+};
+
+const ColorMapping: Record<InfoTokenType, string> = {
     [InfoTokenType.Information]: 'mod-info',
     [InfoTokenType.Success]: 'mod-success',
     [InfoTokenType.Warning]: 'mod-warning',
@@ -73,21 +97,17 @@ const TypeColorMapping: Record<InfoTokenType, string> = {
     [InfoTokenType.Question]: 'mod-info',
 };
 
-const SizeClassMapping: Record<InfoTokenSize, string> = {
-    [InfoTokenSize.Small]: 'mod-16',
-    [InfoTokenSize.Medium]: 'mod-24',
-    [InfoTokenSize.Large]: 'mod-32',
-};
-
-const ModeClassMapping: Record<InfoTokenMode, string> = {
+const ModeMapping: Record<InfoTokenMode, string> = {
     [InfoTokenMode.Stroked]: 'stroked',
     [InfoTokenMode.Filled]: 'filled',
 };
 
-export const InfoToken: React.FunctionComponent<InfoTokenProps> = ({mode, size, type, className}) => (
-    <Svg
-        className={classNames('info-token', ModeClassMapping[mode], SizeClassMapping[size], className)}
-        svgName={SvgMapping[type][size]}
-        svgClass={classNames('icon mod-stroke', SizeClassMapping[size], TypeColorMapping[type])}
-    />
-);
+export const InfoToken: React.FunctionComponent<InfoTokenProps> = ({mode, size, type, className}) => {
+    const IconComponent = IconMapping[type][size];
+    return (
+        <IconComponent
+            height={SizeMapping[size]}
+            className={classNames('info-token', ModeMapping[mode], ColorMapping[type], className)}
+        />
+    );
+};

--- a/packages/react/src/components/info-token/tests/InfoToken.spec.tsx
+++ b/packages/react/src/components/info-token/tests/InfoToken.spec.tsx
@@ -5,181 +5,183 @@ import * as React from 'react';
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '../InfoToken';
 
 describe('InfoToken', () => {
-    it('renders the infoStrokedSmall icon if the specified size and type are Small and Information', () => {
+    it('renders the info icon if the specified size and type are Small and Information', () => {
         render(<InfoToken type={InfoTokenType.Information} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Small} />);
 
-        const smallToken = screen.getByRole('img', {name: 'infoStrokedSmall icon'});
+        const smallToken = screen.getByRole('img', {name: 'info'});
         expect(smallToken).toBeInTheDocument();
-        expect(smallToken).toHaveClass('mod-16');
+        expect(smallToken).toHaveAttribute('height', '16');
         expect(smallToken).toHaveClass('mod-info');
+        expect(smallToken).toHaveClass('stroked');
     });
 
-    it('renders the infoStrokedMedium icon if the specified size and type are Medium and Information', () => {
-        render(<InfoToken type={InfoTokenType.Information} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Medium} />);
+    it('renders the info icon if the specified size and type are Medium and Information', () => {
+        render(<InfoToken type={InfoTokenType.Information} mode={InfoTokenMode.Filled} size={InfoTokenSize.Medium} />);
 
-        const mediumToken = screen.getByRole('img', {name: 'infoStrokedMedium icon'});
+        const mediumToken = screen.getByRole('img', {name: 'info'});
         expect(mediumToken).toBeInTheDocument();
-        expect(mediumToken).toHaveClass('mod-24');
+        expect(mediumToken).toHaveAttribute('height', '24');
         expect(mediumToken).toHaveClass('mod-info');
+        expect(mediumToken).toHaveClass('filled');
     });
 
-    it('renders the infoStrokedLarge icon if the specified size and type are Large and Information', () => {
+    it('renders the info icon if the specified size and type are Large and Information', () => {
         render(<InfoToken type={InfoTokenType.Information} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Large} />);
 
-        const largeToken = screen.getByRole('img', {name: 'infoStrokedLarge icon'});
+        const largeToken = screen.getByRole('img', {name: 'info'});
         expect(largeToken).toBeInTheDocument();
-        expect(largeToken).toHaveClass('mod-32');
+        expect(largeToken).toHaveAttribute('height', '32');
         expect(largeToken).toHaveClass('mod-info');
+        expect(largeToken).toHaveClass('stroked');
     });
 
-    it('renders the checkStrokedSmall icon if the specified size and type are Small and Success', () => {
-        render(<InfoToken type={InfoTokenType.Success} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Small} />);
+    it('renders the checkmark icon if the specified size and type are Small and Success', () => {
+        render(<InfoToken type={InfoTokenType.Success} mode={InfoTokenMode.Filled} size={InfoTokenSize.Small} />);
 
-        const smallToken = screen.getByRole('img', {name: 'checkStrokedSmall icon'});
+        const smallToken = screen.getByRole('img', {name: 'checkmark'});
         expect(smallToken).toBeInTheDocument();
-        expect(smallToken).toHaveClass('mod-16');
+        expect(smallToken).toHaveAttribute('height', '16');
         expect(smallToken).toHaveClass('mod-success');
+        expect(smallToken).toHaveClass('filled');
     });
 
-    it('renders the checkStrokedMedium icon if the specified size and type are Medium and Success', () => {
+    it('renders the checkmark icon if the specified size and type are Medium and Success', () => {
         render(<InfoToken type={InfoTokenType.Success} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Medium} />);
 
-        const mediumToken = screen.getByRole('img', {name: 'checkStrokedMedium icon'});
+        const mediumToken = screen.getByRole('img', {name: 'checkmark'});
         expect(mediumToken).toBeInTheDocument();
-        expect(mediumToken).toHaveClass('mod-24');
+        expect(mediumToken).toHaveAttribute('height', '24');
         expect(mediumToken).toHaveClass('mod-success');
+        expect(mediumToken).toHaveClass('stroked');
     });
 
-    it('renders the checkStrokedLarge icon if the specified size and type are Large and Success', () => {
-        render(<InfoToken type={InfoTokenType.Success} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Large} />);
+    it('renders the checkmark icon if the specified size and type are Large and Success', () => {
+        render(<InfoToken type={InfoTokenType.Success} mode={InfoTokenMode.Filled} size={InfoTokenSize.Large} />);
 
-        const largeToken = screen.getByRole('img', {name: 'checkStrokedLarge icon'});
+        const largeToken = screen.getByRole('img', {name: 'checkmark'});
         expect(largeToken).toBeInTheDocument();
-        expect(largeToken).toHaveClass('mod-32');
+        expect(largeToken).toHaveAttribute('height', '32');
         expect(largeToken).toHaveClass('mod-success');
+        expect(largeToken).toHaveClass('filled');
     });
 
-    it('renders the warningStrokedSmall icon if the specified size and type are Small and Warning', () => {
+    it('renders the warning icon if the specified size and type are Small and Warning', () => {
         render(<InfoToken type={InfoTokenType.Warning} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Small} />);
 
-        const smallToken = screen.getByRole('img', {name: 'warningStrokedSmall icon'});
+        const smallToken = screen.getByRole('img', {name: 'warning'});
         expect(smallToken).toBeInTheDocument();
-        expect(smallToken).toHaveClass('mod-16');
+        expect(smallToken).toHaveAttribute('height', '16');
         expect(smallToken).toHaveClass('mod-warning');
+        expect(smallToken).toHaveClass('stroked');
     });
 
-    it('renders the warningStrokedMedium icon if the specified size and type are Medium and Warning', () => {
-        render(<InfoToken type={InfoTokenType.Warning} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Medium} />);
+    it('renders the warning icon if the specified size and type are Medium and Warning', () => {
+        render(<InfoToken type={InfoTokenType.Warning} mode={InfoTokenMode.Filled} size={InfoTokenSize.Medium} />);
 
-        const mediumToken = screen.getByRole('img', {name: 'warningStrokedMedium icon'});
+        const mediumToken = screen.getByRole('img', {name: 'warning'});
         expect(mediumToken).toBeInTheDocument();
-        expect(mediumToken).toHaveClass('mod-24');
+        expect(mediumToken).toHaveAttribute('height', '24');
         expect(mediumToken).toHaveClass('mod-warning');
+        expect(mediumToken).toHaveClass('filled');
     });
 
-    it('renders the warningStrokedLarge icon if the specified size and type are Large and Warning', () => {
+    it('renders the warning icon if the specified size and type are Large and Warning', () => {
         render(<InfoToken type={InfoTokenType.Warning} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Large} />);
 
-        const largeToken = screen.getByRole('img', {name: 'warningStrokedLarge icon'});
+        const largeToken = screen.getByRole('img', {name: 'warning'});
         expect(largeToken).toBeInTheDocument();
-        expect(largeToken).toHaveClass('mod-32');
+        expect(largeToken).toHaveAttribute('height', '32');
         expect(largeToken).toHaveClass('mod-warning');
+        expect(largeToken).toHaveClass('stroked');
     });
 
-    it('renders the criticalStrokedSmall icon if the specified size and type are Small and Critical', () => {
-        render(<InfoToken type={InfoTokenType.Critical} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Small} />);
+    it('renders the critical icon if the specified size and type are Small and Critical', () => {
+        render(<InfoToken type={InfoTokenType.Critical} mode={InfoTokenMode.Filled} size={InfoTokenSize.Small} />);
 
-        const smallToken = screen.getByRole('img', {name: 'criticalStrokedSmall icon'});
+        const smallToken = screen.getByRole('img', {name: 'critical'});
         expect(smallToken).toBeInTheDocument();
-        expect(smallToken).toHaveClass('mod-16');
+        expect(smallToken).toHaveAttribute('height', '16');
         expect(smallToken).toHaveClass('mod-error');
+        expect(smallToken).toHaveClass('filled');
     });
 
-    it('renders the criticalStrokedMedium icon if the specified size and type are Medium and Critical', () => {
+    it('renders the critical icon if the specified size and type are Medium and Critical', () => {
         render(<InfoToken type={InfoTokenType.Critical} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Medium} />);
 
-        const mediumToken = screen.getByRole('img', {name: 'criticalStrokedMedium icon'});
+        const mediumToken = screen.getByRole('img', {name: 'critical'});
         expect(mediumToken).toBeInTheDocument();
-        expect(mediumToken).toHaveClass('mod-24');
+        expect(mediumToken).toHaveAttribute('height', '24');
         expect(mediumToken).toHaveClass('mod-error');
+        expect(mediumToken).toHaveClass('stroked');
     });
 
-    it('renders the criticalStrokedLarge icon if the specified size and type are Large and Critical', () => {
-        render(<InfoToken type={InfoTokenType.Critical} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Large} />);
+    it('renders the critical icon if the specified size and type are Large and Critical', () => {
+        render(<InfoToken type={InfoTokenType.Critical} mode={InfoTokenMode.Filled} size={InfoTokenSize.Large} />);
 
-        const largeToken = screen.getByRole('img', {name: 'criticalStrokedLarge icon'});
+        const largeToken = screen.getByRole('img', {name: 'critical'});
         expect(largeToken).toBeInTheDocument();
-        expect(largeToken).toHaveClass('mod-32');
+        expect(largeToken).toHaveAttribute('height', '32');
         expect(largeToken).toHaveClass('mod-error');
+        expect(largeToken).toHaveClass('filled');
     });
 
-    it('renders the ideaStrokedSmall icon if the specified size and type are Small and Tip', () => {
+    it('renders the tip icon if the specified size and type are Small and Tip', () => {
         render(<InfoToken type={InfoTokenType.Tip} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Small} />);
 
-        const smallToken = screen.getByRole('img', {name: 'ideaStrokedSmall icon'});
+        const smallToken = screen.getByRole('img', {name: 'tip'});
         expect(smallToken).toBeInTheDocument();
-        expect(smallToken).toHaveClass('mod-16');
+        expect(smallToken).toHaveAttribute('height', '16');
         expect(smallToken).toHaveClass('mod-success');
+        expect(smallToken).toHaveClass('stroked');
     });
 
-    it('renders the ideaStrokedMedium icon if the specified size and type are Medium and Tip', () => {
-        render(<InfoToken type={InfoTokenType.Tip} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Medium} />);
+    it('renders the tip icon if the specified size and type are Medium and Tip', () => {
+        render(<InfoToken type={InfoTokenType.Tip} mode={InfoTokenMode.Filled} size={InfoTokenSize.Medium} />);
 
-        const mediumToken = screen.getByRole('img', {name: 'ideaStrokedMedium icon'});
+        const mediumToken = screen.getByRole('img', {name: 'tip'});
         expect(mediumToken).toBeInTheDocument();
-        expect(mediumToken).toHaveClass('mod-24');
+        expect(mediumToken).toHaveAttribute('height', '24');
         expect(mediumToken).toHaveClass('mod-success');
+        expect(mediumToken).toHaveClass('filled');
     });
 
-    it('renders the ideaStrokedLarge icon if the specified size and type are Large and Tip', () => {
+    it('renders the tip icon if the specified size and type are Large and Tip', () => {
         render(<InfoToken type={InfoTokenType.Tip} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Large} />);
 
-        const largeToken = screen.getByRole('img', {name: 'ideaStrokedLarge icon'});
+        const largeToken = screen.getByRole('img', {name: 'tip'});
         expect(largeToken).toBeInTheDocument();
-        expect(largeToken).toHaveClass('mod-32');
+        expect(largeToken).toHaveAttribute('height', '32');
         expect(largeToken).toHaveClass('mod-success');
+        expect(largeToken).toHaveClass('stroked');
     });
 
-    it('renders the questionStrokedSmall icon if the specified size and type are Small and Question', () => {
-        render(<InfoToken type={InfoTokenType.Question} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Small} />);
+    it('renders the question icon if the specified size and type are Small and Question', () => {
+        render(<InfoToken type={InfoTokenType.Question} mode={InfoTokenMode.Filled} size={InfoTokenSize.Small} />);
 
-        const smallToken = screen.getByRole('img', {name: 'questionStrokedSmall icon'});
+        const smallToken = screen.getByRole('img', {name: 'question'});
         expect(smallToken).toBeInTheDocument();
-        expect(smallToken).toHaveClass('mod-16');
+        expect(smallToken).toHaveAttribute('height', '16');
         expect(smallToken).toHaveClass('mod-info');
+        expect(smallToken).toHaveClass('filled');
     });
 
-    it('renders the questionStrokedMedium icon if the specified size and type are Medium and Question', () => {
+    it('renders the question icon if the specified size and type are Medium and Question', () => {
         render(<InfoToken type={InfoTokenType.Question} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Medium} />);
 
-        const mediumToken = screen.getByRole('img', {name: 'questionStrokedMedium icon'});
+        const mediumToken = screen.getByRole('img', {name: 'question'});
         expect(mediumToken).toBeInTheDocument();
-        expect(mediumToken).toHaveClass('mod-24');
+        expect(mediumToken).toHaveAttribute('height', '24');
         expect(mediumToken).toHaveClass('mod-info');
+        expect(mediumToken).toHaveClass('stroked');
     });
 
-    it('renders the questionStrokedLarge icon if the specified size and type are Large and Question', () => {
-        render(<InfoToken type={InfoTokenType.Question} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Large} />);
+    it('renders the question icon if the specified size and type are Large and Question', () => {
+        render(<InfoToken type={InfoTokenType.Question} mode={InfoTokenMode.Filled} size={InfoTokenSize.Large} />);
 
-        const largeToken = screen.getByRole('img', {name: 'questionStrokedLarge icon'});
+        const largeToken = screen.getByRole('img', {name: 'question'});
         expect(largeToken).toBeInTheDocument();
-        expect(largeToken).toHaveClass('mod-32');
+        expect(largeToken).toHaveAttribute('height', '32');
         expect(largeToken).toHaveClass('mod-info');
-    });
-
-    it('renders with a "filled" class is mode is "Filled"', () => {
-        const {container} = render(
-            <InfoToken type={InfoTokenType.Information} mode={InfoTokenMode.Filled} size={InfoTokenSize.Large} />
-        );
-
-        expect(container.querySelector('.filled')).toBeInTheDocument();
-    });
-
-    it('does not render with a "filled" class is mode is "Stroked"', () => {
-        const {container} = render(
-            <InfoToken type={InfoTokenType.Information} mode={InfoTokenMode.Stroked} size={InfoTokenSize.Large} />
-        );
-
-        expect(container.querySelector('.filled')).not.toBeInTheDocument();
+        expect(largeToken).toHaveClass('filled');
     });
 });

--- a/packages/react/src/components/textInput/tests/TextInput.spec.tsx
+++ b/packages/react/src/components/textInput/tests/TextInput.spec.tsx
@@ -61,7 +61,7 @@ describe('TextInput', () => {
             </FormProvider>
         );
 
-        const icon = screen.getByRole('img', {name: /questionstrokedmedium icon/i});
+        const icon = screen.getByRole('img', {name: /question/i});
         userEvent.hover(icon);
 
         expect(await screen.findByText('🍌')).toBeInTheDocument();
@@ -99,25 +99,25 @@ describe('TextInput', () => {
 
         expect(textinput).toBeValid();
         expect(screen.queryByText('valid!')).not.toBeInTheDocument();
-        expect(screen.queryByRole('img', {name: 'checkStrokedSmall icon'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: 'checkmark'})).not.toBeInTheDocument();
 
         fireEvent.blur(textinput);
 
         expect(screen.getByText('valid!')).toBeInTheDocument();
-        expect(screen.getByRole('img', {name: 'checkStrokedSmall icon'})).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'checkmark'})).toBeInTheDocument();
 
         userEvent.clear(textinput);
 
         expect(textinput).toBeInvalid();
         expect(screen.queryByText('valid!')).not.toBeInTheDocument();
-        expect(screen.queryByRole('img', {name: 'checkStrokedSmall icon'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: 'checkmark'})).not.toBeInTheDocument();
 
         userEvent.type(textinput, '⚠️');
         expect(textinput).toBeValid();
         fireEvent.blur(textinput);
 
         expect(screen.getByText('warning!')).toBeInTheDocument();
-        expect(screen.getByRole('img', {name: 'warningStrokedSmall icon'})).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'warning'})).toBeInTheDocument();
 
         userEvent.clear(textinput);
         expect(textinput).toBeInvalid();
@@ -126,7 +126,7 @@ describe('TextInput', () => {
         fireEvent.blur(textinput);
 
         expect(screen.getByText('invalid!')).toBeInTheDocument();
-        expect(screen.getByRole('img', {name: 'criticalStrokedSmall icon'})).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'critical'})).toBeInTheDocument();
     });
 
     it('validates the input on mount when showValidationOnMount prop is true', () => {
@@ -140,7 +140,7 @@ describe('TextInput', () => {
 
         expect(screen.getByRole('textbox', {name: '💬'})).toBeInvalid();
         expect(screen.getByText('invalid!')).toBeInTheDocument();
-        expect(screen.getByRole('img', {name: 'criticalStrokedSmall icon'})).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'critical'})).toBeInTheDocument();
     });
 
     it('validates the input on change when showValidationOnChange prop is true', () => {
@@ -156,19 +156,19 @@ describe('TextInput', () => {
         const textinput = screen.getByRole('textbox', {name: '💬'});
 
         expect(screen.queryByText('invalid!')).not.toBeInTheDocument();
-        expect(screen.queryByRole('img', {name: 'criticalStrokedSmall icon'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: 'critical'})).not.toBeInTheDocument();
 
         userEvent.type(textinput, '✅');
 
         expect(textinput).toBeValid();
         expect(screen.getByText('valid!')).toBeInTheDocument();
-        expect(screen.getByRole('img', {name: 'checkStrokedSmall icon'})).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'checkmark'})).toBeInTheDocument();
 
         userEvent.clear(textinput);
 
         expect(textinput).toBeInvalid();
         expect(screen.getByText('invalid!')).toBeInTheDocument();
-        expect(screen.getByRole('img', {name: 'criticalStrokedSmall icon'})).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'critical'})).toBeInTheDocument();
     });
 
     it('is independant from the other inputs in the same provider', () => {

--- a/packages/react/src/components/toast/Toast.tsx
+++ b/packages/react/src/components/toast/Toast.tsx
@@ -171,7 +171,7 @@ export const Toast: React.FC<IToastProps> = ({
                 downloadToast
             ) : (
                 <>
-                    {infoToken}
+                    <span className="info-token-container">{infoToken}</span>
                     <div className="toast-content-container">
                         {title && <div className="toast-title">{title}</div>}
                         {toastContent}

--- a/packages/react/src/components/toast/tests/Toast.spec.tsx
+++ b/packages/react/src/components/toast/tests/Toast.spec.tsx
@@ -320,14 +320,11 @@ describe('Toasts', () => {
 
             expect(toastComponent.find('.search-bar-spinner').length).toBe(1);
         });
-        it('should render the by default infoToken Svg', () => {
+
+        it('should render the success infoToken by default', () => {
             render(<Toast title="admin-ui" />);
 
-            expect(
-                screen.getByRole('img', {
-                    name: /checkstrokedlarge icon/i,
-                })
-            ).toBeInTheDocument();
+            expect(screen.getByRole('img', {name: /checkmark/i})).toBeInTheDocument();
         });
     });
 });

--- a/packages/style/scss/components/info-token.scss
+++ b/packages/style/scss/components/info-token.scss
@@ -1,25 +1,33 @@
 .info-token {
-    display: inline-block;
-
-    &.mod-16 {
-        height: 16px;
+    &.mod-info {
+        color: var(--info-60);
     }
 
-    &.mod-24 {
-        height: 24px;
+    &.mod-success {
+        color: var(--success-60);
     }
 
-    &.mod-32 {
-        height: 32px;
+    &.mod-warning {
+        color: var(--warning-70);
+    }
+
+    &.mod-error {
+        color: var(--critical-70);
     }
 
     &.filled {
-        .icon {
-            fill: var(--fill);
-            --stroke: var(--white);
-
-            &.mod-warning {
-                --stroke: var(--black);
+        &,
+        [fill] {
+            fill: currentColor;
+        }
+        &,
+        [stroke] {
+            stroke: var(--white);
+        }
+        &.mod-warning {
+            stroke: var(--black);
+            [stroke] {
+                stroke: var(--black);
             }
         }
     }

--- a/packages/style/scss/components/toast.scss
+++ b/packages/style/scss/components/toast.scss
@@ -116,7 +116,7 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         min-height: 55px;
     }
 
-    .info-token {
+    .info-token-container {
         position: static;
         padding: $toast-info-token-padding;
     }


### PR DESCRIPTION
### Proposed Changes

Switch out the Svg component for plasma-react-icons in the InfoToken component

Before
![image](https://user-images.githubusercontent.com/35579930/157540712-7ffe0fe2-b96b-4d1f-afb8-694499ba83f2.png)

After
![image](https://user-images.githubusercontent.com/35579930/157540735-8f075eee-eb56-4007-a883-588dbf46a469.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
