### PR TITLE
feat(iconbadge): removed svg and using new icons

### DIFF
--- a/packages/react/src/components/iconBadge/IconBadge.tsx
+++ b/packages/react/src/components/iconBadge/IconBadge.tsx
@@ -1,8 +1,6 @@
-import {SvgName} from '@coveord/plasma-style';
+import {Icon} from '@coveord/plasma-react-icons';
 import classNames from 'classnames';
 import {FunctionComponent} from 'react';
-
-import {Svg} from '../svg';
 
 export enum IconBadgeSize {
     Medium,
@@ -19,7 +17,7 @@ export interface IconBadgeProps {
     /**
      * Icon to display
      */
-    svgName: SvgName;
+    icon: Icon;
     /**
      * Type of the icon badge (New - Information - Warning - Major)
      */
@@ -31,7 +29,7 @@ export interface IconBadgeProps {
      */
     size?: IconBadgeSize;
     /**
-     * Additionnal CSS class for the icon
+     * @deprecated will have no effet
      */
     svgClass?: string;
     /**
@@ -51,16 +49,12 @@ const TypeColorMapping: Record<IconBadgeType, string> = {
     [IconBadgeType.Major]: 'mod-major',
 };
 
-export const IconBadge: FunctionComponent<IconBadgeProps> = ({
-    svgName,
-    type,
-    size = IconBadgeSize.Medium,
-    svgClass,
-    className,
-}) => (
-    <Svg
-        className={classNames('icon-badge', SizeClassMapping[size], TypeColorMapping[type], className)}
-        svgName={svgName}
-        svgClass={classNames('icon align-middle', SizeClassMapping[size], svgClass)}
-    />
-);
+export const IconBadge: FunctionComponent<IconBadgeProps> = ({icon, type, size = IconBadgeSize.Medium, className}) => {
+    const IconName = icon;
+
+    return (
+        <div className={classNames('icon-badge', SizeClassMapping[size], TypeColorMapping[type], className)}>
+            <IconName height={24} className={classNames('align-middle')} />
+        </div>
+    );
+};

--- a/packages/react/src/components/iconBadge/tests/IconBadge.spec.tsx
+++ b/packages/react/src/components/iconBadge/tests/IconBadge.spec.tsx
@@ -1,38 +1,46 @@
 import {render, screen} from '@test-utils';
-import {svg} from '@coveord/plasma-style';
 
+import {BellSize16Px} from '@coveord/plasma-react-icons';
 import {IconBadge, IconBadgeType} from '../IconBadge';
 
 describe('IconBadge', () => {
-    it('renders the specified icon with the type New, and size Medium by default', () => {
-        render(<IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.New} />);
+    it('renders the specified icon with the type New, and size Medium by default', async () => {
+        render(<IconBadge icon={BellSize16Px} type={IconBadgeType.New} />);
 
-        const iconBadge = screen.getByRole('img', {name: 'bellStrokedMedium icon'}).parentElement;
+        await screen.findByRole('img', {name: 'bell'});
+        const iconBadge = screen.getByRole('img', {name: 'bell'}).parentElement;
+
         expect(iconBadge).toBeInTheDocument();
         expect(iconBadge).toHaveClass('mod-24');
         expect(iconBadge).toHaveClass('mod-new');
     });
 
-    it('renders the specified icon with the type Information', () => {
-        render(<IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.Information} />);
+    it('renders the specified icon with the type Information', async () => {
+        render(<IconBadge icon={BellSize16Px} type={IconBadgeType.Information} />);
 
-        const iconBadge = screen.getByRole('img', {name: 'bellStrokedMedium icon'}).parentElement;
+        await screen.findByRole('img', {name: 'bell'});
+        const iconBadge = screen.getByRole('img', {name: 'bell'}).parentElement;
+
         expect(iconBadge).toBeInTheDocument();
         expect(iconBadge).toHaveClass('mod-info');
     });
 
-    it('renders the specified icon with the type Warning', () => {
-        render(<IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.Warning} />);
+    it('renders the specified icon with the type Warning', async () => {
+        render(<IconBadge icon={BellSize16Px} type={IconBadgeType.Warning} />);
 
-        const iconBadge = screen.getByRole('img', {name: 'bellStrokedMedium icon'}).parentElement;
+        await screen.findByRole('img', {name: 'bell'});
+        const iconBadge = screen.getByRole('img', {name: 'bell'}).parentElement;
+
         expect(iconBadge).toBeInTheDocument();
         expect(iconBadge).toHaveClass('mod-warning');
     });
 
-    it('renders the specified icon with the type Major', () => {
-        render(<IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.Major} />);
+    it('renders the specified icon with the type Major', async () => {
+        render(<IconBadge icon={BellSize16Px} type={IconBadgeType.Major} />);
 
-        const iconBadge = screen.getByRole('img', {name: 'bellStrokedMedium icon'}).parentElement;
+        await screen.findByRole('img', {name: 'bell'});
+        const iconBadge = screen.getByRole('img', {name: 'bell'}).parentElement;
+
         expect(iconBadge).toBeInTheDocument();
         expect(iconBadge).toHaveClass('mod-major');
     });

--- a/packages/website/src/pages/feedback/IconBadge.tsx
+++ b/packages/website/src/pages/feedback/IconBadge.tsx
@@ -2,28 +2,26 @@ import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
     import {IconBadge, IconBadgeType} from '@coveord/plasma-react';
+    import {BellSize16Px}  from '@coveord/plasma-react-icons'
 
     export default () => (
         <>
             <IconBadge
-                svgName={"bellStrokedMedium"}
+                icon={BellSize16Px}
                 type={IconBadgeType.New}
-                svgClass="mod-stroke"
                 className="mr1"
             />
             <IconBadge
-                svgName={"bellStrokedMedium"}
+                icon={BellSize16Px}
                 type={IconBadgeType.Information}
-                svgClass="mod-stroke"
                 className="mr1"
             />
             <IconBadge
-                svgName={"bellStrokedMedium"}
+                icon={BellSize16Px}
                 type={IconBadgeType.Warning}
-                svgClass="mod-stroke"
                 className="mr1"
             />
-            <IconBadge svgName={"bellStrokedMedium"} type={IconBadgeType.Major} svgClass="mod-stroke" />
+            <IconBadge icon={BellSize16Px} type={IconBadgeType.Major} />
         </>
     );
 `;

--- a/packages/website/src/pages/foundations/Links.tsx
+++ b/packages/website/src/pages/foundations/Links.tsx
@@ -2,7 +2,7 @@ import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
     import {TargetSize16Px} from '@coveord/plasma-react-icons';
-    
+
     export default () => (
         <a className="link" href="/foundations/Links">
             Link <TargetSize16Px height={16} />
@@ -12,7 +12,7 @@ const code = `
 
 const disabledLink = `
     import {TargetSize16Px} from '@coveord/plasma-react-icons';
-    
+
     export default () => (
         <a className="link disabled" href="/foundations/Links">
             Link <TargetSize16Px height={16} />
@@ -22,7 +22,7 @@ const disabledLink = `
 
 const buttonLink = `
     import {TargetSize16Px} from '@coveord/plasma-react-icons';
-    
+
     export default () => (
         <button className="link" onClick={() => alert('The button was clicked')}>
             Link <TargetSize16Px height={16} />


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-675

Before: 

![image](https://user-images.githubusercontent.com/63734941/167706168-7e6bf206-8f37-4901-b8a0-36cbb5fbf93e.png)

After:

![image](https://user-images.githubusercontent.com/63734941/167706121-4e46d0f9-ea99-4d04-ba7e-873d657ee091.png)


### Potential Breaking Changes

`svgClasses` is now deprecated and using it will have no effect on the style of the icon.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
