### PR TITLE
fix(plasma-tokens): change ICONS for Icons in the jenkins params

### DIFF
--- a/TokensExtraction.groovy
+++ b/TokensExtraction.groovy
@@ -25,7 +25,7 @@ pipeline {
         name: 'LIBRARIES', 
         description: 'Name of the Figma libraries to extract tokens from (leave all unchecked to extract them all)', 
         type: 'PT_CHECKBOX', 
-        value: 'ICONS', 
+        value: 'Icons', 
         multiSelectDelimiter: ' ', 
         quoteValue: false, 
         saveJSONParameterToFile: false, 


### PR DESCRIPTION
### Proposed Changes

Fixing this: https://coveord.atlassian.net/browse/UITOOL-612

The library name is actually [`Icons`](https://github.com/coveo/plasma/blob/master/packages/tokens/bin/lib/mappings.ts#L1), not `ICONS`

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
