### PR TITLE
ci: fix the publish step for the next branch

### DIFF
--- a/build/publishNewVersion.mjs
+++ b/build/publishNewVersion.mjs
@@ -26,8 +26,8 @@ const BUMP_TYPES = ['major', 'minor', 'patch', 'prerelease'];
 const program = new Command();
 program
     .option('--dry', 'dry run', false)
-    .option('--tag', 'tag to use on NPM', 'latest')
-    .option('--branch', 'allow deploy on branch', 'master')
+    .option('--tag <tag>', 'tag to use on NPM', 'latest')
+    .option('--branch <branch>', 'allow deploy on branch', 'master')
     .addOption(
         new Option('--bump <type>', 'bump a <type> version instead of reliying on commit messages').choices(BUMP_TYPES)
     );
@@ -105,6 +105,9 @@ const outputProcess = (process) => {
 
                 console.log(`Publishing version ${versionTag} on NPM`);
                 outputProcess(pnpmPublish(lastTag, options.tag, options.branch));
+            } else {
+                console.log('Would have called pnpmPublish with the following arguments:');
+                console.log(`pnpmPublish(${lastTag}, ${options.tag}, ${options.branch})`);
             }
         }
     } else {


### PR DESCRIPTION
### Proposed Changes

When running `node build/publishNewVersion.mjs --dry --bump prerelease --tag next --branch next` locally,

output before
```
Last tag: v41.5.1-next.1
Bumping root to version 41.5.1-next.2
Would have called pnpmPublish with the following arguments:
pnpmPublish(v41.5.1-next.1, true, true)
```

output after
```
Last tag: v41.5.1-next.1
Bumping root to version 41.5.1-next.2
Would have called pnpmPublish with the following arguments:
pnpmPublish(v41.5.1-next.1, next, next)
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
