### PR TITLE
feat(subnav): add a description in subnav

### DIFF
--- a/packages/react/src/components/subNavigation/SubNavigation.tsx
+++ b/packages/react/src/components/subNavigation/SubNavigation.tsx
@@ -88,7 +88,7 @@ export const SubNavigation: FunctionComponent<ISubNavigationProps & HTMLAttribut
                 </a>
                 {description && (
                     <SlideY in={openDescription}>
-                        <div className={classNames('sub-navigation-item-description')}>{description}</div>
+                        <div className="sub-navigation-item-description body-m-book-subdued">{description}</div>
                     </SlideY>
                 )}
             </li>

--- a/packages/react/src/components/subNavigation/SubNavigation.tsx
+++ b/packages/react/src/components/subNavigation/SubNavigation.tsx
@@ -93,9 +93,7 @@ export const SubNavigation: FunctionComponent<ISubNavigationProps & HTMLAttribut
                             ? createElement(
                                   'div',
                                   {
-                                      className: description
-                                          ? 'sub-navigation-item-link-with-description-label'
-                                          : 'sub-navigation-item-link-with-description-label-solo',
+                                      className: 'sub-navigation-item-link-with-description-label',
                                   },
                                   `${label}`
                               )

--- a/packages/react/src/components/subNavigation/SubNavigation.tsx
+++ b/packages/react/src/components/subNavigation/SubNavigation.tsx
@@ -83,7 +83,11 @@ export const SubNavigation: FunctionComponent<ISubNavigationProps & HTMLAttribut
             <li key={id} className={classNames('sub-navigation-item', {'mod-selected': id === selectedItem})}>
                 <a
                     href={link}
-                    className={classNames('sub-navigation-item-link', {disabled})}
+                    className={classNames(
+                        {'sub-navigation-item-link': !description},
+                        {'sub-navigation-item-link-with-description': description},
+                        {disabled}
+                    )}
                     onClick={(e: MouseEvent<HTMLAnchorElement>) => handleItemClick(e, id)}
                 >
                     {label}

--- a/packages/react/src/components/subNavigation/SubNavigation.tsx
+++ b/packages/react/src/components/subNavigation/SubNavigation.tsx
@@ -77,7 +77,7 @@ export const SubNavigation: FunctionComponent<ISubNavigationProps & HTMLAttribut
     };
     const selectedItem = selected || defaultSelected;
 
-    const navItemsContainDescription = items.map((item) => Object.keys(item).includes('description')).includes(true);
+    const navItemsContainDescription = items.some((item) => item.description);
     const navItems = map(items, ({id, link, label, disabled, description}: ISubNavigationItem) => {
         const openDescription = description && selectedItem === id;
 
@@ -106,19 +106,18 @@ export const SubNavigation: FunctionComponent<ISubNavigationProps & HTMLAttribut
                     )}
                 </li>
             );
-        } else {
-            return (
-                <li key={id} className={classNames('sub-navigation-item', {'mod-selected': id === selectedItem})}>
-                    <a
-                        href={link}
-                        className={classNames('sub-navigation-item-link', {disabled})}
-                        onClick={(e: MouseEvent<HTMLAnchorElement>) => handleItemClick(e, id)}
-                    >
-                        {label}
-                    </a>
-                </li>
-            );
         }
+        return (
+            <li key={id} className={classNames('sub-navigation-item', {'mod-selected': id === selectedItem})}>
+                <a
+                    href={link}
+                    className={classNames('sub-navigation-item-link', {disabled})}
+                    onClick={(e: MouseEvent<HTMLAnchorElement>) => handleItemClick(e, id)}
+                >
+                    {label}
+                </a>
+            </li>
+        );
     });
 
     return (

--- a/packages/react/src/components/subNavigation/SubNavigation.tsx
+++ b/packages/react/src/components/subNavigation/SubNavigation.tsx
@@ -16,8 +16,10 @@ export interface ISubNavigationOwnProps {
      * Element selected by default
      */
     defaultSelected?: string;
+    /**
+     * A small description that appears once the subNavigation selected
+     */
     description?: string;
-    headerClass?: string;
 }
 
 export interface ISubNavigationStateProps {

--- a/packages/react/src/components/subNavigation/SubNavigation.tsx
+++ b/packages/react/src/components/subNavigation/SubNavigation.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import {ReactNode, HTMLAttributes, FunctionComponent, MouseEvent, useEffect} from 'react';
 import {map, omit} from 'underscore';
+import {SlideY} from '../../animations';
 
 export interface ISubNavigationOwnProps {
     /**
@@ -15,6 +16,8 @@ export interface ISubNavigationOwnProps {
      * Element selected by default
      */
     defaultSelected?: string;
+    description?: string;
+    headerClass?: string;
 }
 
 export interface ISubNavigationStateProps {
@@ -32,6 +35,7 @@ export interface ISubNavigationItem {
     label: ReactNode;
     disabled?: boolean;
     link?: string;
+    description?: string;
 }
 
 export interface ISubNavigationProps
@@ -71,22 +75,25 @@ export const SubNavigation: FunctionComponent<ISubNavigationProps & HTMLAttribut
     };
     const selectedItem = selected || defaultSelected;
 
-    const navItems = map(items, ({id, link, label, disabled}: ISubNavigationItem) => (
-        <li
-            key={id}
-            className={classNames('sub-navigation-item', {
-                'mod-selected': id === selectedItem,
-            })}
-        >
-            <a
-                href={link}
-                className={classNames('sub-navigation-item-link', {disabled})}
-                onClick={(e: MouseEvent<HTMLAnchorElement>) => handleItemClick(e, id)}
-            >
-                {label}
-            </a>
-        </li>
-    ));
+    const navItems = map(items, ({id, link, label, disabled, description}: ISubNavigationItem) => {
+        const openDescription = description && selectedItem === id;
+        return (
+            <li key={id} className={classNames('sub-navigation-item', {'mod-selected': id === selectedItem})}>
+                <a
+                    href={link}
+                    className={classNames('sub-navigation-item-link', {disabled})}
+                    onClick={(e: MouseEvent<HTMLAnchorElement>) => handleItemClick(e, id)}
+                >
+                    {label}
+                </a>
+                {description && (
+                    <SlideY in={openDescription}>
+                        <div className={classNames('sub-navigation-item-description')}>{description}</div>
+                    </SlideY>
+                )}
+            </li>
+        );
+    });
 
     return (
         <nav {...navProps} className={classNames('sub-navigation', className)}>

--- a/packages/react/src/components/subNavigation/SubNavigation.tsx
+++ b/packages/react/src/components/subNavigation/SubNavigation.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {ReactNode, HTMLAttributes, FunctionComponent, MouseEvent, useEffect} from 'react';
+import {ReactNode, HTMLAttributes, FunctionComponent, MouseEvent, useEffect, createElement} from 'react';
 import {map, omit} from 'underscore';
 import {SlideY} from '../../animations';
 
@@ -77,28 +77,50 @@ export const SubNavigation: FunctionComponent<ISubNavigationProps & HTMLAttribut
     };
     const selectedItem = selected || defaultSelected;
 
+    const navItemsContainDescription = items.map((item) => Object.keys(item).includes('description')).includes(true);
     const navItems = map(items, ({id, link, label, disabled, description}: ISubNavigationItem) => {
         const openDescription = description && selectedItem === id;
-        return (
-            <li key={id} className={classNames('sub-navigation-item', {'mod-selected': id === selectedItem})}>
-                <a
-                    href={link}
-                    className={classNames(
-                        {'sub-navigation-item-link': !description},
-                        {'sub-navigation-item-link-with-description': description},
-                        {disabled}
+
+        if (navItemsContainDescription) {
+            return (
+                <li key={id} className={classNames('sub-navigation-item', {'mod-selected': id === selectedItem})}>
+                    <a
+                        href={link}
+                        className={classNames('sub-navigation-item-link-with-description', {disabled})}
+                        onClick={(e: MouseEvent<HTMLAnchorElement>) => handleItemClick(e, id)}
+                    >
+                        {typeof label === 'string'
+                            ? createElement(
+                                  'div',
+                                  {
+                                      className: description
+                                          ? 'sub-navigation-item-link-with-description-label'
+                                          : 'sub-navigation-item-link-with-description-label-solo',
+                                  },
+                                  `${label}`
+                              )
+                            : label}
+                    </a>
+                    {description && (
+                        <SlideY in={openDescription}>
+                            <div className="sub-navigation-item-description body-m-book-subdued">{description}</div>
+                        </SlideY>
                     )}
-                    onClick={(e: MouseEvent<HTMLAnchorElement>) => handleItemClick(e, id)}
-                >
-                    {label}
-                </a>
-                {description && (
-                    <SlideY in={openDescription}>
-                        <div className="sub-navigation-item-description body-m-book-subdued">{description}</div>
-                    </SlideY>
-                )}
-            </li>
-        );
+                </li>
+            );
+        } else {
+            return (
+                <li key={id} className={classNames('sub-navigation-item', {'mod-selected': id === selectedItem})}>
+                    <a
+                        href={link}
+                        className={classNames('sub-navigation-item-link', {disabled})}
+                        onClick={(e: MouseEvent<HTMLAnchorElement>) => handleItemClick(e, id)}
+                    >
+                        {label}
+                    </a>
+                </li>
+            );
+        }
     });
 
     return (

--- a/packages/react/src/components/subNavigation/tests/SubNavigation.spec.tsx
+++ b/packages/react/src/components/subNavigation/tests/SubNavigation.spec.tsx
@@ -67,8 +67,15 @@ describe('SubNavigation', () => {
 
         const propsWithDescription: ISubNavigationProps = {
             items: [
-                {id: 'a', label: 'A', description: 'Apple'},
-                {id: 'b', label: 'B'},
+                {id: 'a', label: 'A'},
+                {id: 'b', label: 'B', description: 'Apple'},
+            ],
+        };
+
+        const propsWithCustomLabel: ISubNavigationProps = {
+            items: [
+                {id: 'a', label: <h1>Hello World</h1>},
+                {id: 'b', label: 'B', description: 'hello hello'},
             ],
         };
 
@@ -80,10 +87,25 @@ describe('SubNavigation', () => {
 
         it('should render a description', () => {
             subNavigation = shallow(<SubNavigation {...propsWithDescription} />);
-            expect(subNavigation.find('div').length).toBe(1);
-            expect(subNavigation.find('div').hasClass('sub-navigation-item-description body-m-book-subdued')).toBe(
-                true
-            );
+            expect(subNavigation.find('div').length).toBe(3);
+            expect(subNavigation.find('div').last().hasClass('sub-navigation-item-description')).toBe(true);
+        });
+
+        it('should create items in div elements with a solo class if item does not have a description', () => {
+            subNavigation = shallow(<SubNavigation {...propsWithDescription} />);
+            expect(subNavigation.find('div').length).toBe(3);
+            expect(
+                subNavigation.find('div').first().hasClass('sub-navigation-item-link-with-description-label-solo')
+            ).toBe(true);
+        });
+
+        it('should respect the label when a description is supplied', () => {
+            subNavigation = shallow(<SubNavigation {...propsWithCustomLabel} />);
+            expect(subNavigation.find('div').length).toBe(2);
+            expect(
+                subNavigation.find('div').last().hasClass('sub-navigation-item-description body-m-book-subdued')
+            ).toBe(true);
+            expect(subNavigation.find('h1').length).toBe(1);
         });
 
         it('should have the "mod-selected" class on the selected item', () => {

--- a/packages/react/src/components/subNavigation/tests/SubNavigation.spec.tsx
+++ b/packages/react/src/components/subNavigation/tests/SubNavigation.spec.tsx
@@ -21,6 +21,19 @@ describe('SubNavigation', () => {
         ).not.toThrow();
 
         expect(() =>
+            shallow(
+                <SubNavigation
+                    items={[
+                        {id: 'a', label: 'A'},
+                        {id: 'b', label: 'B'},
+                    ]}
+                    selected="b"
+                    description="alphabet soup"
+                />
+            )
+        ).not.toThrow();
+
+        expect(() =>
             shallow(<SubNavigation items={[{id: 'a', label: 'A'}]} selected="not-existing-id" />)
         ).not.toThrow();
     });
@@ -52,10 +65,25 @@ describe('SubNavigation', () => {
             ],
         };
 
+        const propsWithDescription: ISubNavigationProps = {
+            items: [
+                {id: 'a', label: 'A', description: 'Apple'},
+                {id: 'b', label: 'B'},
+            ],
+        };
+
         it('should render one navigation link per item', () => {
             subNavigation = shallow(<SubNavigation {...basicProps} />);
 
             expect(subNavigation.find('li').length).toBe(basicProps.items.length);
+        });
+
+        it('should render a description', () => {
+            subNavigation = shallow(<SubNavigation {...propsWithDescription} />);
+            expect(subNavigation.find('div').length).toBe(1);
+            expect(subNavigation.find('div').hasClass('sub-navigation-item-description body-m-book-subdued')).toBe(
+                true
+            );
         });
 
         it('should have the "mod-selected" class on the selected item', () => {

--- a/packages/react/src/components/subNavigation/tests/SubNavigation.spec.tsx
+++ b/packages/react/src/components/subNavigation/tests/SubNavigation.spec.tsx
@@ -91,12 +91,12 @@ describe('SubNavigation', () => {
             expect(subNavigation.find('div').last().hasClass('sub-navigation-item-description')).toBe(true);
         });
 
-        it('should create items in div elements with a solo class if item does not have a description', () => {
+        it('should create items in div elements', () => {
             subNavigation = shallow(<SubNavigation {...propsWithDescription} />);
             expect(subNavigation.find('div').length).toBe(3);
-            expect(
-                subNavigation.find('div').first().hasClass('sub-navigation-item-link-with-description-label-solo')
-            ).toBe(true);
+            expect(subNavigation.find('div').first().hasClass('sub-navigation-item-link-with-description-label')).toBe(
+                true
+            );
         });
 
         it('should respect the label when a description is supplied', () => {

--- a/packages/style/scss/components/sub-navigation.scss
+++ b/packages/style/scss/components/sub-navigation.scss
@@ -21,6 +21,16 @@
                 &-with-description {
                     display: block;
                     padding: 0 40px;
+
+                    &-label {
+                        @extend .body-m;
+                        padding: 24px 0 8px;
+
+                        &-solo {
+                            @extend .body-m;
+                            padding: 24px 0;
+                        }
+                    }
                 }
                 &.disabled {
                     color: var(--deprecated-medium-grey);

--- a/packages/style/scss/components/sub-navigation.scss
+++ b/packages/style/scss/components/sub-navigation.scss
@@ -23,13 +23,8 @@
                     padding: 0 40px;
 
                     &-label {
-                        @extend .body-m;
-                        padding: 24px 0 8px;
-
-                        &-solo {
-                            @extend .body-m;
-                            padding: 24px 0;
-                        }
+                        @extend .body-l;
+                        padding: 16px 0;
                     }
                 }
                 &.disabled {
@@ -41,7 +36,6 @@
             &-description {
                 display: block;
                 padding: 0 40px 24px;
-                line-height: $sub-navigation-line-height;
             }
 
             &.mod-selected {

--- a/packages/style/scss/components/sub-navigation.scss
+++ b/packages/style/scss/components/sub-navigation.scss
@@ -24,6 +24,12 @@
                 }
             }
 
+            &-description {
+                display: block;
+                padding: 7px 40px 20px 40px;
+                line-height: $sub-navigation-line-height;
+            }
+
             &.mod-selected {
                 background-color: var(--grey-20);
 

--- a/packages/style/scss/components/sub-navigation.scss
+++ b/packages/style/scss/components/sub-navigation.scss
@@ -18,6 +18,10 @@
                 color: var(--title-text-color);
                 line-height: $sub-navigation-line-height;
 
+                &-with-description {
+                    display: block;
+                    padding: 0 40px;
+                }
                 &.disabled {
                     color: var(--deprecated-medium-grey);
                     cursor: default;
@@ -26,7 +30,7 @@
 
             &-description {
                 display: block;
-                padding: 7px 40px 20px;
+                padding: 0 40px 24px;
                 line-height: $sub-navigation-line-height;
             }
 

--- a/packages/style/scss/components/sub-navigation.scss
+++ b/packages/style/scss/components/sub-navigation.scss
@@ -26,7 +26,7 @@
 
             &-description {
                 display: block;
-                padding: 7px 40px 20px 40px;
+                padding: 7px 40px 20px;
                 line-height: $sub-navigation-line-height;
             }
 

--- a/packages/style/scss/variables.scss
+++ b/packages/style/scss/variables.scss
@@ -252,7 +252,7 @@ $application-container-min-height: 400px;
 // Sub Navigation
 $sub-navigation-padding-top: 26px;
 $sub-navigation-border: $default-border;
-$sub-navigation-item-padding: 7px 40px;
+$sub-navigation-item-padding: 16px 40px;
 $sub-navigation-selected-border-width: $navigation-active-border-width;
 $sub-navigation-line-height: 16px;
 $sub-navigation-min-width: 200px;

--- a/packages/website/src/examples/SubNavigation/custom.example.tsx
+++ b/packages/website/src/examples/SubNavigation/custom.example.tsx
@@ -1,0 +1,56 @@
+import {SubNavigationConnected, Svg} from '@coveord/plasma-react';
+
+export default () => (
+    <SubNavigationConnected
+        id="third-sub-nav"
+        items={[
+            {
+                label: (
+                    <span className="flex space-between">
+                        <span className="truncate">Avatar</span>
+                        <Svg svgName="thumbUp" svgClass="icon" />
+                    </span>
+                ),
+                id: 'avatar',
+                disabled: true,
+            },
+            {
+                label: (
+                    <span className="flex space-between">
+                        <span className="truncate">Titanic</span>
+                        <Svg svgName="thumbUp" svgClass="icon" />
+                    </span>
+                ),
+                id: 'titanic',
+            },
+            {
+                label: (
+                    <span className="flex space-between">
+                        <span className="truncate pr1">Star Wars: The Force Awakens</span>
+                        <Svg svgName="thumbUp" svgClass="icon" />
+                    </span>
+                ),
+                id: 'star-wars',
+            },
+            {
+                label: (
+                    <span className="flex space-between">
+                        <span className="truncate">Jurassic World</span>
+                        <Svg svgName="thumbDown" svgClass="icon" />
+                    </span>
+                ),
+                id: 'jurasic-world',
+            },
+            {
+                label: (
+                    <span className="flex space-between">
+                        <span className="truncate">The Avengers</span>
+                        <Svg svgName="thumbDown" svgClass="icon" />
+                    </span>
+                ),
+                id: 'the-avengers',
+            },
+        ]}
+        defaultSelected="titanic"
+    />
+);

--- a/packages/website/src/examples/SubNavigation/customWithDesc.example.tsx
+++ b/packages/website/src/examples/SubNavigation/customWithDesc.example.tsx
@@ -3,7 +3,12 @@ import {SubNavigationConnected} from '@coveord/plasma-react';
 export default () => {
     const exampleItems = [
         {label: <h3>H3 React Node</h3>, id: 'react-node'},
-        {label: 'Gummies', id: 'gummies'},
+        {
+            label: 'Gummies',
+            id: 'gummies',
+            description:
+                'Brownie cheesecake brownie shortbread toffee. Candy danish gingerbread cake powder cake. Marzipan marzipan sweet roll apple pie cupcake lollipop.',
+        },
         {
             label: 'Cupcake',
             id: 'cupcake',
@@ -11,7 +16,12 @@ export default () => {
                 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie',
         },
         {label: 'Chocolate', id: 'chocolate'},
-        {label: 'Banana', id: 'banana'},
+        {
+            label: 'Banana',
+            id: 'banana',
+            description:
+                'Sweet lollipop toffee donut candy brownie shortbread icing pudding. Caramels ice cream dragée lemon drops soufflé cotton candy cheesecake. Toffee apple pie pastry gummi bears danish.',
+        },
     ];
 
     return <SubNavigationConnected id="first-sub-nav" items={exampleItems} />;

--- a/packages/website/src/examples/SubNavigation/customWithDesc.example.tsx
+++ b/packages/website/src/examples/SubNavigation/customWithDesc.example.tsx
@@ -1,0 +1,18 @@
+import {SubNavigationConnected} from '@coveord/plasma-react';
+
+export default () => {
+    const exampleItems = [
+        {label: <h3>H3 React Node</h3>, id: 'react-node'},
+        {label: 'Gummies', id: 'gummies'},
+        {
+            label: 'Cupcake',
+            id: 'cupcake',
+            description:
+                'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie',
+        },
+        {label: 'Chocolate', id: 'chocolate'},
+        {label: 'Banana', id: 'banana'},
+    ];
+
+    return <SubNavigationConnected id="first-sub-nav" items={exampleItems} />;
+};

--- a/packages/website/src/examples/SubNavigation/defaultSelected.example.tsx
+++ b/packages/website/src/examples/SubNavigation/defaultSelected.example.tsx
@@ -1,0 +1,13 @@
+import {SubNavigationConnected} from '@coveord/plasma-react';
+
+export default () => {
+    const exampleItems = [
+        {label: 'Avatar', id: 'avatar'},
+        {label: 'Titanic', id: 'titanic'},
+        {label: 'Star Wars: The Force Awakens', id: 'star-wars'},
+        {label: 'Jurassic World', id: 'jurasic-world'},
+        {label: 'The Avengers', id: 'the-avengers'},
+    ];
+
+    return <SubNavigationConnected id="second-sub-nav" items={exampleItems} defaultSelected="star-wars" />;
+};

--- a/packages/website/src/examples/SubNavigation/main.example.tsx
+++ b/packages/website/src/examples/SubNavigation/main.example.tsx
@@ -1,0 +1,12 @@
+import {SubNavigationConnected} from '@coveord/plasma-react';
+
+export default () => {
+    const exampleItems = [
+        {label: 'Avatar', id: 'avatar'},
+        {label: 'Titanic', id: 'titanic'},
+        {label: 'The Avengers', id: 'the-avengers'},
+        {label: 'Banana', id: 'banana'},
+    ];
+
+    return <SubNavigationConnected id="first-sub-nav" items={exampleItems} />;
+};

--- a/packages/website/src/pages/navigation/SubNavigation.tsx
+++ b/packages/website/src/pages/navigation/SubNavigation.tsx
@@ -2,7 +2,7 @@ import {PageLayout} from '../../building-blocs/PageLayout';
 
 const custom = `
     import {SubNavigationConnected, Svg} from '@coveord/plasma-react';
-    
+
     export default () => (
         <SubNavigationConnected
             id="third-sub-nav"
@@ -73,7 +73,7 @@ const defaultSelected = `
 
         return (
             <SubNavigationConnected id="second-sub-nav" items={exampleItems} defaultSelected="star-wars" />
-        ); 
+        );
     };
 `;
 
@@ -82,7 +82,7 @@ const code = `
 
     export default () => {
         const exampleItems = [
-            {label: 'Avatar', id: 'avatar'},
+            {label: <h4>Avatar</h4>, id: 'avatar', description: 'helloWorld'},
             {label: 'Titanic', id: 'titanic'},
             {label: 'Star Wars: The Force Awakens', id: 'star-wars'},
             {label: 'Jurassic World', id: 'jurasic-world'},
@@ -90,8 +90,8 @@ const code = `
         ];
 
         return (
-            <SubNavigationConnected id="first-sub-nav" items={exampleItems} />
-        ); 
+            <SubNavigationConnected id="first-sub-nav" items={exampleItems} headerClass="h4" />
+        );
     };
 `;
 

--- a/packages/website/src/pages/navigation/SubNavigation.tsx
+++ b/packages/website/src/pages/navigation/SubNavigation.tsx
@@ -1,99 +1,8 @@
+import code from '@examples/SubNavigation/main.example.tsx';
+import custom from '@examples/SubNavigation/custom.example.tsx';
+import defaultSelected from '@examples/SubNavigation/defaultSelected.example.tsx';
+import customWithDesc from '@examples/SubNavigation/customWithDesc.example.tsx';
 import {PageLayout} from '../../building-blocs/PageLayout';
-
-const custom = `
-    import {SubNavigationConnected, Svg} from '@coveord/plasma-react';
-
-    export default () => (
-        <SubNavigationConnected
-            id="third-sub-nav"
-            items={[
-                {
-                    label: (
-                        <span className="flex space-between">
-                            <span className="truncate">Avatar</span>
-                            <Svg svgName="thumbUp" svgClass="icon" />
-                        </span>
-                    ),
-                    id: 'avatar',
-                    disabled: true,
-                },
-                {
-                    label: (
-                        <span className="flex space-between">
-                            <span className="truncate">Titanic</span>
-                            <Svg svgName="thumbUp" svgClass="icon" />
-                        </span>
-                    ),
-                    id: 'titanic',
-                },
-                {
-                    label: (
-                        <span className="flex space-between">
-                            <span className="truncate pr1">Star Wars: The Force Awakens</span>
-                            <Svg svgName="thumbUp" svgClass="icon" />
-                        </span>
-                    ),
-                    id: 'star-wars',
-                },
-                {
-                    label: (
-                        <span className="flex space-between">
-                            <span className="truncate">Jurassic World</span>
-                            <Svg svgName="thumbDown" svgClass="icon" />
-                        </span>
-                    ),
-                    id: 'jurasic-world',
-                },
-                {
-                    label: (
-                        <span className="flex space-between">
-                            <span className="truncate">The Avengers</span>
-                            <Svg svgName="thumbDown" svgClass="icon" />
-                        </span>
-                    ),
-                    id: 'the-avengers',
-                },
-            ]}
-            defaultSelected="titanic"
-        />
-    );
-`;
-
-const defaultSelected = `
-    import {SubNavigationConnected} from '@coveord/plasma-react';
-
-    export default () => {
-        const exampleItems = [
-            {label: 'Avatar', id: 'avatar'},
-            {label: 'Titanic', id: 'titanic'},
-            {label: 'Star Wars: The Force Awakens', id: 'star-wars'},
-            {label: 'Jurassic World', id: 'jurasic-world'},
-            {label: 'The Avengers', id: 'the-avengers'},
-        ];
-
-        return (
-            <SubNavigationConnected id="second-sub-nav" items={exampleItems} defaultSelected="star-wars" />
-        );
-    };
-`;
-
-const code = `
-    import {SubNavigationConnected} from '@coveord/plasma-react';
-
-    export default () => {
-        const exampleItems = [
-            {label: 'Avatar', id: 'avatar'},
-            {label: 'Titanic', id: 'titanic'},
-            {label: 'The Avengers', id: 'the-avengers'},
-            {label: 'Banana', id: 'banana'},
-            {label: 'Chocolate', id: 'chocolate', description: 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie.'},
-        ];
-
-        return (
-            <SubNavigationConnected id="first-sub-nav" items={exampleItems} />
-        );
-    };
-`;
 
 export const SubNavigationExamples = () => (
     <PageLayout
@@ -107,6 +16,7 @@ export const SubNavigationExamples = () => (
         examples={{
             defaultSelected: {code: defaultSelected, title: 'Default selected'},
             custom: {code: custom, title: 'Custom JSX labels and disabled item'},
+            customWithDesc: {code: customWithDesc, title: 'When there are descriptions in Sub Nav'},
         }}
     />
 );

--- a/packages/website/src/pages/navigation/SubNavigation.tsx
+++ b/packages/website/src/pages/navigation/SubNavigation.tsx
@@ -82,15 +82,15 @@ const code = `
 
     export default () => {
         const exampleItems = [
-            {label: <h4>Avatar</h4>, id: 'avatar', description: 'helloWorld'},
-            {label: 'Titanic', id: 'titanic'},
+            {label: 'Avatar', id: 'avatar'},
+            {label: 'Titanic', id: 'titanic', description: 'boat'},
             {label: 'Star Wars: The Force Awakens', id: 'star-wars'},
             {label: 'Jurassic World', id: 'jurasic-world'},
             {label: 'The Avengers', id: 'the-avengers'},
         ];
 
         return (
-            <SubNavigationConnected id="first-sub-nav" items={exampleItems} headerClass="h4" />
+            <SubNavigationConnected id="first-sub-nav" items={exampleItems} />
         );
     };
 `;

--- a/packages/website/src/pages/navigation/SubNavigation.tsx
+++ b/packages/website/src/pages/navigation/SubNavigation.tsx
@@ -85,9 +85,8 @@ const code = `
             {label: 'Avatar', id: 'avatar'},
             {label: 'Titanic', id: 'titanic'},
             {label: 'The Avengers', id: 'the-avengers'},
-            {label: <div className="body-m py3">Cupcakes</div>, id: 'cupcake', description: 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie.'},
-            {label: <div className="body-m py3">Banana</div>, id: 'banana'},
-            {label: <div className="body-m py3">Chocolate</div>, id: 'chocolate', description: 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie.'},
+            {label: 'Banana', id: 'banana'},
+            {label: 'Chocolate', id: 'chocolate', description: 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie.'},
         ];
 
         return (

--- a/packages/website/src/pages/navigation/SubNavigation.tsx
+++ b/packages/website/src/pages/navigation/SubNavigation.tsx
@@ -83,7 +83,7 @@ const code = `
     export default () => {
         const exampleItems = [
             {label: 'Avatar', id: 'avatar'},
-            {label: 'Titanic', id: 'titanic', description: 'boat'},
+            {label: <div className="body-m py1">Titanic</div>, id: 'titanic', description: 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie.'},
             {label: 'Star Wars: The Force Awakens', id: 'star-wars'},
             {label: 'Jurassic World', id: 'jurasic-world'},
             {label: 'The Avengers', id: 'the-avengers'},

--- a/packages/website/src/pages/navigation/SubNavigation.tsx
+++ b/packages/website/src/pages/navigation/SubNavigation.tsx
@@ -83,10 +83,11 @@ const code = `
     export default () => {
         const exampleItems = [
             {label: 'Avatar', id: 'avatar'},
-            {label: <div className="body-m py1">Titanic</div>, id: 'titanic', description: 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie.'},
-            {label: 'Star Wars: The Force Awakens', id: 'star-wars'},
-            {label: 'Jurassic World', id: 'jurasic-world'},
+            {label: 'Titanic', id: 'titanic'},
             {label: 'The Avengers', id: 'the-avengers'},
+            {label: <div className="body-m py3">Cupcakes</div>, id: 'cupcake', description: 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie.'},
+            {label: <div className="body-m py3">Banana</div>, id: 'banana'},
+            {label: <div className="body-m py3">Chocolate</div>, id: 'chocolate', description: 'Cupcake ipsum dolor sit amet. Lemon drops croissant sesame snaps cookie jelly beans tootsie roll muffin. Liquorice liquorice fruitcake tiramisu sesame snaps sugar plum lollipop gummi bears cookie.'},
         ];
 
         return (


### PR DESCRIPTION
### Proposed Changes

- Adjust the default padding of the existing sub nav `7px` -> `16px` as per Gustavo's request
- Add an option to add `description` in the SubNavigation component using a slider to appear when selected
- When a user utilizes the `description` in the navItems, the component will style the labels if it is a `string`, otherwise it respects the `ReactNode` rule the user puts on the tab
- UX padding and specification has been tweaked with @guscoveo 

This is the initial change needed for the upcoming UX updates.

### Potential Breaking Changes

- None - as the `description` prop is completely optional

https://user-images.githubusercontent.com/66333175/168903927-a06f544f-3552-4217-a1d9-0b70d263e132.mp4

Styling of all the tabs change automatically when a description is detected

https://user-images.githubusercontent.com/66333175/168904064-e006de04-2918-4977-be41-e12d0e6c52b7.mp4

## 👉  [Demo Link](https://plasma.coveo.com/feature/PR-2747/navigation/SubNavigation)

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
