### PR TITLE
ci(lint): automatically sort package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,47 @@
     "version": "41.2.10",
     "private": true,
     "scripts": {
+        "build": "ultra --recursive build",
+        "clean": "pnpm --recursive --parallel clean",
+        "commit-cli": "cz",
         "preinstall": "npx only-allow pnpm",
+        "lintfix": "pnpm --recursive --parallel lintfix",
+        "precommit": "lint-staged",
+        "prepare": "husky install",
+        "reconstruct": "npx rimraf node_modules packages/*/node_modules && npm run setup && echo done",
         "setup": "pnpm install",
         "start": "pnpm build && pnpm --recursive --parallel start",
         "test": "pnpm --recursive test",
-        "test:ci": "pnpm --recursive test:ci",
         "test:changed": "pnpm --recursive test:changed",
-        "clean": "pnpm --recursive --parallel clean",
-        "build": "ultra --recursive build",
-        "lintfix": "pnpm --recursive --parallel lintfix",
-        "commit-cli": "cz",
-        "reconstruct": "npx rimraf node_modules packages/*/node_modules && npm run setup && echo done",
-        "prepare": "husky install"
+        "test:ci": "pnpm --recursive test:ci"
+    },
+    "commitlint": {
+        "extends": [
+            "@commitlint/config-conventional"
+        ]
+    },
+    "lint-staged": {
+        "package.json": [
+            "sort-package-json",
+            "git add"
+        ]
+    },
+    "config": {
+        "commitizen": {
+            "path": "cz-conventional-changelog"
+        }
+    },
+    "browserslist": [
+        "cover 90%",
+        "last 1 versions",
+        "IE 11",
+        "not dead"
+    ],
+    "prettier": "tsjs/prettier-config",
+    "stylelint": {
+        "extends": [
+            "tsjs/stylelint-config"
+        ]
     },
     "devDependencies": {
         "@commitlint/cli": "15.0.0",
@@ -29,34 +58,14 @@
         "cz-conventional-changelog": "3.3.0",
         "eslint": "8.14.0",
         "husky": "7.0.4",
+        "lint-staged": "9.5.0",
         "mime-types": "2.1.35",
         "prettier": "2.0.5",
+        "sort-package-json": "1.57.0",
         "stylelint": "13.13.1",
         "tsjs": "3.0.2",
         "ultra-runner": "3.10.5",
         "underscore": "1.13.1",
         "walkdir": "0.4.1"
-    },
-    "stylelint": {
-        "extends": [
-            "tsjs/stylelint-config"
-        ]
-    },
-    "prettier": "tsjs/prettier-config",
-    "browserslist": [
-        "cover 90%",
-        "last 1 versions",
-        "IE 11",
-        "not dead"
-    ],
-    "config": {
-        "commitizen": {
-            "path": "cz-conventional-changelog"
-        }
-    },
-    "commitlint": {
-        "extends": [
-            "@commitlint/config-conventional"
-        ]
     }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,27 +11,51 @@
         "web"
     ],
     "homepage": "https://github.com/coveo/plasma#readme",
-    "author": "Coveo",
-    "license": "Apache-2.0",
-    "main": "./dist/cjs/Entry.js",
-    "module": "./dist/esm/Entry.js",
-    "types": "dist/definitions/Entry.d.ts",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/coveo/plasma.git"
     },
+    "license": "Apache-2.0",
+    "author": "Coveo",
+    "main": "./dist/cjs/Entry.js",
+    "module": "./dist/esm/Entry.js",
+    "types": "dist/definitions/Entry.d.ts",
+    "files": [
+        "dist"
+    ],
     "scripts": {
-        "start": "node scripts/start",
         "build": "node scripts/build",
-        "test": "jest --maxWorkers=65%",
-        "test:ci": "jest --maxWorkers=65% --silent",
-        "test:changed": "jest --maxWorkers=65% --changedSince master",
-        "test:watch": "jest --watchAll",
-        "test:debug": "node --inspect-brk node_modules/jest/bin/jest --runInBand --watchAll --detectOpenHandles --forceExit",
-        "precommit": "lint-staged",
         "clean": "rimraf dist coverage",
-        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"src/**/*.{ts,tsx}\" --fix"
+        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"src/**/*.{ts,tsx}\" --fix",
+        "precommit": "lint-staged",
+        "start": "node scripts/start",
+        "test": "jest --maxWorkers=65%",
+        "test:changed": "jest --maxWorkers=65% --changedSince master",
+        "test:ci": "jest --maxWorkers=65% --silent",
+        "test:debug": "node --inspect-brk node_modules/jest/bin/jest --runInBand --watchAll --detectOpenHandles --forceExit",
+        "test:watch": "jest --watchAll"
     },
+    "lint-staged": {
+        "package.json": [
+            "sort-package-json",
+            "git add"
+        ],
+        "**/*.scss": [
+            "stylelint --fix",
+            "prettier --write",
+            "git add"
+        ],
+        "**/*.{ts,tsx}": [
+            "prettier --write",
+            "eslint -c ./.eslintrc.js --fix",
+            "git add"
+        ],
+        "**/*.{js,jsx,json,md,yml,html}": [
+            "prettier --write",
+            "git add"
+        ]
+    },
+    "prettier": "tsjs/prettier-config",
     "dependencies": {
         "@coveord/plasma-style": "workspace:*",
         "@loadable/component": "5.15.2",
@@ -59,17 +83,6 @@
         "strict-uri-encode": "2.x.x",
         "unidiff": "0.0.4"
     },
-    "peerDependencies": {
-        "codemirror": "^5.39.2",
-        "d3": "^3.5.17",
-        "jquery": ">= 2.0.0 =< 3",
-        "react": "^16.14.21",
-        "react-dom": "^16.14.0",
-        "react-redux": "^7.2.4",
-        "redux": "^4.0.1",
-        "underscore": "^1.8.3",
-        "underscore.string": "^3.3.5"
-    },
     "devDependencies": {
         "@helpers/enzyme-redux": "workspace:*",
         "@hot-loader/react-dom": "17.0.2",
@@ -90,6 +103,7 @@
         "@types/jquery": "2.0.60",
         "@types/loadable__component": "5.13.4",
         "@types/lorem-ipsum": "2.0.0",
+        "@types/react": "17.0.44",
         "@types/react-bootstrap": "0.32.29",
         "@types/react-codemirror": "1.0.7",
         "@types/react-color": "3.0.6",
@@ -100,12 +114,11 @@
         "@types/react-tether": "0.5.5",
         "@types/react-textarea-autosize": "4.3.6",
         "@types/react-transition-group": "2.9.2",
-        "@types/react": "17.0.44",
         "@types/redux-logger": "3.0.9",
         "@types/redux-mock-store": "1.0.3",
         "@types/redux-promise-middleware": "6.0.0",
-        "@types/underscore.string": "0.0.38",
         "@types/underscore": "1.8.10",
+        "@types/underscore.string": "0.0.38",
         "@typescript-eslint/eslint-plugin": "5.21.0",
         "@typescript-eslint/parser": "5.21.0",
         "@wojtekmaj/enzyme-adapter-react-17": "0.6.7",
@@ -117,55 +130,46 @@
         "del": "6.0.0",
         "enzyme": "3.11.0",
         "escape-string-regexp": "1.0.5",
-        "eslint-plugin-jest-dom": "3.9.4",
         "eslint-plugin-jest": "25.7.0",
+        "eslint-plugin-jest-dom": "3.9.4",
         "eslint-plugin-testing-library": "5.3.1",
         "faker": "4.1.0",
         "fancy-log": "1.3.3",
         "identity-obj-proxy": "3.0.0",
-        "jest-environment-jsdom": "28.0.2",
         "jest": "28.0.3",
+        "jest-environment-jsdom": "28.0.2",
         "jquery": "3.6.0",
         "lint-staged": "9.5.0",
         "lorem-ipsum": "2.0.4",
         "minimist": "1.2.6",
         "postcss": "8.4.13",
+        "react": "17.0.2",
         "react-dnd-test-backend": "15.1.2",
         "react-dom": "17.0.2",
         "react-redux": "7.2.6",
-        "react": "17.0.2",
+        "redux": "4.2.0",
         "redux-logger": "3.0.6",
         "redux-mock-store": "1.5.4",
         "redux-promise-middleware": "6.1.2",
         "redux-thunk": "2.4.1",
-        "redux": "4.2.0",
         "regenerator-runtime": "0.13.9",
         "rimraf": "3.0.2",
         "sass": "1.51.0",
         "ts-jest": "27.1.4",
         "tslib": "2.3.1",
         "typescript": "4.6.4",
-        "underscore.string": "3.3.6",
-        "underscore": "1.13.1"
+        "underscore": "1.13.1",
+        "underscore.string": "3.3.6"
     },
-    "files": [
-        "dist"
-    ],
-    "lint-staged": {
-        "**/*.scss": [
-            "stylelint --fix",
-            "prettier --write",
-            "git add"
-        ],
-        "**/*.{ts,tsx}": [
-            "prettier --write",
-            "eslint -c ./.eslintrc.js --fix",
-            "git add"
-        ],
-        "**/*.{js,jsx,json,md,yml,html}": [
-            "prettier --write",
-            "git add"
-        ]
-    },
-    "prettier": "tsjs/prettier-config"
+    "peerDependencies": {
+        "codemirror": "^5.39.2",
+        "d3": "^3.5.17",
+        "jquery": ">= 2.0.0 =< 3",
+        "react": "^16.14.21",
+        "react-dom": "^16.14.0",
+        "react-redux": "^7.2.4",
+        "redux": "^4.0.1",
+        "underscore": "^1.8.3",
+        "underscore.string": "^3.3.5"
+    }
 }

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -10,25 +10,61 @@
         "web"
     ],
     "homepage": "https://plasma.coveo.com/",
-    "author": "Coveo",
-    "license": "Apache-2.0",
-    "main": "dist/js/PlasmaStyle.js",
-    "types": "index.d.ts",
-    "scripts": {
-        "build": "gulp clean && gulp && webpack",
-        "start": "concurrently \"gulp watch\" \"webpack --watch\"",
-        "precommit": "lint-staged",
-        "clean": "gulp clean",
-        "lintfix": "../../node_modules/.bin/stylelint --fix \"**/*.scss\" && ../../node_modules/.bin/prettier --write \"**/*.{scss,js,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"**/*.js\" --fix"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/coveo/plasma.git"
     },
-    "peerDependencies": {
-        "chosen-npm": "^1.4.2",
-        "coveo-slider": "^1.0.1",
-        "materialize-css": "^0.98.2"
+    "license": "Apache-2.0",
+    "author": "Coveo",
+    "main": "dist/js/PlasmaStyle.js",
+    "types": "index.d.ts",
+    "files": [
+        "dist",
+        "gulpTasks",
+        "scss/**/*.scss",
+        "lib",
+        "resources",
+        "gulpfile.js",
+        "LICENSE",
+        "index.d.ts",
+        "SvgName.d.ts"
+    ],
+    "scripts": {
+        "build": "gulp clean && gulp && webpack",
+        "clean": "gulp clean",
+        "lintfix": "../../node_modules/.bin/stylelint --fix \"**/*.scss\" && ../../node_modules/.bin/prettier --write \"**/*.{scss,js,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"**/*.js\" --fix",
+        "precommit": "lint-staged",
+        "start": "concurrently \"gulp watch\" \"webpack --watch\""
+    },
+    "lint-staged": {
+        "package.json": [
+            "sort-package-json",
+            "git add"
+        ],
+        "**/*.scss": [
+            "stylelint --fix",
+            "prettier --write",
+            "git add"
+        ],
+        "**/*.{js}": [
+            "eslint -c ./.eslintrc --fix",
+            "prettier --write",
+            "git add"
+        ],
+        "**/*.{js,json,md,yml,html}": [
+            "prettier --write",
+            "git add"
+        ]
+    },
+    "browserslist": [
+        "cover 90%",
+        "last 1 versions",
+        "IE 11",
+        "not dead"
+    ],
+    "dependencies": {
+        "codemirror": "^5.59.4",
+        "rc-slider": "8.7.1"
     },
     "devDependencies": {
         "ansi-colors": "4.1.1",
@@ -67,41 +103,9 @@
         "webpack": "4.46.0",
         "webpack-cli": "3.3.12"
     },
-    "dependencies": {
-        "codemirror": "^5.59.4",
-        "rc-slider": "8.7.1"
-    },
-    "files": [
-        "dist",
-        "gulpTasks",
-        "scss/**/*.scss",
-        "lib",
-        "resources",
-        "gulpfile.js",
-        "LICENSE",
-        "index.d.ts",
-        "SvgName.d.ts"
-    ],
-    "browserslist": [
-        "cover 90%",
-        "last 1 versions",
-        "IE 11",
-        "not dead"
-    ],
-    "lint-staged": {
-        "**/*.scss": [
-            "stylelint --fix",
-            "prettier --write",
-            "git add"
-        ],
-        "**/*.{js}": [
-            "eslint -c ./.eslintrc --fix",
-            "prettier --write",
-            "git add"
-        ],
-        "**/*.{js,json,md,yml,html}": [
-            "prettier --write",
-            "git add"
-        ]
+    "peerDependencies": {
+        "chosen-npm": "^1.4.2",
+        "coveo-slider": "^1.0.1",
+        "materialize-css": "^0.98.2"
     }
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -2,20 +2,36 @@
     "name": "@coveord/plasma-tokens",
     "version": "41.2.9",
     "description": "Design tokens of the Plasma Design System",
+    "homepage": "https://github.com/coveo/plasma/packages/tokens#readme",
     "repository": {
         "type": "git",
         "url": "https://github.com/coveo/plasma.git",
         "directory": "packages/tokens"
     },
-    "homepage": "https://github.com/coveo/plasma/packages/tokens#readme",
+    "license": "Apache-2.0",
+    "files": [
+        "dist",
+        "icons",
+        "scss"
+    ],
     "scripts": {
         "build": "rimraf dist && tsc --project tsconfig.json",
-        "tokens:fetch": "ts-node -r dotenv-safe/config --project ./bin/tsconfig.json ./bin/fetch.ts",
+        "precommit": "lint-staged",
         "tokens:build": "ts-node ./bin/build.ts --project ./bin/tsconfig.json && pnpm tokens:lint",
-        "tokens:lint": "prettier --write \"{src,scss,data}/*.{scss,ts,tsx,json}\"",
-        "precommit": "lint-staged"
+        "tokens:fetch": "ts-node -r dotenv-safe/config --project ./bin/tsconfig.json ./bin/fetch.ts",
+        "tokens:lint": "prettier --write \"{src,scss,data}/*.{scss,ts,tsx,json}\""
     },
-    "license": "Apache-2.0",
+    "lint-staged": {
+        "package.json": [
+            "sort-package-json",
+            "git add"
+        ],
+        "**/*.{ts,tsx,json,md,scss}": [
+            "prettier --write",
+            "git add"
+        ]
+    },
+    "prettier": "tsjs/prettier-config",
     "devDependencies": {
         "@types/fs-extra": "9.0.13",
         "@types/lodash": "4.14.182",
@@ -36,17 +52,5 @@
         "ts-node": "10.7.0",
         "tslib": "2.3.1",
         "typescript": "4.6.4"
-    },
-    "lint-staged": {
-        "**/*.{ts,tsx,json,md,scss}": [
-            "prettier --write",
-            "git add"
-        ]
-    },
-    "prettier": "tsjs/prettier-config",
-    "files": [
-        "dist",
-        "icons",
-        "scss"
-    ]
+    }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,21 +3,41 @@
     "version": "41.2.11",
     "private": true,
     "description": "Plasma Design System",
-    "main": "src/Index.ts",
-    "scripts": {
-        "start": "open-cli http://localhost:3000/ && next dev",
-        "build": "next build && next export && next-sitemap",
-        "prod:server": "next start",
-        "precommit": "lint-staged",
-        "clean": "rimraf dist built",
-        "lintfix": "../../node_modules/.bin/stylelint --fix \"**/*.scss\" && ../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"src/**/*.{ts,tsx}\" --fix"
-    },
-    "author": "Coveo",
-    "license": "Apache-2.0",
     "homepage": "https://plasma.coveo.com/",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/coveo/plasma.git"
+    },
+    "license": "Apache-2.0",
+    "author": "Coveo",
+    "main": "src/Index.ts",
+    "scripts": {
+        "build": "next build && next export && next-sitemap",
+        "clean": "rimraf dist built",
+        "lintfix": "../../node_modules/.bin/stylelint --fix \"**/*.scss\" && ../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"src/**/*.{ts,tsx}\" --fix",
+        "precommit": "lint-staged",
+        "prod:server": "next start",
+        "start": "open-cli http://localhost:3000/ && next dev"
+    },
+    "lint-staged": {
+        "package.json": [
+            "sort-package-json",
+            "git add"
+        ],
+        "**/*.scss": [
+            "stylelint --fix",
+            "prettier --write",
+            "git add"
+        ],
+        "**/*.{ts,tsx}": [
+            "prettier --write",
+            "eslint -c ./.eslintrc.js --fix",
+            "git add"
+        ],
+        "**/*.{js,jsx,json,md,yml,html}": [
+            "prettier --write",
+            "git add"
+        ]
     },
     "dependencies": {
         "@coveo/atomic-react": "0.5.8",
@@ -88,21 +108,5 @@
         "sass": "1.51.0",
         "tslib": "2.3.1",
         "typescript": "4.6.4"
-    },
-    "lint-staged": {
-        "**/*.scss": [
-            "stylelint --fix",
-            "prettier --write",
-            "git add"
-        ],
-        "**/*.{ts,tsx}": [
-            "prettier --write",
-            "eslint -c ./.eslintrc.js --fix",
-            "git add"
-        ],
-        "**/*.{js,jsx,json,md,yml,html}": [
-            "prettier --write",
-            "git add"
-        ]
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,10 @@ importers:
       cz-conventional-changelog: 3.3.0
       eslint: 8.14.0
       husky: 7.0.4
+      lint-staged: 9.5.0
       mime-types: 2.1.35
       prettier: 2.0.5
+      sort-package-json: 1.57.0
       stylelint: 13.13.1
       tsjs: 3.0.2
       ultra-runner: 3.10.5
@@ -36,8 +38,10 @@ importers:
       cz-conventional-changelog: 3.3.0
       eslint: 8.14.0
       husky: 7.0.4
+      lint-staged: 9.5.0
       mime-types: 2.1.35
       prettier: 2.0.5
+      sort-package-json: 1.57.0
       stylelint: 13.13.1
       tsjs: 3.0.2_fdlo723o4hk57utyojtrx726fa
       ultra-runner: 3.10.5
@@ -854,7 +858,7 @@ packages:
     resolution: {integrity: sha512-WxYHHUWF2uZ7Hp1K+D1xQgbgkGUfA+5UPOegEXGt2Y5SMog/rYCVaifLZDbw8UkNXozEqqrZTy6bglL7xTaCOw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      core-js-pure: 3.22.3
+      core-js-pure: 3.22.4
       regenerator-runtime: 0.13.9
     dev: true
 
@@ -1169,7 +1173,7 @@ packages:
       '@reduxjs/toolkit': 1.8.1_g7iv2n2puphpvmcbz4lgg4le54
       '@types/pino': 6.3.12
       '@types/redux-mock-store': 1.0.3
-      coveo.analytics: 2.19.9
+      coveo.analytics: 2.19.10
       cross-fetch: 3.1.5
       dayjs: 1.11.1
       exponential-backoff: 3.1.0
@@ -1198,7 +1202,7 @@ packages:
       '@types/pino': 6.3.12
       '@types/redux-mock-store': 1.0.3
       abab: 2.0.6
-      coveo.analytics: 2.19.9
+      coveo.analytics: 2.19.10
       cross-fetch: 3.1.5
       dayjs: 1.11.1
       exponential-backoff: 3.1.0
@@ -2512,14 +2516,14 @@ packages:
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 16.11.32
+      '@types/node': 17.0.31
     dev: true
 
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 16.11.32
+      '@types/node': 17.0.31
     dev: true
 
   /@types/graceful-fs/4.1.5:
@@ -2734,7 +2738,7 @@ packages:
     resolution: {integrity: sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 17.0.44
+      '@types/react': 18.0.8
       hoist-non-react-statics: 3.3.2
       redux: 4.2.0
 
@@ -2785,6 +2789,13 @@ packages:
       '@types/scheduler': 0.16.2
       csstype: 3.0.11
 
+  /@types/react/18.0.8:
+    resolution: {integrity: sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.2
+      csstype: 3.0.11
+
   /@types/reactcss/1.2.6:
     resolution: {integrity: sha512-qaIzpCuXNWomGR1Xq8SCFTtF4v8V27Y6f+b9+bzHiv087MylI/nTCqqdChNeWS7tslgROmYB7yeiruWX7WnqNg==}
     dependencies:
@@ -2815,7 +2826,7 @@ packages:
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
     dependencies:
       '@types/glob': 7.2.0
-      '@types/node': 16.11.32
+      '@types/node': 17.0.31
     dev: true
 
   /@types/scheduler/0.16.2:
@@ -2828,7 +2839,7 @@ packages:
   /@types/svgo/2.6.3:
     resolution: {integrity: sha512-5sP0Xgo0dXppY0tbYF6TevB/1+tzFLuu71XXxC/zGvQAn9PW7y+DwtDO81g0ZUPye00K6tPwtsLDOpARa0mFcA==}
     dependencies:
-      '@types/node': 16.11.32
+      '@types/node': 17.0.31
     dev: true
 
   /@types/tern/0.23.4:
@@ -2974,13 +2985,13 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.21.0_typescript@4.6.4:
-    resolution: {integrity: sha512-mzF6ert/6iQoESV0z9v5/mEaJRKL4fv68rHoZ6exM38xjxkw4MNx54B7ferrnMTM/GIRKLDaJ3JPRi+Dxa5Hlg==}
+  /@typescript-eslint/experimental-utils/5.22.0_typescript@4.6.4:
+    resolution: {integrity: sha512-rKxoCUtAHwEH6IcAoVpqipY6Th+YKW7WFspAKu0IFdbdKZpveFBeqxxE9Xn+GWikhq1o03V3VXbxIe+GdhggiQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.21.0_typescript@4.6.4
+      '@typescript-eslint/utils': 5.22.0_typescript@4.6.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3033,6 +3044,14 @@ packages:
       '@typescript-eslint/visitor-keys': 5.21.0
     dev: true
 
+  /@typescript-eslint/scope-manager/5.22.0:
+    resolution: {integrity: sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.22.0
+      '@typescript-eslint/visitor-keys': 5.22.0
+    dev: true
+
   /@typescript-eslint/type-utils/5.21.0_typescript@4.6.4:
     resolution: {integrity: sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3058,6 +3077,11 @@ packages:
 
   /@typescript-eslint/types/5.21.0:
     resolution: {integrity: sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types/5.22.0:
+    resolution: {integrity: sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -3103,6 +3127,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.22.0_typescript@4.6.4:
+    resolution: {integrity: sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.22.0
+      '@typescript-eslint/visitor-keys': 5.22.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.6.4
+      typescript: 4.6.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils/5.21.0_typescript@4.6.4:
     resolution: {integrity: sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3113,6 +3158,23 @@ packages:
       '@typescript-eslint/scope-manager': 5.21.0
       '@typescript-eslint/types': 5.21.0
       '@typescript-eslint/typescript-estree': 5.21.0_typescript@4.6.4
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils/5.22.0_typescript@4.6.4:
+    resolution: {integrity: sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.22.0
+      '@typescript-eslint/types': 5.22.0
+      '@typescript-eslint/typescript-estree': 5.22.0_typescript@4.6.4
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0
     transitivePeerDependencies:
@@ -3132,6 +3194,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.21.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.22.0:
+    resolution: {integrity: sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.22.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -4251,7 +4321,7 @@ packages:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.1.13
+      ieee754: 1.2.1
       isarray: 1.0.0
     dev: true
 
@@ -4278,7 +4348,7 @@ packages:
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
       promise-inflight: 1.0.1
-      rimraf: 2.7.1
+      rimraf: 2.6.3
       ssri: 6.0.2
       unique-filename: 1.1.1
       y18n: 4.0.3
@@ -5007,7 +5077,7 @@ packages:
       fs-write-stream-atomic: 1.0.10
       iferr: 0.1.5
       mkdirp: 0.5.6
-      rimraf: 2.7.1
+      rimraf: 2.6.3
       run-queue: 1.0.3
     dev: true
 
@@ -5023,8 +5093,8 @@ packages:
       is-plain-object: 5.0.0
     dev: true
 
-  /core-js-pure/3.22.3:
-    resolution: {integrity: sha512-oN88zz7nmKROMy8GOjs+LN+0LedIvbMdnB5XsTlhcOg1WGARt9l0LFg0zohdoFmCsEZ1h2ZbSQ6azj3M+vhzwQ==}
+  /core-js-pure/3.22.4:
+    resolution: {integrity: sha512-4iF+QZkpzIz0prAFuepmxwJ2h5t4agvE8WPYqs2mjLJMNNwJOnpch76w2Q7bUfCPEv/V7wpvOfog0w273M+ZSw==}
     requiresBuild: true
     dev: true
 
@@ -5118,8 +5188,8 @@ packages:
       rc-slider: 8.7.1
     dev: false
 
-  /coveo.analytics/2.19.9:
-    resolution: {integrity: sha512-S5PJs+J7PyjUkEU1KGjfpoKcGPDcz7RC558euJpnqPxoP13KJgUCaqpwRJi55iGDAae/fSnSWEPqmmsZtzqHQg==}
+  /coveo.analytics/2.19.10:
+    resolution: {integrity: sha512-LrGxp4Vk3DXijlJG9TYlMssR+pS2hdutO2hnP+23dM7rhmaWxx5kIPYR6fC4cAzfMd1yrPTGIOjkJrGhnsm/Iw==}
     dependencies:
       '@react-native-async-storage/async-storage': 1.17.3
       cross-fetch: 3.1.5
@@ -5868,7 +5938,7 @@ packages:
   /domutils/1.5.1:
     resolution: {integrity: sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=}
     dependencies:
-      dom-serializer: 0.1.1
+      dom-serializer: 0.2.2
       domelementtype: 1.3.1
     dev: true
 
@@ -6253,7 +6323,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.21.0_3zcv2rgeu7r2itzbj2gs5m4rda
-      '@typescript-eslint/experimental-utils': 5.21.0_typescript@4.6.4
+      '@typescript-eslint/experimental-utils': 5.22.0_typescript@4.6.4
       jest: 28.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6341,7 +6411,7 @@ packages:
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.21.0_typescript@4.6.4
+      '@typescript-eslint/utils': 5.22.0_typescript@4.6.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7185,7 +7255,7 @@ packages:
       graceful-fs: 4.2.10
       inherits: 2.0.4
       mkdirp: 0.5.6
-      rimraf: 2.7.1
+      rimraf: 2.6.3
     dev: true
 
   /function-bind/1.1.1:
@@ -7274,6 +7344,10 @@ packages:
   /get-value/2.0.6:
     resolution: {integrity: sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /git-hooks-list/1.0.3:
+    resolution: {integrity: sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==}
     dev: true
 
   /git-raw-commits/2.0.11:
@@ -7416,6 +7490,20 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: true
+
+  /globby/10.0.0:
+    resolution: {integrity: sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/glob': 7.2.0
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.2.11
+      glob: 7.2.0
+      ignore: 5.2.0
+      merge2: 1.4.1
+      slash: 3.0.0
     dev: true
 
   /globby/10.0.2:
@@ -10703,7 +10791,7 @@ packages:
       copy-concurrently: 1.0.5
       fs-write-stream-atomic: 1.0.10
       mkdirp: 0.5.6
-      rimraf: 2.7.1
+      rimraf: 2.6.3
       run-queue: 1.0.3
     dev: true
 
@@ -10743,8 +10831,8 @@ packages:
     dev: true
     optional: true
 
-  /nanoid/3.3.3:
-    resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10918,7 +11006,7 @@ packages:
       os-browserify: 0.3.0
       path-browserify: 0.0.1
       process: 0.11.10
-      punycode: 1.4.1
+      punycode: 1.3.2
       querystring-es3: 0.2.1
       readable-stream: 2.3.7
       stream-browserify: 2.0.2
@@ -11474,7 +11562,7 @@ packages:
       klaw-sync: 6.0.0
       minimist: 1.2.6
       open: 7.4.2
-      rimraf: 2.7.1
+      rimraf: 2.6.3
       semver: 5.7.1
       slash: 2.0.0
       tmp: 0.0.33
@@ -12154,7 +12242,7 @@ packages:
     resolution: {integrity: sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.3
+      nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: true
@@ -12163,7 +12251,7 @@ packages:
     resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.3
+      nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: false
@@ -12335,10 +12423,6 @@ packages:
 
   /punycode/1.3.2:
     resolution: {integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=}
-    dev: true
-
-  /punycode/1.4.1:
-    resolution: {integrity: sha1-wNWmOycYgArY4esPpSachN1BhF4=}
     dev: true
 
   /punycode/2.1.1:
@@ -13313,11 +13397,6 @@ packages:
     engines: {node: '>= 0.10'}
     dev: true
 
-  /replace-ext/1.0.1:
-    resolution: {integrity: sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==}
-    engines: {node: '>= 0.10'}
-    dev: true
-
   /replace-homedir/1.0.0:
     resolution: {integrity: sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=}
     engines: {node: '>= 0.10'}
@@ -13487,13 +13566,6 @@ packages:
 
   /rimraf/2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
-    hasBin: true
-    dependencies:
-      glob: 7.2.0
-    dev: true
-
-  /rimraf/2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
     hasBin: true
     dependencies:
       glob: 7.2.0
@@ -13855,6 +13927,22 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-plain-obj: 1.1.0
+    dev: true
+
+  /sort-object-keys/1.1.3:
+    resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
+    dev: true
+
+  /sort-package-json/1.57.0:
+    resolution: {integrity: sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==}
+    hasBin: true
+    dependencies:
+      detect-indent: 6.0.0
+      detect-newline: 3.1.0
+      git-hooks-list: 1.0.3
+      globby: 10.0.0
+      is-plain-obj: 2.1.0
+      sort-object-keys: 1.1.3
     dev: true
 
   /source-list-map/2.0.1:
@@ -15225,6 +15313,7 @@ packages:
     resolution: {integrity: sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+    requiresBuild: true
     dev: true
 
   /ultra-runner/3.10.5:
@@ -15820,7 +15909,7 @@ packages:
       clone-stats: 1.0.0
       cloneable-readable: 1.1.3
       remove-trailing-separator: 1.1.0
-      replace-ext: 1.0.1
+      replace-ext: 1.0.0
     dev: true
 
   /vinyl/2.2.1:
@@ -15832,7 +15921,7 @@ packages:
       clone-stats: 1.0.0
       cloneable-readable: 1.1.3
       remove-trailing-separator: 1.1.0
-      replace-ext: 1.0.1
+      replace-ext: 1.0.0
     dev: true
 
   /vm-browserify/1.1.2:


### PR DESCRIPTION
### Proposed Changes

Instead of manually sorting stuff inside package.json files, I added something ([`sort-package-json`](https://www.npmjs.com/package/sort-package-json)) that will automatically sort package.json files on pre-commit when they are staged. Now all our package.json files will always stay ordered in the same way.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
