### PR TITLE
fix(react, table): improve accessibility of loading tables

### DIFF
--- a/packages/react/src/components/loading/components/TableLoading.tsx
+++ b/packages/react/src/components/loading/components/TableLoading.tsx
@@ -36,7 +36,7 @@ const Body = ({
     numberOfRow?: number;
     numberOfSubRow?: number;
 }) => (
-    <tbody>
+    <tbody role="status">
         {_.times(numberOfRow, (nColumn: number) =>
             isCard ? (
                 <CardRow

--- a/packages/react/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react/src/components/table-hoc/TableHOC.tsx
@@ -145,7 +145,12 @@ export const TableHOC: React.FunctionComponent<ITableHOCProps & React.HTMLAttrib
     const table = (
         <table className={classNames(className)} style={{marginTop: hasActionBar() ? '-1px' : 0}}>
             {tableHeader}
-            <tbody key={`table-body-${id}`} className={classNames({hidden: isLoading}, tbodyClassName)}>
+            <tbody
+                key={`table-body-${id}`}
+                className={classNames({hidden: isLoading}, tbodyClassName)}
+                aria-busy={isLoading}
+                aria-hidden={isLoading}
+            >
                 {renderBody(data || [])}
             </tbody>
             {isLoading && (

--- a/packages/react/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -1,4 +1,4 @@
-import {render} from '@test-utils';
+import {render, screen} from '@test-utils';
 import {shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -136,16 +136,22 @@ describe('TableHOC', () => {
             expect(wrapper.find(ActionBarConnected).props().prefixContent).toBe(content);
         });
 
-        it('should keep the tbody with rows data during the loading', () => {
-            const wrapper = shallow(<TableHOC {...defaultProps} isLoading />);
+        it('renders a status during the loading', () => {
+            const {rerender} = render(<TableHOC {...defaultProps} isLoading />);
 
-            expect(wrapper.find('tbody').length).toBe(1);
+            expect(screen.getByRole('status')).toBeVisible();
+
+            rerender(<TableHOC {...defaultProps} isLoading={false} />);
+
+            expect(screen.queryByRole('status')).not.toBeInTheDocument();
         });
 
-        it('should set the tbody rows data hidden during the loading', () => {
-            const wrapper = shallow(<TableHOC {...defaultProps} isLoading />);
+        it('hides the real rows during the loading', () => {
+            render(<TableHOC {...defaultProps} isLoading />);
 
-            expect(wrapper.find('tbody').hasClass('hidden')).toBe(true);
+            const hiddenBody = screen.getByRole('rowgroup', {hidden: true});
+
+            expect(hiddenBody).toBeInTheDocument();
         });
 
         it('should disabled actions on loading', () => {


### PR DESCRIPTION
### Proposed Changes

Improve accessibility of tables when they are loading.

You'll be able to do `await waitForElementToBeRemoved(screen.getByRole('status'));` to make sure your table is not loading anymore

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
