### PR TITLE
feat(icons): lazy load react-icons

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -5,6 +5,7 @@
     "main": "./dist/cjs/index.js",
     "types": "./dist/definitions/index.d.ts",
     "module": "dist/esm/index.js",
+    "sideEffects": false,
     "scripts": {
         "build": "pnpm generate && pnpm compile",
         "generate": "node ./bin/index.js",
@@ -47,6 +48,7 @@
         "typescript": "4.5.4"
     },
     "dependencies": {
+        "@loadable/component": "5.15.2",
         "@swc/helpers": "0.3.8"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,7 @@ importers:
     specifiers:
       '@babel/types': 7.17.0
       '@coveord/plasma-tokens': workspace:*
+      '@loadable/component': 5.15.2
       '@svgr/core': 6.2.1
       '@swc/cli': 0.1.57
       '@swc/core': 1.2.165
@@ -277,6 +278,7 @@ importers:
       tslib: 2.3.1
       typescript: 4.5.4
     dependencies:
+      '@loadable/component': 5.15.2
       '@swc/helpers': 0.3.8
     devDependencies:
       '@babel/types': 7.17.0
@@ -1594,6 +1596,17 @@ packages:
       '@types/yargs': 16.0.4
       chalk: 4.1.2
     dev: true
+
+  /@loadable/component/5.15.2:
+    resolution: {integrity: sha512-ryFAZOX5P2vFkUdzaAtTG88IGnr9qxSdvLRvJySXcUA4B4xVWurUNADu3AnKPksxOZajljqTrDEDcYjeL4lvLw==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      react: '>=16.3.0'
+    dependencies:
+      '@babel/runtime': 7.16.3
+      hoist-non-react-statics: 3.3.2
+      react-is: 16.13.1
+    dev: false
 
   /@loadable/component/5.15.2_react@16.14.0:
     resolution: {integrity: sha512-ryFAZOX5P2vFkUdzaAtTG88IGnr9qxSdvLRvJySXcUA4B4xVWurUNADu3AnKPksxOZajljqTrDEDcYjeL4lvLw==}


### PR DESCRIPTION
### Proposed Changes

While debugging in another package we saw that loading the icon package could take multiple seconds in Jest (using commonJs). To avoid this we wrap the component in a Loadable component. It should be transparent when using the library.

### Potential Breaking Changes

The d.ts did change a bit, if developer were importing the component from /dist/some/path/sizeXPx it now use a default export

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
