### PR TITLE
fix(pagination): fix font color when selected

### DIFF
--- a/packages/style/scss/tables/pagination.scss
+++ b/packages/style/scss/tables/pagination.scss
@@ -56,10 +56,12 @@
     }
 
     .flat-select .flat-select-option {
+        color: var(--white);
         background-color: var(--digital-blue-60);
         border: 1px solid var(--digital-blue-60);
 
         &.selectable {
+            color: var(--digital-blue-80);
             background-color: var(--white);
             border: $default-border;
         }


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-663

The pagination is using the flat-select css classes and when I did the MVP for the flat select, some on the colors for the font were changed. I fixed them 👍 

To test, go in the Table page and scroll down until you get to the example with pagination.

Before:

![image](https://user-images.githubusercontent.com/63734941/167401815-47ca39cd-f998-454b-97bf-19dd1e4520e8.png)

After:

![image](https://user-images.githubusercontent.com/63734941/167401758-5456e509-45f2-4f59-b90b-155f972fafd4.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
