### PR TITLE
fix(react, chart-tooltip): throws an error on null drop position

### DIFF
--- a/packages/react/src/components/chart/ChartTooltip.tsx
+++ b/packages/react/src/components/chart/ChartTooltip.tsx
@@ -74,12 +74,12 @@ export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({sort =
                 ref={ref}
                 isOpen={!!position.position}
                 positions={[position.position, DropPodPosition.left, DropPodPosition.right]}
-                renderDrop={(style: React.CSSProperties, dropPosition: IDropUIPosition): React.ReactNode => (
+                renderDrop={(style: React.CSSProperties, dropPosition: IDropUIPosition | null): React.ReactNode => (
                     <div
                         style={{...style, pointerEvents: 'none'}}
                         className={classNames('show-on-top', {
-                            'ml-2': dropPosition.position === DropPodPosition.left,
-                            ml2: dropPosition.position === DropPodPosition.right,
+                            'ml-2': dropPosition?.position === DropPodPosition.left,
+                            ml2: dropPosition?.position === DropPodPosition.right,
                         })}
                     >
                         <ChartTooltipContent x={position.index} sort={sort} />

--- a/packages/react/src/components/chart/tests/ChartTooltip.spec.tsx
+++ b/packages/react/src/components/chart/tests/ChartTooltip.spec.tsx
@@ -46,10 +46,13 @@ describe('<ChartTooltip />', () => {
     it('should render a ChartTooltipContent inside the DropPod', () => {
         const component = shallow(<ChartTooltip />);
         const content = shallow(
-            component.find(DropPod).prop('renderDrop')({}, React.createRef(), {
-                position: DropPodPosition.left,
-                orientation: '',
-            }) as React.ReactElement
+            component.find(DropPod).prop('renderDrop')(
+                {},
+                {
+                    position: DropPodPosition.left,
+                    orientation: '',
+                }
+            ) as React.ReactElement
         );
 
         expect(content.find(ChartTooltipContent).exists()).toBe(true);

--- a/packages/react/src/components/drop/DropPod.tsx
+++ b/packages/react/src/components/drop/DropPod.tsx
@@ -14,7 +14,7 @@ import {
 } from './DomPositionCalculator';
 
 export interface IDropPodProps {
-    renderDrop: (style: React.CSSProperties, position: IDropUIPosition) => React.ReactNode;
+    renderDrop: (style: React.CSSProperties, position: IDropUIPosition | null) => React.ReactNode;
     isOpen?: boolean;
     positions?: Array<'bottom' | 'top' | 'left' | 'right'>;
     selector?: string;

--- a/packages/react/src/components/drop/tests/Drop.spec.tsx
+++ b/packages/react/src/components/drop/tests/Drop.spec.tsx
@@ -208,7 +208,7 @@ describe('Drop', () => {
                     wrapper
                         .find(DropPod)
                         .props()
-                        .renderDrop({} as any, {} as any, {} as any) as any,
+                        .renderDrop({} as any, {} as any) as any,
                     {}
                 );
 


### PR DESCRIPTION
### Proposed Changes

Fix issue with drop position that can be null

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
