### PR TITLE
fix(checkbox): fix checkbox disabled tooltip

### DIFF
--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -66,7 +66,11 @@ export class Checkbox extends Component<ICheckboxProps> {
             {disabled: !!this.props.disabled, 'checkbox-clear': this.props.clearSides},
             this.props.classes
         );
-        const innerInputClasses: string = classNames('react-vapor-checkbox', this.props.innerInputClasses);
+        const innerInputClasses: string = classNames(
+            {'checkbox checkbox-label': !!this.props.disabledTooltip},
+            'react-vapor-checkbox',
+            this.props.innerInputClasses
+        );
         const hasChildren = Children.count(this.props.children) > 0;
         const labelId = hasChildren && this.props.id ? `checkbox-${this.props.id}` : labeledBy;
         return (
@@ -77,6 +81,7 @@ export class Checkbox extends Component<ICheckboxProps> {
                 type="checkbox"
                 onClick={(e: MouseEvent<HTMLElement>) => this.handleOnClick(e)}
                 readOnly
+                tooltipClasses={this.props.disabledTooltip ? 'flex center-align' : null}
             >
                 <button
                     type="button"

--- a/packages/react/src/components/checkbox/tests/Checkbox.spec.tsx
+++ b/packages/react/src/components/checkbox/tests/Checkbox.spec.tsx
@@ -128,5 +128,12 @@ describe('Checkbox', () => {
             );
             expect(screen.getByRole('checkbox', {name: 'custom label'})).toBeVisible();
         });
+
+        it('a disabled checkbox with tooltip should set classes on tooltip', () => {
+            render(<Checkbox id="my-test" aria-labelledby="hover me" disabled disabledTooltip="test tooltip" />);
+
+            const tooltipContent = document.querySelector('.input-wrapper > span');
+            expect(tooltipContent).toHaveClass('flex center-align');
+        });
     });
 });

--- a/packages/react/src/components/input/Input.tsx
+++ b/packages/react/src/components/input/Input.tsx
@@ -241,11 +241,11 @@ export class Input extends Component<IInputProps, IInputComponentState> {
         ];
 
         return (this.props.disabled || this.props.isReadOnly) && this.props.disabledTooltip ? (
-            <div className={classes} onClick={(e: MouseEvent<HTMLElement>) => this.handleClick(e)}>
-                <Tooltip title={this.props.disabledTooltip} placement={TooltipPlacement.Right}>
+            <Tooltip title={this.props.disabledTooltip} placement={TooltipPlacement.Right}>
+                <div className={classes} onClick={(e: MouseEvent<HTMLElement>) => this.handleClick(e)}>
                     {inputElements}
-                </Tooltip>
-            </div>
+                </div>
+            </Tooltip>
         ) : (
             <div className={classes} onClick={(e: MouseEvent<HTMLElement>) => this.handleClick(e)}>
                 {inputElements}

--- a/packages/react/src/components/input/Input.tsx
+++ b/packages/react/src/components/input/Input.tsx
@@ -38,6 +38,7 @@ export interface IInputAdditionalOwnProps {
     onChangeHandler?: ChangeEventHandler<HTMLInputElement>;
     defaultValue?: string;
     isReadOnly?: boolean;
+    tooltipClasses?: IClassName;
 }
 
 export interface IInputNativeTagStateProps {
@@ -241,11 +242,15 @@ export class Input extends Component<IInputProps, IInputComponentState> {
         ];
 
         return (this.props.disabled || this.props.isReadOnly) && this.props.disabledTooltip ? (
-            <Tooltip title={this.props.disabledTooltip} placement={TooltipPlacement.Right}>
-                <div className={classes} onClick={(e: MouseEvent<HTMLElement>) => this.handleClick(e)}>
+            <div className={classes} onClick={(e: MouseEvent<HTMLElement>) => this.handleClick(e)}>
+                <Tooltip
+                    title={this.props.disabledTooltip}
+                    placement={TooltipPlacement.Right}
+                    className={this.props.tooltipClasses}
+                >
                     {inputElements}
-                </div>
-            </Tooltip>
+                </Tooltip>
+            </div>
         ) : (
             <div className={classes} onClick={(e: MouseEvent<HTMLElement>) => this.handleClick(e)}>
                 {inputElements}

--- a/packages/react/src/components/input/Input.tsx
+++ b/packages/react/src/components/input/Input.tsx
@@ -25,6 +25,7 @@ export interface IInputAdditionalOwnProps {
     id?: string;
     classes?: IClassName;
     innerInputClasses?: IClassName;
+    tooltipClasses?: string;
     validate?: (value: any) => boolean;
     labelTitle?: ReactNode;
     labelProps?: ILabelProps;
@@ -38,7 +39,6 @@ export interface IInputAdditionalOwnProps {
     onChangeHandler?: ChangeEventHandler<HTMLInputElement>;
     defaultValue?: string;
     isReadOnly?: boolean;
-    tooltipClasses?: IClassName;
 }
 
 export interface IInputNativeTagStateProps {

--- a/packages/react/src/components/input/tests/Input.spec.tsx
+++ b/packages/react/src/components/input/tests/Input.spec.tsx
@@ -257,6 +257,20 @@ describe('<Input />', () => {
                 expect(input.find(Tooltip).props().title).toBe(disabledTooltip);
                 expect(input.find(Tooltip).find('input').length).toBe(1);
             });
+
+            describe('with tooltipClasses', () => {
+                it('should set the given class to the tooltip element', () => {
+                    const disabledTooltip = 'i am truthy';
+                    const tooltipClasses = 'test-class';
+                    shallowInput({
+                        disabled: true,
+                        disabledTooltip,
+                        tooltipClasses,
+                    });
+
+                    expect(input.find(Tooltip).hasClass(tooltipClasses)).toBe(true);
+                });
+            });
         });
     });
 });

--- a/packages/react/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
+++ b/packages/react/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
@@ -91,7 +91,7 @@ describe('MultiValuesInput', () => {
             />
         );
 
-        expect(screen.getAllByRole('textbox')[3].parentElement.parentElement).toHaveAttribute('aria-labelledby');
+        expect(screen.getAllByRole('textbox')[3].parentElement).toHaveAttribute('aria-labelledby');
         userEvent.hover(screen.getAllByRole('textbox')[3].parentElement);
 
         expect(await screen.findByText('You have no power here')).toBeVisible();

--- a/packages/react/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
+++ b/packages/react/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
@@ -91,7 +91,7 @@ describe('MultiValuesInput', () => {
             />
         );
 
-        expect(screen.getAllByRole('textbox')[3].parentElement).toHaveAttribute('aria-labelledby');
+        expect(screen.getAllByRole('textbox')[3].parentElement.parentElement).toHaveAttribute('aria-labelledby');
         userEvent.hover(screen.getAllByRole('textbox')[3].parentElement);
 
         expect(await screen.findByText('You have no power here')).toBeVisible();

--- a/packages/style/scss/controls/checkboxes.scss
+++ b/packages/style/scss/controls/checkboxes.scss
@@ -138,7 +138,8 @@
             display: flex;
         }
 
-        > label {
+        > label,
+        > span > label {
             margin-right: calc(4 * 0.5rem);
             margin-left: 18px;
             cursor: pointer;


### PR DESCRIPTION
### Proposed Changes

Issue we're trying to fix:

<img width="924" alt="Screen Shot 2022-05-09 at 12 00 47 PM" src="https://user-images.githubusercontent.com/16785453/167466444-0265ec99-ac8f-46b6-a34a-dc29b227e31d.png">

- Added prop to Input to set classes on the Tooltip`<span></span>` element as putting it in between the container and the content would break the styling.
- Modified css rule to account for possible tooltip being inserted.
ex:
  - checkbox container has a flex display
  - span wrapping the content breaks the arrangement and clashes with some css settings which function by specifying a descendant tree.

<img width="159" alt="Screen Shot 2022-05-09 at 1 41 12 PM" src="https://user-images.githubusercontent.com/16785453/167466600-dec544fd-5323-4a70-91a5-3b2e3392922d.png">
<img width="378" alt="Screen Shot 2022-05-09 at 1 40 57 PM" src="https://user-images.githubusercontent.com/16785453/167466604-dc5691d5-a4d0-4c12-b7d5-041d8490ccd5.png">
<img width="402" alt="Screen Shot 2022-05-09 at 1 40 50 PM" src="https://user-images.githubusercontent.com/16785453/167466605-c4e8a6f3-a2e7-417d-b98c-a749f89644dc.png">

After change
<img width="949" alt="Screen Shot 2022-05-09 at 1 46 15 PM" src="https://user-images.githubusercontent.com/16785453/167467434-1c7d815b-3bac-4de7-9f06-99fabc5e9bc1.png">


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
