### PR TITLE
fix(button): fix icon alignment in button with href

### DIFF
--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -57,7 +57,7 @@ export class Button extends React.Component<IButtonProps & React.ButtonHTMLAttri
             });
 
             buttonElement = (
-                <a className={`${this.className} btn-container`} {...buttonAttrs}>
+                <a className={`${this.className}`} {...buttonAttrs}>
                     {this.props.name}
                     {this.props.children}
                 </a>

--- a/packages/react/src/components/button/tests/Button.spec.tsx
+++ b/packages/react/src/components/button/tests/Button.spec.tsx
@@ -116,14 +116,6 @@ describe('Button', () => {
                 expect(buttonComponent.find('a').prop('href')).toEqual(link);
             });
 
-            it('should have the class btn-container', () => {
-                showButton({
-                    link,
-                });
-
-                expect(buttonComponent.find('.btn-container').length).toBe(1);
-            });
-
             it('should add the rel default value', () => {
                 showButton({
                     link,

--- a/packages/react/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react/src/components/editor/tests/CodeEditor.spec.tsx
@@ -102,7 +102,7 @@ describe('CodeEditor', () => {
             userEvent.type(screen.getByRole('textbox'), 'new value');
             screen.getByRole('textbox').blur();
 
-            await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(2), {timeout: 2000});
+            await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(2));
         });
 
         it('removes the code editor from the store on unmount if mounted with an id', () => {

--- a/packages/website/src/pages/form/Button.tsx
+++ b/packages/website/src/pages/form/Button.tsx
@@ -62,7 +62,7 @@ export const ButtonExamples: React.FunctionComponent = () => (
             small: {code: small, title: 'Secondary, Small size'},
             disabled: {code: disabled, title: 'Disabled'},
             prepend: {code: prepend, title: 'Prepended icon'},
-            iconAndLink: {code: iconAndLink, title: 'Icon only with an hyperlkink'},
+            iconAndLink: {code: iconAndLink, title: 'Icon only with an hyperlink'},
         }}
         componentSourcePath="/button/Button.tsx"
     />

--- a/packages/website/src/pages/form/Button.tsx
+++ b/packages/website/src/pages/form/Button.tsx
@@ -22,6 +22,14 @@ const small = `
     export default () => <Button small>Hello World!</Button>;
 `;
 
+const iconAndLink = `
+    import * as React from "react";
+    import {Button} from "@coveord/plasma-react";
+    import {ZombieSize24Px} from '@coveord/plasma-react-icons';
+
+    export default () => <Button link="https://www.coveo.com"><ZombieSize24Px height={24} aria-label="zombie" /></Button>;
+`;
+
 const disabled = `
     import * as React from "react";
     import {Button} from "@coveord/plasma-react";
@@ -54,6 +62,7 @@ export const ButtonExamples: React.FunctionComponent = () => (
             small: {code: small, title: 'Secondary, Small size'},
             disabled: {code: disabled, title: 'Disabled'},
             prepend: {code: prepend, title: 'Prepended icon'},
+            iconAndLink: {code: iconAndLink, title: 'Icon only with an hyperlkink'},
         }}
         componentSourcePath="/button/Button.tsx"
     />


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-587

The buttons with an hyperlink + an icon had this weird padding on top cause by the `btn-container` class. I just removed it and added an new example to keep track on the style :+1: 

Before:

![image](https://user-images.githubusercontent.com/63734941/160152376-8c54799f-0c58-4850-b671-d32cdc435275.png)

After: 
![image](https://user-images.githubusercontent.com/63734941/160152467-9ad52f1e-93d3-411d-85cd-17ba085bb137.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
