### PR TITLE
fix(badges): adding back information type + remove breaking change

### DIFF
--- a/packages/react/src/components/badge/Badge.tsx
+++ b/packages/react/src/components/badge/Badge.tsx
@@ -12,6 +12,7 @@ export enum BadgeType {
     Success,
     Beta,
     New,
+    Information,
 }
 
 export enum BadgeIconPlacement {
@@ -26,6 +27,7 @@ const TypeClassMapping: Record<BadgeType, string> = {
     [BadgeType.New]: 'mod-new',
     [BadgeType.Success]: 'mod-success',
     [BadgeType.Warning]: 'mod-warning',
+    [BadgeType.Information]: 'mod-information',
 };
 
 interface BadgeBasicProps {
@@ -70,7 +72,6 @@ export type IBadgeProps = BadgeWithLabelProps | BadgeWithIconProps | (BadgeWithL
 export class Badge extends Component<IBadgeProps> {
     static defaultProps: IBadgeProps = {
         extraClasses: [],
-        type: BadgeType.Default,
         isSmall: false,
         label: '',
         iconPlacement: BadgeIconPlacement.Left,

--- a/packages/style/scss/components/badge.scss
+++ b/packages/style/scss/components/badge.scss
@@ -34,6 +34,13 @@
         --line-height: 16px;
     }
 
+    &.mod-information {
+        --color: var(--navy-blue-80);
+        --fill: var(--navy-blue-80);
+        --border-color: var(--navy-blue-40);
+        --background-color: var(--navy-blue-20);
+    }
+
     &.mod-critical {
         --color: var(--pomegranate-red-70);
         --fill: var(--pomegranate-red-70);

--- a/packages/website/src/examples/Badge/Badge.example.tsx
+++ b/packages/website/src/examples/Badge/Badge.example.tsx
@@ -8,5 +8,6 @@ export default () => (
         <Badge label="New" type={BadgeType.New} extraClasses={['ml1']} />
         <Badge label="Success" type={BadgeType.Success} extraClasses={['ml1']} />
         <Badge label="Warning" type={BadgeType.Warning} extraClasses={['ml1']} />
+        <Badge label="Information" type={BadgeType.Information} extraClasses={['ml1']} />
     </>
 );

--- a/packages/website/src/examples/Badge/BadgeSmall.example.tsx
+++ b/packages/website/src/examples/Badge/BadgeSmall.example.tsx
@@ -8,5 +8,6 @@ export default () => (
         <Badge isSmall label="New" type={BadgeType.New} extraClasses={['ml1']} />
         <Badge isSmall label="Success" type={BadgeType.Success} extraClasses={['ml1']} />
         <Badge isSmall label="Warning" type={BadgeType.Warning} extraClasses={['ml1']} />
+        <Badge isSmall label="Information" type={BadgeType.Information} extraClasses={['ml1']} />
     </>
 );


### PR DESCRIPTION
### Proposed Changes

There's was a sneaky breaking change with the revamp badges. By removing the default value for the type, it allows the existing badge using directly the css classes to keep their colors.

mod-information also make a come back because it's currently used in the admin.

![image](https://user-images.githubusercontent.com/63734941/169575471-c9d0f773-dfb9-492b-8bc6-754f6b20dc79.png)

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
