### PR TITLE
feat(website): allow import of examples from files

### DIFF
--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -20,6 +20,10 @@ module.exports = withPlugins([withTM, withImages], {
                 poll: 10000,
             };
         }
+        config.module.rules.push({
+            test: /\.example.tsx$/,
+            loader: 'raw-loader',
+        });
         return config;
     },
 });

--- a/packages/website/src/building-blocs/Sandbox.tsx
+++ b/packages/website/src/building-blocs/Sandbox.tsx
@@ -75,6 +75,7 @@ export const Sandbox: React.FunctionComponent<{children: string; id: string; tit
                     .replace(/var .+ = __importStar\(require(.+)\);/g, '') // remove the import statements
                     .replace(/_plasmaReact/g, 'PlasmaReact') // use plasma-react from the window Plasma object
                     .replace(/_reactRedux/g, 'ReactRedux') // use react-redux from the window ReactRedux object
+                    .replace(/_redux/g, 'Redux') // use redux from the window Redux object
                     .replace(/\(.+, _moment\)\.default/g, 'moment') // replace the moment object
                     .replace(/_moment.default/g, 'moment') // replace the moment() function
                     .replace(/_loremIpsum/g, 'LoremIpsum') +

--- a/packages/website/src/building-blocs/useTypescriptServer.ts
+++ b/packages/website/src/building-blocs/useTypescriptServer.ts
@@ -6,7 +6,7 @@ import {loader} from '@monaco-editor/react';
 
 export const compilerOptions: ts.CompilerOptions = {
     jsx: ts.JsxEmit.React,
-    lib: ['es2015', 'dom'],
+    lib: ['es2017', 'dom'],
     module: ts.ModuleKind.CommonJS,
     target: ts.ScriptTarget.ES5,
     skipLibCheck: true,

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -18,6 +18,7 @@ import type {AppProps} from 'next/app';
 import Head from 'next/head';
 import Link from 'next/link';
 import * as React from 'react';
+import * as Redux from 'redux';
 import * as ReactDOM from 'react-dom';
 import * as ReactRedux from 'react-redux';
 import * as LoremIpsum from 'lorem-ipsum';
@@ -59,6 +60,7 @@ const MyApp = ({Component, pageProps}: AppProps) => {
         (window as any).PlasmaReactIcons = PlasmaReactIcons;
         (window as any).moment = moment;
         (window as any).LoremIpsum = LoremIpsum;
+        (window as any).Redux = Redux;
 
         if (window.location.host === 'vapor.coveo.com') {
             window.location.href = window.location.href.replace('vapor.coveo.com', 'plasma.coveo.com');

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -9,7 +9,8 @@
         "tsBuildInfoFile": "./built/.tsbuildinfo",
         "paths": {
             "@coveord/plasma-react/dist/*": ["../react/dist/*"],
-            "@styles/*": ["./src/styles/*"]
+            "@styles/*": ["./src/styles/*"],
+            "@examples/*": ["./src/examples/*"]
         },
         "lib": ["ES2020", "dom"],
         "typeRoots": ["./types", "./node_modules/@types"],

--- a/packages/website/types/custom/index.d.ts
+++ b/packages/website/types/custom/index.d.ts
@@ -10,3 +10,8 @@ declare module '*.md' {
     const content: string;
     export default content;
 }
+
+declare module '*.example.tsx' {
+    const content: string;
+    export default content;
+}


### PR DESCRIPTION
### Proposed Changes

Allow us to import the examples from another file instead of inlining them.

It comes with a lot of good stuff: automatic imports, syntax validation, code formating, ... 

#### Usage:

Add a `.example.tsx` file in the `src/examples/some-folder` folder and add an import like this in your page

`import code from '@examples/some-folder/myExample.example.tsx';` (note the `.example.tsx` extension)

`code` will be a string

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
