### PR TITLE
feat(card): added props to iconcard

### DIFF
--- a/packages/react/src/components/iconCard/IconCard.tsx
+++ b/packages/react/src/components/iconCard/IconCard.tsx
@@ -64,7 +64,7 @@ export interface IconCardProps {
     /**
      * Classes to apply to the card button element.
      */
-    cardClasses?: string[];
+    cardClassName?: string[];
 }
 
 export const IconCard: React.FunctionComponent<Override<
@@ -83,7 +83,7 @@ export const IconCard: React.FunctionComponent<Override<
     choices,
     animateOnHover,
     placeBadgesAbove,
-    cardClasses,
+    cardClassName,
     className,
     small,
     children,
@@ -133,7 +133,7 @@ export const IconCard: React.FunctionComponent<Override<
                             'cursor-pointer': (!!onClick || hasChoices) && !disabled && !isOpen,
                             'mod-small': !!small,
                         },
-                        cardClasses
+                        cardClassName
                     )}
                     onClick={handleCardClick}
                     aria-expanded={isOpen}

--- a/packages/react/src/components/iconCard/IconCard.tsx
+++ b/packages/react/src/components/iconCard/IconCard.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {slugify} from 'underscore.string';
 
 import {SlideY} from '../../animations';
-import {TooltipPlacement} from '../../utils';
+import {Override, TooltipPlacement} from '../../utils';
 import {Badge, IBadgeProps} from '../badge/Badge';
 import {SvgChild, SvgChildProps, OptionalSvgChildProps} from '../svg/SvgChild';
 import {ITooltipProps, Tooltip} from '../tooltip';
@@ -20,7 +20,7 @@ export interface IconCardProps {
     /**
      * The main text displayed on the card
      */
-    title: string;
+    title: React.ReactNode;
     /**
      * The secondary text displayed on the card
      */
@@ -57,11 +57,20 @@ export interface IconCardProps {
      * @default false
      */
     disabled?: boolean;
+    /**
+     * Whether to place the badges above the title.
+     */
+    placeBadgesAbove?: boolean;
+    /**
+     * Whether the card should have a fixed width of `456px` and height of `216px`.
+     */
+    fixedSize?: boolean;
 }
 
-export const IconCard: React.FunctionComponent<
-    IconCardProps & SvgChildProps & Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>
-> = ({
+export const IconCard: React.FunctionComponent<Override<
+    SvgChildProps & React.HTMLAttributes<HTMLDivElement>,
+    IconCardProps
+>> = ({
     title,
     badges = [],
     description,
@@ -73,6 +82,8 @@ export const IconCard: React.FunctionComponent<
     tooltip,
     choices,
     animateOnHover,
+    placeBadgesAbove,
+    fixedSize,
     className,
     small,
     children,
@@ -116,9 +127,11 @@ export const IconCard: React.FunctionComponent<
         >
             <Tooltip {...tooltip} placement={tooltip?.placement || TooltipPlacement.Top} noSpanWrapper>
                 <button
-                    className={classNames('card flex full-content-x p3', {
+                    className={classNames('card flex center-align p3', {
                         'cursor-pointer': (!!onClick || hasChoices) && !disabled && !isOpen,
                         'mod-small': !!small,
+                        'mod-fixed': fixedSize,
+                        'full-content-x': !fixedSize,
                     })}
                     onClick={handleCardClick}
                     aria-expanded={isOpen}
@@ -135,15 +148,17 @@ export const IconCard: React.FunctionComponent<
                             svgClass
                         )}
                     />
-                    <div className="flex flex-column flex-auto justify-center">
+                    <div data-testid="main-content" className="flex flex-column flex-auto justify-center">
+                        {placeBadgesAbove && !!badgeComponents.length ? (
+                            <div className="flex mb1">{badgeComponents}</div>
+                        ) : null}
                         <h6 className="title">{title}</h6>
                         {description && <p className="description">{description}</p>}
                     </div>
-
-                    {badgeComponents.length > 0 || React.Children.count(children) > 0 ? (
+                    {(!placeBadgesAbove && !!badgeComponents.length) || React.Children.count(children) > 0 ? (
                         <div className="flex center-align">
                             {children}
-                            {badgeComponents}
+                            {!placeBadgesAbove && badgeComponents}
                         </div>
                     ) : null}
                 </button>

--- a/packages/react/src/components/iconCard/IconCard.tsx
+++ b/packages/react/src/components/iconCard/IconCard.tsx
@@ -62,9 +62,9 @@ export interface IconCardProps {
      */
     placeBadgesAbove?: boolean;
     /**
-     * Whether the card should have a fixed width of `456px` and height of `216px`.
+     * Classes to apply to the card button element.
      */
-    fixedSize?: boolean;
+    cardClasses?: string[];
 }
 
 export const IconCard: React.FunctionComponent<Override<
@@ -83,7 +83,7 @@ export const IconCard: React.FunctionComponent<Override<
     choices,
     animateOnHover,
     placeBadgesAbove,
-    fixedSize,
+    cardClasses,
     className,
     small,
     children,
@@ -127,12 +127,14 @@ export const IconCard: React.FunctionComponent<Override<
         >
             <Tooltip {...tooltip} placement={tooltip?.placement || TooltipPlacement.Top} noSpanWrapper>
                 <button
-                    className={classNames('card flex center-align p3', {
-                        'cursor-pointer': (!!onClick || hasChoices) && !disabled && !isOpen,
-                        'mod-small': !!small,
-                        'mod-fixed': fixedSize,
-                        'full-content-x': !fixedSize,
-                    })}
+                    className={classNames(
+                        'card flex center-align p3 full-content-x',
+                        {
+                            'cursor-pointer': (!!onClick || hasChoices) && !disabled && !isOpen,
+                            'mod-small': !!small,
+                        },
+                        cardClasses
+                    )}
                     onClick={handleCardClick}
                     aria-expanded={isOpen}
                 >

--- a/packages/react/src/components/iconCard/tests/IconCard.spec.tsx
+++ b/packages/react/src/components/iconCard/tests/IconCard.spec.tsx
@@ -271,7 +271,7 @@ describe('IconCard', () => {
         expect(card).not.toHaveClass('animateOnHover');
     });
 
-    it('should NOT render the badges within the main content container if placeBadgesAbove is unset', () => {
+    it('does not render the badges within the main content container if placeBadgesAbove is false', () => {
         const badgeLabel = 'Badge1';
         render(<IconCard title="Title" svgChild={svgChild} badges={[{label: badgeLabel}]} />);
 
@@ -288,7 +288,7 @@ describe('IconCard', () => {
     });
 
     it('should add the given class to the container button if cardClasses is defined', () => {
-        render(<IconCard title="Title" svgChild={svgChild} cardClasses={['mod-fixed-size']} />);
+        render(<IconCard title="Title" svgChild={svgChild} cardClassName={['mod-fixed-size']} />);
 
         const card = screen.getByRole('button', {name: /title/i});
         expect(card).toHaveClass('mod-fixed-size');

--- a/packages/react/src/components/iconCard/tests/IconCard.spec.tsx
+++ b/packages/react/src/components/iconCard/tests/IconCard.spec.tsx
@@ -287,24 +287,10 @@ describe('IconCard', () => {
         expect(within(contentContainer).getByText(badgeLabel)).toBeVisible();
     });
 
-    it('should not add the mod-fixed class to the container button if fixedSize is unset', () => {
-        render(<IconCard title="Title" svgChild={svgChild} />);
+    it('should add the given class to the container button if cardClasses is defined', () => {
+        render(<IconCard title="Title" svgChild={svgChild} cardClasses={['mod-fixed-size']} />);
 
         const card = screen.getByRole('button', {name: /title/i});
-        expect(card).not.toHaveClass('mod-fixed');
-    });
-
-    it('should add the mod-fixed class to the container button if fixedSize is true', () => {
-        render(<IconCard title="Title" svgChild={svgChild} fixedSize />);
-
-        const card = screen.getByRole('button', {name: /title/i});
-        expect(card).toHaveClass('mod-fixed');
-    });
-
-    it('should not add the full-content-x class to the container button if fixedSize is true', () => {
-        render(<IconCard title="Title" svgChild={svgChild} fixedSize />);
-
-        const card = screen.getByRole('button', {name: /title/i});
-        expect(card).not.toHaveClass('full-content-x');
+        expect(card).toHaveClass('mod-fixed-size');
     });
 });

--- a/packages/react/src/components/iconCard/tests/IconCard.spec.tsx
+++ b/packages/react/src/components/iconCard/tests/IconCard.spec.tsx
@@ -6,6 +6,12 @@ import * as React from 'react';
 import {IconCard} from '../IconCard';
 
 describe('IconCard', () => {
+    const svgChild = (
+        <div role="img" aria-label="shrug icon">
+            🤷
+        </div>
+    );
+
     it('renders the specified icon and title', () => {
         render(<IconCard title="The Title" svgName="home" />);
 
@@ -13,12 +19,14 @@ describe('IconCard', () => {
         expect(screen.getByRole('heading', {name: /the title/i})).toBeVisible();
     });
 
+    it('accepts and renders a node as title', () => {
+        const testId = 'test-id';
+        render(<IconCard title={<div data-testid={testId}>Title</div>} svgName="home" />);
+
+        expect(screen.getByTestId(testId)).toBeVisible();
+    });
+
     it('renders custom icons', () => {
-        const svgChild = (
-            <div role="img" aria-label="shrug icon">
-                🤷
-            </div>
-        );
         render(<IconCard title="The Title" svgChild={svgChild} />);
 
         expect(screen.getByRole('img', {name: /shrug icon/i})).toBeVisible();
@@ -113,11 +121,6 @@ describe('IconCard', () => {
     });
 
     it('shows icons in the drawer when clicking on it', () => {
-        const svgChild = (
-            <div role="img" aria-label="shrug icon">
-                🤷
-            </div>
-        );
         render(
             <IconCard
                 title="Title"
@@ -266,5 +269,42 @@ describe('IconCard', () => {
 
         const card = container.querySelector('.icon-card');
         expect(card).not.toHaveClass('animateOnHover');
+    });
+
+    it('should NOT render the badges within the main content container if placeBadgesAbove is unset', () => {
+        const badgeLabel = 'Badge1';
+        render(<IconCard title="Title" svgChild={svgChild} badges={[{label: badgeLabel}]} />);
+
+        const contentContainer = screen.getByTestId('main-content');
+        expect(within(contentContainer).queryByText(badgeLabel)).not.toBeInTheDocument();
+    });
+
+    it('should render the badges within the main content container if placeBadgesAbove is true', () => {
+        const badgeLabel = 'Badge1';
+        render(<IconCard title="Title" svgChild={svgChild} badges={[{label: badgeLabel}]} placeBadgesAbove />);
+
+        const contentContainer = screen.getByTestId('main-content');
+        expect(within(contentContainer).getByText(badgeLabel)).toBeVisible();
+    });
+
+    it('should not add the mod-fixed class to the container button if fixedSize is unset', () => {
+        render(<IconCard title="Title" svgChild={svgChild} />);
+
+        const card = screen.getByRole('button', {name: /title/i});
+        expect(card).not.toHaveClass('mod-fixed');
+    });
+
+    it('should add the mod-fixed class to the container button if fixedSize is true', () => {
+        render(<IconCard title="Title" svgChild={svgChild} fixedSize />);
+
+        const card = screen.getByRole('button', {name: /title/i});
+        expect(card).toHaveClass('mod-fixed');
+    });
+
+    it('should not add the full-content-x class to the container button if fixedSize is true', () => {
+        render(<IconCard title="Title" svgChild={svgChild} fixedSize />);
+
+        const card = screen.getByRole('button', {name: /title/i});
+        expect(card).not.toHaveClass('full-content-x');
     });
 });

--- a/packages/react/src/utils/TypeUtils.ts
+++ b/packages/react/src/utils/TypeUtils.ts
@@ -1,0 +1,1 @@
+export type Override<T1, T2> = Omit<T1, keyof T2> & T2;

--- a/packages/react/src/utils/TypeUtils.ts
+++ b/packages/react/src/utils/TypeUtils.ts
@@ -1,1 +1,1 @@
-export type Override<T1, T2> = Omit<T1, keyof T2> & T2;
+export type Override<T1, T2> = T2 & Omit<T1, keyof T2>;

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -19,3 +19,4 @@ export * from './TypesUtils';
 export * from './UrlUtils';
 export * from './UUID';
 export * from './ValidComponentChildren';
+export * from './TypeUtils';

--- a/packages/style/scss/components/card.scss
+++ b/packages/style/scss/components/card.scss
@@ -21,10 +21,6 @@ $status-card-small-width: 160px;
     border: $default-border;
     border-radius: var(--border-radius);
     box-shadow: var(--low-elevation-on-light);
-
-    .fixed-width {
-        width: 456px;
-    }
 }
 
 .status-card {

--- a/packages/style/scss/components/card.scss
+++ b/packages/style/scss/components/card.scss
@@ -21,6 +21,10 @@ $status-card-small-width: 160px;
     border: $default-border;
     border-radius: var(--border-radius);
     box-shadow: var(--low-elevation-on-light);
+
+    .fixed-width {
+        width: 456px;
+    }
 }
 
 .status-card {

--- a/packages/style/scss/components/icon-card.scss
+++ b/packages/style/scss/components/icon-card.scss
@@ -1,4 +1,7 @@
 .icon-card {
+    --fixed-height: 216px;
+    --fixed-width: 456px;
+
     position: relative;
     top: -8px;
     transition: var(--default-transition);
@@ -26,9 +29,11 @@
         z-index: 1;
         transition: var(--default-transition);
 
-        &.mod-fixed {
-            width: 456px;
-            height: 216px;
+        &.mod-fixed-size {
+            width: var(--fixed-width);
+            min-width: var(--fixed-width);
+            height: var(--fixed-height);
+            min-height: var(--fixed-height);
         }
     }
 

--- a/packages/style/scss/components/icon-card.scss
+++ b/packages/style/scss/components/icon-card.scss
@@ -25,6 +25,11 @@
         top: 8px;
         z-index: 1;
         transition: var(--default-transition);
+
+        &.mod-fixed {
+            width: 456px;
+            height: 216px;
+        }
     }
 
     &.disabled {

--- a/packages/website/src/pages/layout/IconCard.tsx
+++ b/packages/website/src/pages/layout/IconCard.tsx
@@ -80,12 +80,12 @@ const badgesOnTop = `
         <IconCard
             title={<span className="h5 bolder">Simple builder</span>}
             description="For lightweight usage, prototyping, and testing the search experience. Hosted by Coveo."
-            svgChild={<img className="mr2" style={{width: '112px', height: '112px'}} src="https://placeholder.pics/svg/112x112/DEDEDE/FFFFFF-FFFFFF" />}
-            fixedSize
+            svgChild={<img className="mr3" style={{width: '112px', height: '112px'}} src="https://placeholder.pics/svg/112x112/DEDEDE/FFFFFF-FFFFFF" />}
             placeBadgesAbove
             badges={[{label: 'Recommended', extraClasses: ['mod-small', 'mod-information']}]}
             animateOnHover
             onClick={() => alert('You clicked the card')}
+            cardClasses={['mod-fixed-size']}
         />
     );
 `;

--- a/packages/website/src/pages/layout/IconCard.tsx
+++ b/packages/website/src/pages/layout/IconCard.tsx
@@ -85,7 +85,7 @@ const badgesOnTop = `
             badges={[{label: 'Recommended', extraClasses: ['mod-small', 'mod-information']}]}
             animateOnHover
             onClick={() => alert('You clicked the card')}
-            cardClasses={['mod-fixed-size']}
+            cardClassName={['mod-fixed-size']}
         />
     );
 `;

--- a/packages/website/src/pages/layout/IconCard.tsx
+++ b/packages/website/src/pages/layout/IconCard.tsx
@@ -72,6 +72,24 @@ const disabled = `
     );
 `;
 
+const badgesOnTop = `
+    import * as React from 'react';
+    import {IconCard} from '@coveord/plasma-react';
+
+    export default () => (
+        <IconCard
+            title={<span className="h5 bolder">Simple builder</span>}
+            description="For lightweight usage, prototyping, and testing the search experience. Hosted by Coveo."
+            svgChild={<img className="mr2" style={{width: '112px', height: '112px'}} src="https://placeholder.pics/svg/112x112/DEDEDE/FFFFFF-FFFFFF" />}
+            fixedSize
+            placeBadgesAbove
+            badges={[{label: 'Recommended', extraClasses: ['mod-small', 'mod-information']}]}
+            animateOnHover
+            onClick={() => alert('You clicked the card')}
+        />
+    );
+`;
+
 export const IconCardExamples: React.FunctionComponent = () => (
     <PageLayout
         id="IconCard"
@@ -84,6 +102,7 @@ export const IconCardExamples: React.FunctionComponent = () => (
             choices: {code: choices, title: 'With multiple choices'},
             small: {code: small, title: 'Small, with multiple choices'},
             disabled: {code: disabled, title: 'Disabled, with lock badge'},
+            badgesOnTop: {code: badgesOnTop, title: 'With badges on top'},
         }}
     />
 );


### PR DESCRIPTION
### Proposed Changes
On the IconCard component:

- Modified the title prop type from `string` to `ReactNode`
- Added props
```typescript
/**
 * Whether to place the badges above the title.
 */
placeBadgesAbove?: boolean;
/**
 * Classes to apply to the card button element.
 */
cardClasses?: string[];
```
- Added `mod-fixed-size` class in css for use with the cardClasses prop.

| Goal | Result (using the new prop update) |
|---|---|
|<img width="468" alt="Screen Shot 2022-04-01 at 4 38 06 PM" src="https://user-images.githubusercontent.com/16785453/161338018-58b1ce5a-7ce5-4c48-8cb9-9999b77cafc3.png">|<img width="474" alt="Screen Shot 2022-04-01 at 5 29 19 PM" src="https://user-images.githubusercontent.com/16785453/161343889-2565484f-915d-40ae-97ea-792cf9e280ee.png">|

### Potential Breaking Changes

There shouldn't be any if I did it right.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
