### PR TITLE
MultiValuesInput fixes

### DIFF
--- a/packages/react/src/components/input/Input.tsx
+++ b/packages/react/src/components/input/Input.tsx
@@ -35,6 +35,7 @@ export interface IInputAdditionalOwnProps {
     minimum?: number /* @deprecated use min instead */;
     maximum?: number /* @deprecated use max instead */;
     onBlur?: (value: string) => void;
+    onChangeHandler?: React.ChangeEventHandler<HTMLInputElement>;
     defaultValue?: string;
     isReadOnly?: boolean;
 }
@@ -166,13 +167,14 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
         }
     }
 
-    private handleChange() {
+    private handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
         if (this.props.onChange) {
             const validOnChange =
                 this.props.validateOnChange && this.props.validate && this.props.validate(this.getInnerValue());
             this.props.onChange(this.getInnerValue(), validOnChange);
         }
-    }
+        this.props.onChangeHandler?.(e);
+    };
 
     private handleClick(e: React.MouseEvent<HTMLElement>) {
         if (this.props.onClick) {
@@ -227,7 +229,7 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
                 defaultValue={!isUndefined(this.props.value) ? this.props.value : this.props.defaultValue}
                 ref={(innerInput: HTMLInputElement) => (this.innerInput = innerInput)}
                 onBlur={() => this.handleBlur()}
-                onChange={() => this.handleChange()}
+                onChange={this.handleChange}
                 onKeyUp={(event: React.KeyboardEvent<HTMLInputElement>) => this.handleKeyUp(event)}
                 min={this.props.minimum}
                 max={this.props.maximum}

--- a/packages/react/src/components/input/Input.tsx
+++ b/packages/react/src/components/input/Input.tsx
@@ -98,6 +98,9 @@ export interface IInputComponentState {
     valid: boolean;
 }
 
+/**
+ * @deprecated Use TextInput instead
+ */
 export class Input extends React.Component<IInputProps, IInputComponentState> {
     private innerInput: HTMLInputElement;
 
@@ -268,4 +271,7 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: IInputProps): IInputD
     },
 });
 
+/**
+ * @deprecated use TextInput instead
+ */
 export const InputConnected = connect(mapStateToProps, mapDispatchToProps, ReduxUtils.mergeProps)(Input);

--- a/packages/react/src/components/multiValueInputs/MultiValuesInput.tsx
+++ b/packages/react/src/components/multiValueInputs/MultiValuesInput.tsx
@@ -76,10 +76,9 @@ export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = 
                         id={cData.id}
                         defaultValue={cData.props}
                         {...inputProps}
-                        onKeyUp={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                            inputProps?.onKeyUp?.(e);
-                            const value = e.currentTarget.value;
-                            if (value !== '' && cData.isLast) {
+                        onKeyUp={inputProps?.onKeyUp}
+                        onChangeHandler={(e: React.ChangeEvent<HTMLInputElement>) => {
+                            if (e.currentTarget.value !== '' && cData.isLast) {
                                 parentProps.addNewBox();
                             }
                         }}

--- a/packages/react/src/components/multilineBox/MultilineBoxSelector.ts
+++ b/packages/react/src/components/multilineBox/MultilineBoxSelector.ts
@@ -3,10 +3,11 @@ import {PlasmaState} from '../../PlasmaState';
 import {IStringListState} from '../../reusableState/customList/StringListReducers';
 
 const initialMultiBoxIDs: IStringListState = {id: undefined, list: []};
-const getMultiBoxIDs = (state: Partial<PlasmaState>, props: {id: string}): IStringListState =>
-    (state && state.multilineIds && state.multilineIds[props.id]) || initialMultiBoxIDs;
 
-const multiBoxIDsCombiner = (multiBoxState: IStringListState): string[] => (multiBoxState && multiBoxState.list) || [];
+const getMultiBoxIDs = (state: Partial<PlasmaState>, {id}: {id: string}): IStringListState =>
+    state?.multilineIds?.[id] ?? initialMultiBoxIDs;
+
+const multiBoxIDsCombiner = (multiBoxState: IStringListState): string[] => multiBoxState?.list ?? [];
 
 const getMultiBoxIDsList: (state: Partial<PlasmaState>, props: {id: string}) => string[] = createSelector(
     getMultiBoxIDs,

--- a/packages/react/src/components/multilineBox/hoc/MultilineBoxWithRemoveButton.tsx
+++ b/packages/react/src/components/multilineBox/hoc/MultilineBoxWithRemoveButton.tsx
@@ -63,25 +63,23 @@ export const multilineBoxWithRemoveButton = (
             props: Partial<IButtonProps> = {},
             index: number
         ) {
+            const isLastMeaningfulEntry = data.length <= 1;
+            const isDisabled = this.props.disabled || isLastMeaningfulEntry || data[index].isLast;
             return (
                 <Button
-                    classes={[
-                        classNames(defaultMultilineBoxRemoveButtonClasses, {
-                            'cursor-pointer': !data[index]?.isLast,
-                        }),
-                    ]}
+                    classes={[classNames(defaultMultilineBoxRemoveButtonClasses)]}
                     style={{
-                        visibility: data.length > 1 ? 'visible' : 'hidden',
+                        visibility: isDisabled ? 'hidden' : 'visible',
                     }}
-                    onClick={() => !this.props.disabled && this.props.removeBox(data[index].id)}
-                    enabled={!this.props.disabled}
+                    onClick={() => this.props.removeBox(data[index].id)}
+                    enabled={!isDisabled}
                     {...props}
                 >
                     <Svg
                         svgName={svg.remove.name}
                         className="icon mod-18"
                         style={{
-                            visibility: data.length > 1 ? 'visible' : 'hidden',
+                            visibility: isDisabled ? 'hidden' : 'visible',
                         }}
                     />
                 </Button>

--- a/packages/react/src/components/multilineBox/tests/MultilineBoxWithRemoveButton.spec.tsx
+++ b/packages/react/src/components/multilineBox/tests/MultilineBoxWithRemoveButton.spec.tsx
@@ -195,10 +195,10 @@ describe('Multiline box with remove button', () => {
                                 {name: 'potatas', displayName: 'cromonasse'},
                                 {name: 'help', displayName: 'me'},
                             ]}
-                            renderBody={(data: IMultilineSingleBoxProps[]) => data.map((test) => <div>{'mommy'}</div>)}
+                            renderBody={(data: IMultilineSingleBoxProps[]) => data.map((test) => <div>mommy</div>)}
                         />
                     );
-                    expect(screen.getAllByRole('button', {name: /remove icon/i}).length).toBe(4);
+                    expect(screen.getAllByRole('button', {name: /remove icon/i}).length).toBe(3);
                 });
 
                 it('should not render a remove button if one element is returned from the renderBody prop', () => {


### PR DESCRIPTION
### Proposed Changes

The `MultiValuesInput` had the following problems that needed to be fixed:
- Pressing `Enter` in any of the input lines would remove that line even if it had no remove button displayed.
- The last entry, which is usually an empty new line useful to add a new row could be deleted by clicking on the remove button.
- Copy pasting a value using only the mouse (right click > paste) would not trigger a new line, only the keyboard could.

All of those are fixed by this PR + the `Input` and `InputConnected` are marked as deprecated.

### Potential Breaking Changes

None
