### PR TITLE
feat(react-icons): add accessible role to all icons

### DIFF
--- a/packages/react-icons/bin/index.js
+++ b/packages/react-icons/bin/index.js
@@ -39,6 +39,8 @@ const convertVariant = async (file) => {
                 template,
                 expandProps: false,
                 svgProps: {
+                    'aria-label': iconName,
+                    role: 'img',
                     height: '{height || width || "1em"}',
                     width: '{width || height || "1em"}',
                 },


### PR DESCRIPTION
### Proposed Changes

Add the necessary ARIA attributes to all plasma-react-icons to be able to `getByRole('img', {name: 'zombie'})` in unit tests.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
