### PR TITLE
chore(publish): fix publish script

### DIFF
--- a/build/publishNewVersion.mjs
+++ b/build/publishNewVersion.mjs
@@ -3,7 +3,6 @@ import {
     getLastTag,
     getNextVersion,
     getCommits,
-    getCurrentVersion,
     getRemoteName,
     gitPush,
     gitPushTags,
@@ -71,7 +70,7 @@ const outputProcess = (process) => {
             bumpInfo = convention.recommendedBumpOpts.whatBump(parsedCommits);
         }
 
-        const currentVersion = getCurrentVersion(PATH);
+        const currentVersion = {version: lastTag.replace(VERSION_PREFIX, '')};
         const newVersion = getNextVersion(currentVersion, bumpInfo);
 
         if (newVersion !== currentVersion) {


### PR DESCRIPTION
### Proposed Changes

The way PNPM works changed and now it doesn't bump the root package.json version. So in this PR I rely on the tag instead

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
