### PR TITLE
fix(chart): dropPod throws an error when there is no ref

### DIFF
--- a/packages/react/src/components/chart/ChartTooltip.tsx
+++ b/packages/react/src/components/chart/ChartTooltip.tsx
@@ -11,6 +11,7 @@ export interface ChartTooltipProps {
 }
 
 export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({sort = false}) => {
+    const ref = React.useRef<HTMLElement>(null);
     const {series, xScale, yScale, xDomain, yDomain, width, height} = React.useContext(XYChartContext);
     const [position, setPosition] = React.useState({
         x: 0,
@@ -59,6 +60,7 @@ export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({sort =
         <g className="chart-tooltip-zones">
             {!!position.position && (
                 <rect
+                    ref={ref as any}
                     className="chart-tooltip-line"
                     width={2}
                     x={xScale(position.pointX) - 1}
@@ -69,6 +71,7 @@ export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({sort =
             )}
             <circle cx={position.x} cy={position.y} r="1" fill="transparent" />
             <DropPod
+                ref={ref}
                 isOpen={!!position.position}
                 positions={[position.position, DropPodPosition.left, DropPodPosition.right]}
                 renderDrop={(style: React.CSSProperties, dropPosition: IDropUIPosition): React.ReactNode => (


### PR DESCRIPTION
### Proposed Changes

The DropPod uses the ref to detect where the tooltip should be positioned. This PR fixes the error it threw since it could not detect the position of the element

To test the fix, open the demo, go in the Chart component and hover data in the 2nd chart. You should see the tooltip

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
