### PR TITLE
fix(plasma-react): value prop will no longer display syntax error

### DIFF
--- a/packages/react/src/components/editor/CodeEditor.tsx
+++ b/packages/react/src/components/editor/CodeEditor.tsx
@@ -1,13 +1,13 @@
 import loadable from '@loadable/component';
 import classNames from 'classnames';
 import type {Editor, EditorConfiguration} from 'codemirror';
-import {ComponentType, createRef, Component} from 'react';
+import {Component, ComponentType, createRef} from 'react';
 import type {Controlled} from 'react-codemirror2';
 import {connect} from 'react-redux';
 
 import {PlasmaState} from '../../PlasmaState';
 import {IDispatch} from '../../utils';
-import {CollapsibleSelectors} from '../collapsible/CollapsibleSelectors';
+import {CollapsibleSelectors} from '../collapsible';
 import {CodeEditorActions} from './CodeEditorActions';
 import {CodeMirrorGutters} from './EditorConstants';
 
@@ -81,7 +81,7 @@ class CodeEditorDisconnect extends Component<
 > {
     static defaultProps: Partial<ICodeEditorProps> = {
         className: 'mod-border',
-        value: '{}',
+        value: '',
     };
 
     static defaultOptions = {
@@ -119,9 +119,13 @@ class CodeEditorDisconnect extends Component<
             this.editor.refresh();
             this.setState({numberOfRefresh: this.state.numberOfRefresh + 1});
         }
-        if (prevProps.value !== this.props.value && this.editor) {
+
+        if (prevProps.value !== this.props.value) {
             this.setState({value: this.props.value});
-            this.editor.getDoc().clearHistory();
+
+            if (this.editor) {
+                this.editor.getDoc().clearHistory();
+            }
         }
     }
 

--- a/packages/react/src/components/editor/JSONEditor.tsx
+++ b/packages/react/src/components/editor/JSONEditor.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
-import {FunctionComponent, useState, useEffect} from 'react';
+import {FunctionComponent, useEffect, useState} from 'react';
 
-import {Svg} from '../svg/Svg';
+import {Svg} from '../svg';
 import {CodeEditor} from './CodeEditor';
 import {CodeMirrorModes, DEFAULT_JSON_ERROR_MESSAGE} from './EditorConstants';
 import {JSONEditorUtils} from './JSONEditorUtils';
@@ -53,7 +53,10 @@ export interface JSONEditorProps {
 }
 
 export interface JSONEditorStateProps {
-    value: string;
+    /**
+     * @deprecated use defaultValue instead
+     */
+    value?: string;
 }
 
 export interface JSONEditorDispatchProps {
@@ -77,7 +80,8 @@ export const JSONEditor: FunctionComponent<
     onUnmount,
     collapsibleId,
 }) => {
-    const [isInError, setIsInError] = useState(!JSONEditorUtils.validateValue(value || defaultValue));
+    const editorValue = defaultValue || value || '{}';
+    const [isInError, setIsInError] = useState(!JSONEditorUtils.validateValue(editorValue));
 
     useEffect(() => {
         onMount?.();
@@ -85,9 +89,13 @@ export const JSONEditor: FunctionComponent<
         return onUnmount;
     }, []);
 
+    useEffect(() => {
+        const hasError = !JSONEditorUtils.validateValue(editorValue);
+        setIsInError(hasError);
+    }, [editorValue]);
+
     const handleChange = (json: string) => {
         const hasError = !JSONEditorUtils.validateValue(json);
-
         setIsInError(hasError);
         onChange?.(json, hasError);
     };
@@ -95,7 +103,7 @@ export const JSONEditor: FunctionComponent<
     return (
         <div className={classNames('form-group', {'input-validation-error': isInError}, containerClasses)}>
             <CodeEditor
-                value={value || defaultValue}
+                value={editorValue}
                 onChange={handleChange}
                 mode={CodeMirrorModes.JSON}
                 readOnly={readOnly}

--- a/packages/react/src/components/editor/JSONEditor.tsx
+++ b/packages/react/src/components/editor/JSONEditor.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {useEffect, useState} from 'react';
+import {FunctionComponent, useEffect, useState} from 'react';
 
 import {Svg} from '../svg';
 import {CodeEditor} from './CodeEditor';
@@ -12,11 +12,11 @@ export interface JSONEditorProps {
      */
     id?: string;
     /**
-     * @deprecated use defaultValue instead
+     * The text value of the JSON editor
      */
     value?: string;
     /**
-     * The initial value
+     * @deprecated use value instead
      */
     defaultValue?: string;
     /**
@@ -65,8 +65,8 @@ export interface JSONEditorDispatchProps {
 export const JSONEditor: FunctionComponent<
     JSONEditorProps & Partial<JSONEditorStateProps> & Partial<JSONEditorDispatchProps>
 > = ({
-    value,
     defaultValue,
+    value,
     readOnly,
     onChange,
     errorMessage,
@@ -77,7 +77,7 @@ export const JSONEditor: FunctionComponent<
     onUnmount,
     collapsibleId,
 }) => {
-    const editorValue = defaultValue || value || '{}';
+    const editorValue = value || defaultValue || '{}';
     const [isInError, setIsInError] = useState(!JSONEditorUtils.validateValue(editorValue));
 
     useEffect(() => {

--- a/packages/react/src/components/editor/JSONEditor.tsx
+++ b/packages/react/src/components/editor/JSONEditor.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {FunctionComponent, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import {Svg} from '../svg';
 import {CodeEditor} from './CodeEditor';
@@ -53,10 +53,7 @@ export interface JSONEditorProps {
 }
 
 export interface JSONEditorStateProps {
-    /**
-     * @deprecated use defaultValue instead
-     */
-    value?: string;
+    value: string;
 }
 
 export interface JSONEditorDispatchProps {
@@ -89,15 +86,20 @@ export const JSONEditor: FunctionComponent<
         return onUnmount;
     }, []);
 
-    useEffect(() => {
-        const hasError = !JSONEditorUtils.validateValue(editorValue);
+    const validate = (val: string) => {
+        const hasError = !JSONEditorUtils.validateValue(val);
         setIsInError(hasError);
+        return hasError;
+    };
+
+    useEffect(() => {
+        validate(editorValue);
     }, [editorValue]);
 
     const handleChange = (json: string) => {
-        const hasError = !JSONEditorUtils.validateValue(json);
-        setIsInError(hasError);
-        onChange?.(json, hasError);
+        const isValid = validate(json);
+
+        return onChange?.(json, isValid);
     };
 
     return (

--- a/packages/react/src/components/editor/JSONEditorConnected.tsx
+++ b/packages/react/src/components/editor/JSONEditorConnected.tsx
@@ -2,13 +2,13 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useEffect} from 'react';
 
 import {IDispatch} from '../../utils';
-import {JSONEditor, JSONEditorDispatchProps, JSONEditorProps, JSONEditorStateProps} from './JSONEditor';
+import {JSONEditor, JSONEditorProps} from './JSONEditor';
 import {JSONEditorActions} from './JSONEditorActions';
 import {JSONEditorSelectors} from './JSONEditorSelectors';
 
-export const JSONEditorConnected = (props: JSONEditorStateProps & JSONEditorDispatchProps & JSONEditorProps) => {
+export const JSONEditorConnected = (props: JSONEditorProps) => {
     const dispatch: IDispatch = useDispatch();
-    const defaultValue = useSelector((state) => JSONEditorSelectors.getValue(state, props.id));
+    const value = useSelector((state) => JSONEditorSelectors.getValue(state, props.id));
 
     useEffect(() => {
         dispatch(JSONEditorActions.addJSONEditor(props.id, props.defaultValue || props.value));
@@ -18,10 +18,10 @@ export const JSONEditorConnected = (props: JSONEditorStateProps & JSONEditorDisp
         };
     }, []);
 
-    const onChange = (value: string, inError: boolean) => {
-        dispatch(JSONEditorActions.updateJSONEditorValue(props.id, value));
-        props.onChange?.(value, inError);
+    const onChange = (changedValue: string, inError: boolean) => {
+        dispatch(JSONEditorActions.updateJSONEditorValue(props.id, changedValue));
+        props.onChange?.(changedValue, inError);
     };
 
-    return <JSONEditor {...props} defaultValue={defaultValue} onChange={onChange} />;
+    return <JSONEditor {...props} value={value} onChange={onChange} />;
 };

--- a/packages/react/src/components/editor/JSONEditorConnected.tsx
+++ b/packages/react/src/components/editor/JSONEditorConnected.tsx
@@ -6,7 +6,14 @@ import {JSONEditor, JSONEditorProps} from './JSONEditor';
 import {JSONEditorActions} from './JSONEditorActions';
 import {JSONEditorSelectors} from './JSONEditorSelectors';
 
-export const JSONEditorConnected = (props: JSONEditorProps) => {
+interface JSONEditorConnectedProps {
+    /**
+     * initial value of the component
+     */
+    defaultValue?: string;
+}
+
+export const JSONEditorConnected = (props: JSONEditorProps & JSONEditorConnectedProps) => {
     const dispatch: IDispatch = useDispatch();
     const value = useSelector((state) => JSONEditorSelectors.getValue(state, props.id));
 

--- a/packages/react/src/components/editor/tests/JSONEditor.spec.tsx
+++ b/packages/react/src/components/editor/tests/JSONEditor.spec.tsx
@@ -1,5 +1,4 @@
 import {shallow, ShallowWrapper} from 'enzyme';
-import * as _ from 'underscore';
 
 import {CodeEditor} from '../CodeEditor';
 import {CodeMirrorModes} from '../EditorConstants';

--- a/packages/react/src/components/editor/tests/JSONEditorConnected.spec.tsx
+++ b/packages/react/src/components/editor/tests/JSONEditorConnected.spec.tsx
@@ -11,6 +11,28 @@ describe('<JSONEditorConnected />', () => {
         }).not.toThrow();
     });
 
+    it('will display brackets if no value/defaultValue is provided as it is a JSON editor', async () => {
+        const {container} = render(<JSONEditorConnected id="💙" />);
+
+        await waitFor(() => expect(screen.getByRole('textbox')).toBeVisible());
+
+        // eslint-disable-next-line testing-library/no-node-access,testing-library/no-container
+        const line = container.querySelector('.CodeMirror-line [role="presentation"]') as HTMLElement;
+
+        // the codemirror divide the text in multiple elements, by using textContent we "strip" the html
+        const matcher = (_: string, element: HTMLElement) => element?.textContent === '{}';
+
+        expect(within(line).getByText(matcher)).toBeVisible();
+    });
+
+    it('will not display error when rendering with (deprecated) value prop', async() => {
+        render(<JSONEditorConnected id="💙" value={'{}'} />);
+
+        await waitFor(() => expect(screen.getByRole('textbox')).toBeVisible());
+
+        expect(screen.queryByText(/JSON configuration is syntactically invalid/i)).not.toBeInTheDocument();
+    });
+
     it('should not throw when content changes', async () => {
         render(<JSONEditorConnected id="💙" defaultValue={'{}'} />);
 
@@ -49,10 +71,10 @@ describe('<JSONEditorConnected />', () => {
         userEvent.type(screen.getByRole('textbox'), expectedValue);
 
         expect(onChangeSpy).toHaveBeenCalledTimes(5);
-        expect(onChangeSpy).toHaveBeenCalledWith('h', true);
-        expect(onChangeSpy).toHaveBeenCalledWith('he', true);
-        expect(onChangeSpy).toHaveBeenCalledWith('hel', true);
-        expect(onChangeSpy).toHaveBeenCalledWith('hell', true);
-        expect(onChangeSpy).toHaveBeenCalledWith('hello', true);
+        expect(onChangeSpy).toHaveBeenCalledWith('{}h', true);
+        expect(onChangeSpy).toHaveBeenCalledWith('{}he', true);
+        expect(onChangeSpy).toHaveBeenCalledWith('{}hel', true);
+        expect(onChangeSpy).toHaveBeenCalledWith('{}hell', true);
+        expect(onChangeSpy).toHaveBeenCalledWith('{}hello', true);
     });
 });


### PR DESCRIPTION
### Proposed Changes

Fixes [ADUI-7921](https://coveord.atlassian.net/browse/ADUI-7921) and accidentally fixed [UITOOL-646](https://coveord.atlassian.net/browse/UITOOL-646)

- (refactor) JSONEditorConnected converted to Function Component, doing away with `mapDispatch`/`mapState`.  I did this change as part of it as it was a simple component and I find it easier to read.
- ADUI-7921 value prop will not be overridden by Redux - the `mapState` had a `value`, because the initial value was `''` from the selector, it was evaluating on an empty string before updating again from the selector, but whether to show the error was not fired, so it would show it as invalid.
- UITOOL-646 Fixes the Plasma website where the code editor wasn't synced with what was displayed in the JSON editor.
- I moved the default `{}` from CodeEditor the JSONEditor, and made the default value an empty string.  To me it seemed more appropriate than a code editor having JSON as default code.

Some of these changes are not really necessary or a requirement of the JIRAs, I would be happy to revert any of them.

You can test that `value` was the culprit by changing `defaultValue` to `value` on the Plasma website and passing in an empty object
![image](https://user-images.githubusercontent.com/5728044/164533453-9284aa97-9ef9-469c-bb34-a49704faa3ff.png)

### Potential Breaking Changes

- Please verify that both value and defaultValue continue to work as expected.

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
