### PR TITLE
fix(react): make sure a limit of 0 renders the limit label

### DIFF
--- a/packages/react/src/components/limit/Limit.tsx
+++ b/packages/react/src/components/limit/Limit.tsx
@@ -5,9 +5,8 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import {PlasmaState} from '../../PlasmaState';
 import {IDispatch} from '../../utils/ReduxUtils';
-import {InputConnected} from '../input';
+import {InputConnected, InputSelectors} from '../input';
 import {changeInputValue} from '../input/InputActions';
-import {InputSelectors} from '../input/InputSelectors';
 import {Svg} from '../svg';
 
 export interface LimitOwnProps {
@@ -56,16 +55,15 @@ export interface LimitOwnProps {
 }
 
 export const Limit: FunctionComponent<LimitOwnProps> = (props) => {
-    const {id, limit, className} = props;
     const {currentLimit} = useSelector((state: PlasmaState) => ({
-        currentLimit: +InputSelectors.getValue(state, {id}) || limit,
+        currentLimit: +InputSelectors.getValue(state, {id: props.id}) || props.limit,
     }));
 
     return (
-        <div className={classNames('limit-box mb2', className)}>
+        <div className={classNames('limit-box mb2', props.className)}>
             <div className="limit-box-main p2 pb1">
                 <HeaderDivision {...props} />
-                <ContentDivision {...props} currentLimit={currentLimit} />
+                <ContentDivision {...props} limit={currentLimit} />
             </div>
             <ProgressBar usage={props.usage} isLimitTheGoalToReach={props.isLimitTheGoalToReach} limit={currentLimit} />
         </div>
@@ -86,23 +84,16 @@ const HistoryIcon: FunctionComponent<Omit<LimitOwnProps, 'title'>> = ({isHistory
         </span>
     ) : null;
 
-const ContentDivision: FunctionComponent<Omit<LimitOwnProps, 'title'> & {currentLimit: number}> = ({
+const ContentDivision: FunctionComponent<Omit<LimitOwnProps, 'title'>> = ({
     id,
     usage,
     limit,
     isLimitEditable,
     limitLabel = 'Limit',
-    currentLimit,
 }) => (
     <div className="limit-box-numbers pt1 flex">
         <UsageDivision usage={usage} />
-        <LimitDivision
-            id={id}
-            usage={usage}
-            limit={limit}
-            isLimitEditable={!!currentLimit && isLimitEditable}
-            limitLabel={currentLimit ? limitLabel : ''}
-        />
+        <LimitDivision id={id} usage={usage} limit={limit} isLimitEditable={isLimitEditable} limitLabel={limitLabel} />
     </div>
 );
 

--- a/packages/react/src/components/limit/tests/Limit.spec.tsx
+++ b/packages/react/src/components/limit/tests/Limit.spec.tsx
@@ -54,4 +54,10 @@ describe('Limit', () => {
         expect(screen.getByText('42,000,000.5')).toBeInTheDocument();
         expect(screen.getByText('100,000,000.5')).toBeInTheDocument();
     });
+
+    it('shows the limit label even if the limit value is zero', () => {
+        render(<Limit id="🆔" title="My limit" limit={0} limitLabel="abcde" />);
+
+        expect(screen.getByText(/abcde/i)).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
### Proposed Changes

Somehow when the limit value was zero, the limit label was removed. I'm not sure why that was the case, but I removed that behaviour.

Before

![image](https://user-images.githubusercontent.com/35579930/169537494-98a88760-4a68-41c1-a0db-e1a8eabc4efd.png)

After

![image](https://user-images.githubusercontent.com/35579930/169537432-f61e8824-e778-485d-83c5-acb8b5b2759f.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
