### PR TITLE
fix(searchbar): make the loading spinner smaller in the search bar

### DIFF
--- a/packages/react/src/components/loading/LoadingSpinner.tsx
+++ b/packages/react/src/components/loading/LoadingSpinner.tsx
@@ -1,5 +1,16 @@
 import {FunctionComponent} from 'react';
+import classNames from 'classnames';
 
-export const LoadingSpinner: FunctionComponent = () => (
-    <div role="alert" aria-busy="true" className="loading-spinner" />
+interface LoadingSpinnerProps {
+    size?: number;
+    className?: string;
+}
+
+export const LoadingSpinner: FunctionComponent<LoadingSpinnerProps> = ({size = 24, className}) => (
+    <div
+        role="alert"
+        aria-busy="true"
+        className={classNames('loading-spinner', className)}
+        style={{width: size, height: size}}
+    />
 );

--- a/packages/react/src/components/loading/tests/LoadingSpinner.spec.tsx
+++ b/packages/react/src/components/loading/tests/LoadingSpinner.spec.tsx
@@ -1,0 +1,21 @@
+import {render, screen} from '@test-utils';
+
+import {LoadingSpinner} from '../LoadingSpinner';
+
+describe('LoadingSpinner', () => {
+    it('renders a loading of size 24 by default', () => {
+        render(<LoadingSpinner />);
+
+        const loading = screen.getByRole('alert');
+        expect(loading).toBeInTheDocument();
+        expect(loading).toHaveStyle({width: '24px', height: '24px'});
+    });
+
+    it('renders a loading of the specified size', () => {
+        render(<LoadingSpinner size={16} />);
+
+        const loading = screen.getByRole('alert');
+        expect(loading).toBeInTheDocument();
+        expect(loading).toHaveStyle({width: '16px', height: '16px'});
+    });
+});

--- a/packages/react/src/components/searchBar/SearchBar.tsx
+++ b/packages/react/src/components/searchBar/SearchBar.tsx
@@ -153,7 +153,7 @@ export class SearchBar extends Component<ISearchBarProps> {
         const searchIcon = !this.props.searching ? (
             <Svg svgName="search" svgClass={this.props.disabled ? 'search-icon-disabled' : ''} />
         ) : (
-            <LoadingSpinner />
+            <LoadingSpinner size={16} />
         );
 
         return !this.props.searching && !this.props.disabled ? (

--- a/packages/style/scss/components/loading.scss
+++ b/packages/style/scss/components/loading.scss
@@ -92,8 +92,7 @@
 
 .loading-spinner {
     position: relative;
-    width: 24px;
-    height: 24px;
+    display: inline-block;
     background: var(--gradient);
     border-radius: 50%;
     animation: rotationAnimation 2s linear infinite;

--- a/packages/website/src/pages/feedback/Loading.tsx
+++ b/packages/website/src/pages/feedback/Loading.tsx
@@ -15,7 +15,13 @@ const fullContent = `
 const loadingSpinner = `
     import {LoadingSpinner} from '@coveord/plasma-react';
 
-    export default () => <div className="flex justify-center"><LoadingSpinner /></div>
+    export default () => (
+        <>
+            <LoadingSpinner size={16} />
+            <LoadingSpinner />
+            <LoadingSpinner size={32} />
+        </>
+    );
 `;
 
 export default () => (


### PR DESCRIPTION
### Proposed Changes

Before
<img width="529" alt="image" src="https://user-images.githubusercontent.com/35579930/169350548-eec12a27-2fba-483f-89f2-49b6ad48d899.png">
After
<img width="542" alt="image" src="https://user-images.githubusercontent.com/35579930/169350624-ce21a152-1409-4c10-b5b0-35d95371830c.png">

Added the possibility of have loading spinners of different sizes


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
