### PR TITLE
chore(style, deploy): fix permissions on S3 bucket for CDN files

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -71,7 +71,6 @@
                 "directory": "react-vapor/style/v$[VERSION]",
                 "parameters": {
                     "include": "*.min.*",
-                    "acl": "public-read",
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                     "content-encoding": "gzip"
                 },
@@ -85,7 +84,6 @@
                 "directory": "react-vapor/style/v$[VERSION]",
                 "parameters": {
                     "exclude": "*.min.*",
-                    "acl": "public-read",
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
                 "source": "packages/style/dist"


### PR DESCRIPTION
### Proposed Changes

Following this [Slack thread](https://coveo.slack.com/archives/CBP3GTFTQ/p1649691790759329), I removed the `public-read` acl on the ressources since it's not needed anymore and it blocks Jenkins from deploying

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
