### PR TITLE
fix(modal): title is now a reactNode

### DIFF
--- a/packages/react/src/components/modal/ModalHeader.tsx
+++ b/packages/react/src/components/modal/ModalHeader.tsx
@@ -15,7 +15,7 @@ export interface IModalHeaderOwnProps {
     /**
      * Title of the modal
      */
-    title: string;
+    title: React.ReactNode;
     /**
      * Additionnal CSS class for the header
      */


### PR DESCRIPTION
### Proposed Changes

The title of the modal was a string but it should be a reactNode

### Potential Breaking Changes

I don't think so? :thinking:  I mean, it was breaking when it was a string so now it's not broken? :woman_shrugging: :laughing: 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
