### PR TITLE
fix(react): remove extra padding for icon only badge

### DIFF
--- a/packages/react/src/components/badge/Badge.tsx
+++ b/packages/react/src/components/badge/Badge.tsx
@@ -94,7 +94,9 @@ export class Badge extends Component<IBadgeProps> {
                         svgClass={'icon mod-badge'}
                     />
                 ) : null}
-                {'label' in this.props ? <div className="badge_label">{this.props.label}</div> : null}
+                {'label' in this.props && this.props.label ? (
+                    <div className="badge_label">{this.props.label}</div>
+                ) : null}
             </div>
         );
     }


### PR DESCRIPTION
### Proposed Changes

Removed the extra padding when using an icon-only badge

Before

![image](https://user-images.githubusercontent.com/35579930/168902024-04cf6e92-e597-42a4-92fb-272cda16b4db.png)

After

![image](https://user-images.githubusercontent.com/35579930/168901922-69202a3c-db40-4b1a-9717-1d4f3aa598bb.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
