### PR TITLE
fix(plasma-react): better management of isDirty in TextInput

### DIFF
--- a/packages/react/jest/entry.tsx
+++ b/packages/react/jest/entry.tsx
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import 'chosen-js';
 
 import {cleanup, setup} from '@test-utils';
 import * as Enzyme from 'enzyme';

--- a/packages/react/jest/utils.tsx
+++ b/packages/react/jest/utils.tsx
@@ -10,8 +10,6 @@ import {PlasmaReducers} from '../src/PlasmaReducers';
 import {PlasmaState} from '../src/PlasmaState';
 import {IDispatch} from '../src/utils/ReduxUtils';
 
-import 'chosen-js';
-
 const TEST_CONTAINER_ID = 'app';
 const MODAL_ROOT_ID = 'modals';
 const DROP_ROOT_ID = 'dropdowns';

--- a/packages/react/src/components/textInput/TextInput.tsx
+++ b/packages/react/src/components/textInput/TextInput.tsx
@@ -46,10 +46,14 @@ interface TextInputProps {
      * Whether the validation result should be visible when the input looses the focus (recommended)
      */
     showValidationOnBlur?: boolean;
+    /**
+     * The initial value
+     */
+    defaultValue?: string;
 }
 
 export const TextInput: React.FunctionComponent<
-    TextInputProps & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'>
+    TextInputProps & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'defaultValue'>
 > = ({
     id: propsId,
     label,
@@ -67,7 +71,7 @@ export const TextInput: React.FunctionComponent<
     ...inputProps
 }) => {
     const id = React.useMemo(() => propsId || uniqueId(), [propsId]);
-    const {state, dispatch} = useTextInput(id);
+    const {state, dispatch} = useTextInput(id, defaultValue);
     const inputElement = React.useRef<HTMLInputElement>();
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -105,7 +109,7 @@ export const TextInput: React.FunctionComponent<
                 throw new Error(`Unknown input validation status: ${status}.`);
         }
 
-        if (state.value === defaultValue) {
+        if (state.value === (defaultValue ?? '')) {
             dispatch({type: 'set-pristine'});
         } else {
             dispatch({type: 'set-dirty'});

--- a/packages/react/src/components/textInput/tests/TextInput.spec.tsx
+++ b/packages/react/src/components/textInput/tests/TextInput.spec.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {FormProvider} from '../../form/FormProvider';
 import {InputValidator, TextInput} from '../TextInput';
+import {useTextInput} from '../useTextInput';
 
 describe('TextInput', () => {
     it('throws an error if the rendering a TextInput outside a FormProvider', () => {
@@ -221,5 +222,57 @@ describe('TextInput', () => {
         userEvent.click(screen.getByRole('button', {name: /toggle input/i})); // unmount
         userEvent.click(screen.getByRole('button', {name: /toggle input/i})); // mount again
         expect(screen.getByRole('textbox', {name: /name/i})).toHaveValue('');
+    });
+
+    it('indicate the input is dirty if the currentValue is different from the initialValue (no defaultValue)', () => {
+        const Fixture = () => {
+            const {state} = useTextInput('🆔');
+            return (
+                <>
+                    <TextInput id="🆔" type="text" label="Name" />
+                    {state.isDirty ? 'dirty' : 'pristine'}
+                </>
+            );
+        };
+
+        render(
+            <FormProvider>
+                <Fixture />
+            </FormProvider>
+        );
+
+        const nameInput = screen.getByRole('textbox', {name: /name/i});
+
+        expect(screen.getByText('pristine')).toBeInTheDocument();
+        userEvent.type(nameInput, 'John');
+        expect(screen.getByText('dirty')).toBeInTheDocument();
+        userEvent.clear(nameInput);
+        expect(screen.getByText('pristine')).toBeInTheDocument();
+    });
+
+    it('indicate the input is dirty if the currentValue is different from the initialValue (with defaultValue)', () => {
+        const Fixture = () => {
+            const {state} = useTextInput('🆔');
+            return (
+                <>
+                    <TextInput id="🆔" type="text" label="Name" defaultValue="John" />
+                    {state.isDirty ? 'dirty' : 'pristine'}
+                </>
+            );
+        };
+
+        render(
+            <FormProvider>
+                <Fixture />
+            </FormProvider>
+        );
+
+        const nameInput = screen.getByRole('textbox', {name: /name/i});
+
+        expect(screen.getByText('pristine')).toBeInTheDocument();
+        userEvent.clear(nameInput);
+        expect(screen.getByText('dirty')).toBeInTheDocument();
+        userEvent.type(nameInput, 'John');
+        expect(screen.getByText('pristine')).toBeInTheDocument();
     });
 });

--- a/packages/react/src/components/textInput/useTextInput.ts
+++ b/packages/react/src/components/textInput/useTextInput.ts
@@ -2,12 +2,15 @@ import {useContext, Dispatch, useMemo} from 'react';
 import {TextInputAction, TextInputState, textInputDefaultState} from './TextInputReducer';
 import {FormContext} from '../form/FormProvider';
 
-export const useTextInput = (id: string): {state: TextInputState; dispatch: Dispatch<TextInputAction>} => {
+export const useTextInput = (
+    id: string,
+    initialValue?: string
+): {state: TextInputState; dispatch: Dispatch<TextInputAction>} => {
     const formContext = useContext(FormContext);
     if (formContext === undefined) {
         throw new Error('useTextInput must be used within a FormProvider.');
     }
-    const state = formContext.state['TextInput'][id] || textInputDefaultState;
+    const state = formContext.state['TextInput'][id] || {...textInputDefaultState, value: initialValue || ''};
     const dispatch = (action: TextInputAction) => formContext.dispatch({type: 'TextInput', id, action});
     return useMemo(() => ({state, dispatch}), [state]);
 };


### PR DESCRIPTION
### Proposed Changes

Make sure that isDirty is handled well even when setting a defaultValue.

Before

https://user-images.githubusercontent.com/35579930/161303399-b2294c06-9a70-423b-b60e-70729a7533c2.mov

After

https://user-images.githubusercontent.com/35579930/161303423-9684bae5-1b9b-45fe-b085-e4fd98ea1644.mov

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
