### PR TITLE
feat: writing down section names by hand each time is problematic

### DIFF
--- a/packages/website/src/building-blocs/PageHeader.tsx
+++ b/packages/website/src/building-blocs/PageHeader.tsx
@@ -7,7 +7,7 @@ export interface PageHeaderProps {
     title: string;
     thumbnail?: TileProps['thumbnail'];
     description?: React.ReactNode;
-    section: string;
+    section: 'Foundations' | 'Layout' | 'Form' | 'Navigation' | 'Feedback' | 'Advanced';
     /**
      * Path to the component's source file from /packages/react/src/components
      *


### PR DESCRIPTION
### Proposed Changes

Force choices for section name in the pageLayout 

Before, mistakes were made

![image](https://user-images.githubusercontent.com/63734941/158395609-75eb458b-7c0d-405a-a8c9-5c192ce34f23.png)


Now mistakes are not possible :zap: 

![image](https://user-images.githubusercontent.com/63734941/158395760-a76fad6b-b610-49c7-a8c5-891eea98da1a.png)

### Potential Breaking Changes

should be none xD

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
