### PR TITLE
feat(website): display jsdocs params in props table

### DIFF
--- a/packages/website/src/building-blocs/PropsDoc.tsx
+++ b/packages/website/src/building-blocs/PropsDoc.tsx
@@ -12,6 +12,7 @@ interface PropInfo {
     optional: boolean;
     defaultValue: string | null;
     deprecation: string | null;
+    params: Array<{parameterName: string; text: string}>;
 }
 
 export const PropsDoc: React.FunctionComponent<{componentName: string}> = ({componentName}) => {
@@ -64,6 +65,14 @@ const props: React.ComponentProps<typeof ${componentName}> = {`;
                         deprecation = ts.displayPartsToString(deprecatedTag?.text) || '';
                     }
 
+                    const params: Array<{parameterName: string; text: string}> = jsDocTags
+                        .filter((tag) => tag.name === 'param')
+                        .map((param) => ({
+                            parameterName: param.text.find((jsDocComment) => jsDocComment.kind === 'parameterName')
+                                .text,
+                            text: param.text.find((jsDocComment) => jsDocComment.kind === 'text').text,
+                        }));
+
                     accumulator.push({
                         name: entry.name,
                         description: ts.displayPartsToString(symbol.getDocumentationComment(checker)),
@@ -71,6 +80,7 @@ const props: React.ComponentProps<typeof ${componentName}> = {`;
                         optional: entry.kindModifiers.includes('optional'),
                         defaultValue,
                         deprecation,
+                        params,
                     });
                 }
             });
@@ -101,7 +111,7 @@ const props: React.ComponentProps<typeof ${componentName}> = {`;
                 <tbody>
                     {propsList
                         .sort(requiredFirst)
-                        .map(({name, type, description, optional, deprecation, defaultValue}) => (
+                        .map(({name, type, description, optional, deprecation, defaultValue, params}) => (
                             <tr key={name}>
                                 <td>
                                     <span className="code">{name}</span>
@@ -114,9 +124,20 @@ const props: React.ComponentProps<typeof ${componentName}> = {`;
                                     <span className="code">{type}</span>
                                 </td>
                                 <td>{defaultValue}</td>
-                                <td>
+                                <td className="py1">
                                     {deprecation !== null && <div>{deprecation}</div>}
                                     <div>{description}</div>
+                                    {params && (
+                                        <ul className="mt1">
+                                            {params.map(({parameterName, text}) => (
+                                                <li key={parameterName}>
+                                                    <span className="code">{parameterName}</span>
+                                                    <span className="mx1">&ndash;</span>
+                                                    {text}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    )}
                                 </td>
                             </tr>
                         ))}


### PR DESCRIPTION
### Proposed Changes

The props table will now display jsdocs comments about parameters of a function

![image](https://user-images.githubusercontent.com/35579930/158450599-6c7a8367-b485-41ca-bb14-15727720b799.png)
![image](https://user-images.githubusercontent.com/35579930/158450582-a87259dd-72a0-4447-9f91-2af5b205ff6c.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
