### PR TITLE
fix(draggableselectedoption): removeOnClick prop was not defined

### DIFF
--- a/packages/react/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
+++ b/packages/react/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
@@ -1,6 +1,5 @@
 import {FunctionComponent, useRef} from 'react';
 import {useDrag, useDrop} from 'react-dnd';
-
 import {Svg} from '../../svg';
 import {ISelectedOptionProps, SelectedOption} from './SelectedOption';
 
@@ -21,6 +20,7 @@ export const DraggableSelectedOption: FunctionComponent<IDraggableSelectedOption
     readOnly,
     value,
     onMoveOver,
+    onRemoveClick,
 }) => {
     const dropRef = useRef<HTMLDivElement>();
     const [, drop] = useDrop(() => ({
@@ -47,6 +47,7 @@ export const DraggableSelectedOption: FunctionComponent<IDraggableSelectedOption
                 label={isDragging ? null : label}
                 selectedTooltip={selectedTooltip}
                 readOnly={readOnly}
+                onRemoveClick={onRemoveClick}
                 prepend={
                     !readOnly && (
                         <div className="move-option cursor-move" aria-grabbed={isDragging} ref={drag}>

--- a/packages/react/src/components/select/tests/MultiSelectConnected.spec.tsx
+++ b/packages/react/src/components/select/tests/MultiSelectConnected.spec.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable testing-library/no-container */
+import {fireEvent, render, screen, within} from '@test-utils';
 import userEvent from '@testing-library/user-event';
-import {fireEvent, render, screen, within, act} from '@test-utils';
-
 import {MultiSelectConnected} from '../MultiSelectConnected';
 
 describe('Select', () => {
@@ -266,6 +265,21 @@ describe('Select', () => {
                 expect(listitems[0]).toHaveTextContent('🌱');
                 expect(listitems[1]).toHaveTextContent('🍟');
                 expect(listitems[2]).toHaveTextContent('🥔');
+            });
+
+            it('is possible to remove a selected item', () => {
+                const items = [{value: '🌱', selected: true}, {value: '🥔', selected: true}, {value: '🍟'}];
+                render(<MultiSelectConnected id={id} items={items} sortable />);
+
+                let listitems = screen.getAllByRole('listitem');
+                expect(listitems[0]).toHaveTextContent('🌱');
+                expect(listitems[1]).toHaveTextContent('🥔');
+
+                userEvent.click(within(listitems[0]).getByRole('button'));
+
+                listitems = screen.getAllByRole('listitem');
+                expect(listitems.length).toBe(1);
+                expect(listitems[0]).toHaveTextContent('🥔');
             });
         });
     });


### PR DESCRIPTION
### Proposed Changes
https://coveord.atlassian.net/browse/UITOOL-696
RemoveOnClick prop was not sent for MultiSelectConnected with sortable prop (rendering DraggableSelectedOption)

Use the select-multi component in plasma and copy paste this in the sandbox

```
import {MultiSelectConnected} from '@coveord/plasma-react';

export default () => (
    <MultiSelectConnected
        id="mutli-select-1"
        items={[
            {value: 'one', displayValue: 'Option 1', selected: true},
            {value: 'two', displayValue: 'Option 2'},
            {value: 'three', displayValue: 'Option 3'},
        ]}
        sortable
    />
);
```
The clear button on selected item in the multi select should not work right now (but is fixed in this pr)

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
