### PR TITLE
fix(navigation): disable the click event on locked navigation

### DIFF
--- a/packages/style/scss/components/navigation.scss
+++ b/packages/style/scss/components/navigation.scss
@@ -119,6 +119,7 @@
 
                         &.disabled {
                             cursor: default;
+                            pointer-events: none;
                             .navigation-menu-section-item-link {
                                 color: var(--grey-60);
                             }
@@ -147,6 +148,7 @@
 
                             &.state-locked {
                                 color: $navigation-locked-color;
+                                pointer-events: none;
                             }
                             .navigation-menu-section-item-link-name,
                             .navigation-menu-section-item-link-icon {


### PR DESCRIPTION
### Proposed Changes

When a navigation element is locked in the admin (for lack of license access), the user can still click on the element. I've added a quick css trick just so that the click event does not go through (noticed it while working on https://coveord.atlassian.net/browse/UA-6628)

Go in `weirdorgfyxitz4w` and Data Exports should be locked, but you can still click on it (and there is no redirection whatsoever)

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
