### PR TITLE
fix(navigation): revert css style for state-locked nav

### DIFF
--- a/packages/style/scss/components/navigation.scss
+++ b/packages/style/scss/components/navigation.scss
@@ -119,7 +119,6 @@
 
                         &.disabled {
                             cursor: default;
-                            pointer-events: none;
                             .navigation-menu-section-item-link {
                                 color: var(--grey-60);
                             }
@@ -148,7 +147,6 @@
 
                             &.state-locked {
                                 color: $navigation-locked-color;
-                                pointer-events: none;
                             }
                             .navigation-menu-section-item-link-name,
                             .navigation-menu-section-item-link-icon {


### PR DESCRIPTION
### Proposed Changes

reverting this https://github.com/coveo/plasma/pull/2669. instead I used the disabled props from the SideNavigationItem and it works like a charm

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
