### PR TITLE
fix(website): create a new store for each sandbox

### DIFF
--- a/packages/website/src/Store.ts
+++ b/packages/website/src/Store.ts
@@ -12,8 +12,3 @@ export const Store = createStore(
     combineReducers(PlasmaReducers),
     composeEnhancers(applyMiddleware<IDispatch>(...middlewares))
 );
-
-if (typeof window !== 'undefined') {
-    // Required for the dynamic examples
-    (window as any).Store = Store;
-}

--- a/packages/website/src/building-blocs/Sandbox.tsx
+++ b/packages/website/src/building-blocs/Sandbox.tsx
@@ -84,7 +84,8 @@ export const Sandbox: FunctionComponent<{children: string; id: string; title?: s
                     .replace(/_loremIpsum/g, 'LoremIpsum')
                     .replaceAll('(0, _moment).default', 'moment') // replace the moment object
                     .replace(/_moment.default/g, 'moment') + // replace the moment() function
-                `ReactDOM.render(jsxRuntime.jsx(ReactRedux.Provider, {store: Store, children: jsxRuntime.jsx(_default, {})}), document.getElementById('${id}'));`;
+                `const store = Redux.createStore(Redux.combineReducers(PlasmaReact.PlasmaReducers, Redux.applyMiddleware(ThunkMiddleware, PromiseMiddleware)));
+                ReactDOM.render(jsxRuntime.jsx(ReactRedux.Provider, {store, children: jsxRuntime.jsx(_default, {})}), document.getElementById('${id}'));`;
 
             // eslint-disable-next-line no-eval
             eval(userCodeToEvaluate);

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -22,6 +22,8 @@ import * as ReactDOM from 'react-dom';
 import * as ReactRedux from 'react-redux';
 import * as jsxRuntime from 'react/jsx-runtime';
 import * as Redux from 'redux';
+import promise from 'redux-promise-middleware';
+import thunk from 'redux-thunk';
 import * as React from 'react';
 
 import logo from '../../resources/plasma-logo.svg';
@@ -61,6 +63,8 @@ const MyApp = ({Component, pageProps}: AppProps) => {
         (window as any).moment = moment;
         (window as any).LoremIpsum = LoremIpsum;
         (window as any).Redux = Redux;
+        (window as any).PromiseMiddleware = promise;
+        (window as any).ThunkMiddleware = thunk;
 
         if (window.location.host === 'vapor.coveo.com') {
             window.location.href = window.location.href.replace('vapor.coveo.com', 'plasma.coveo.com');


### PR DESCRIPTION
### Proposed Changes

We had some issues when changing page in the demo. We weren't cleaning the store so the sandbox could break in some case. In this PR I create a new Redux Store for every sandbox.

Every time you change the store it is re-created which mean you lose the state. In the future we could do some improvement to keep the state, but still make it unique per Sandbox.

### Potential Breaking Changes

None, only affects the website

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
