### PR TITLE
Button guidelines order

### DIFF
--- a/packages/website/docs/Button.md
+++ b/packages/website/docs/Button.md
@@ -1,4 +1,4 @@
-a# Best Practices
+# Best Practices
 
 The button label should allow users to **foresee what will happen** when clicking them.
 
@@ -23,7 +23,7 @@ For example, in the [Sticky footer](https://plasma.coveo.com/layout/StickyFooter
 
 Similarly, in the footer of a [modal wizard](https://plasma.coveo.com/layout/ModalWizard), navigation buttons must be ordered as follows: "Previous" (secondary), then "Next" (primary). At the last step, the “Next” button must be replaced with a primary button with a label indicating the resulting action. For example, an appropriate label would be “Add filter” rather than “Save”.
 
-For buttons located in a [page header](https://plasma.coveo.com/layout/PageHeader), always put **the primary button to the left** instead and the secondary to the right of the primary button. In a page header, the primary action usually relates to the creation of new elements, while secondary actions are usually used to trigger troubleshooting or management actions, such as activity review. If multiple secondary actions are required, regroup them using a [actionable item](https://plasma.coveo.com/form/ActionableItem) on the rightmost side of the header. 
+In a [page header](https://plasma.coveo.com/layout/PageHeader), **the primary button should appear on the left** and the secondary button should be to the right of the primary button. The primary action usually relates to the creation of new elements, while secondary actions are usually used to trigger troubleshooting or management actions, such as activity review. If multiple secondary actions are required, group them using an [actionable item](https://plasma.coveo.com/form/ActionableItem) on the rightmost side of the header. 
 
 # Variants
 

--- a/packages/website/docs/Button.md
+++ b/packages/website/docs/Button.md
@@ -1,4 +1,4 @@
-# Best Practices
+a# Best Practices
 
 The button label should allow users to **foresee what will happen** when clicking them.
 
@@ -23,7 +23,7 @@ For example, in the [Sticky footer](https://plasma.coveo.com/layout/StickyFooter
 
 Similarly, in the footer of a [modal wizard](https://plasma.coveo.com/layout/ModalWizard), navigation buttons must be ordered as follows: "Previous" (secondary), then "Next" (primary). At the last step, the “Next” button must be replaced with a primary button with a label indicating the resulting action. For example, an appropriate label would be “Add filter” rather than “Save”.
 
-Buttons located in a [page header](https://plasma.coveo.com/layout/PageHeader) must also appear in the order described above. The primary action must appear on the rightmost side with the secondary actions to the left of this button. In a page header, the primary action usually relates to the creation of new elements, while secondary actions are usually used to trigger troubleshooting or management actions, such as activity review.
+For buttons located in a [page header](https://plasma.coveo.com/layout/PageHeader), always put **the primary button to the left** instead and the secondary to the right of the primary button. In a page header, the primary action usually relates to the creation of new elements, while secondary actions are usually used to trigger troubleshooting or management actions, such as activity review. If multiple secondary actions are required, regroup them using a [actionable item](https://plasma.coveo.com/form/ActionableItem) on the rightmost side of the header. 
 
 # Variants
 


### PR DESCRIPTION
Updated the guidelines related to the order of the buttons that appear in the header.

### Proposed Changes

After much investigation, we came to the decision that that the primary button for this group of button should remain on the left side of the group of buttons.
The principal reason for this change of guidelines is that the we wanted to make sure that the order of actions was consistent with their order importance and the logical reading order.
Since we have a couple of occurrences where the header contains additional secondary actions grouped under the […] (more/actionable items) button, having that button on the right felt wrong.

Read the detailed guidelines here for additional details: https://coveord.atlassian.net/wiki/spaces/UX/pages/3063545872/Header+button+ordering


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
