### PR TITLE
fix(react): prevent dragging stuff across different components

### DIFF
--- a/packages/react/src/components/dragAndDrop/DnDContainer.tsx
+++ b/packages/react/src/components/dragAndDrop/DnDContainer.tsx
@@ -6,6 +6,7 @@ import {Svg} from '../svg/Svg';
 
 export interface IDraggableContainerOwnProps {
     id: string;
+    parentId: string;
     /**
      * A function triggered when another box is dragged over the current box
      *
@@ -18,8 +19,6 @@ export interface IDraggableContainerOwnProps {
     isDraggable?: boolean;
 }
 
-export const DraggableContainerType = 'CONTAINER_BOX';
-
 type DragItem = {id: string};
 
 export const DnDContainer: FunctionComponent<IDraggableContainerOwnProps> = ({
@@ -30,11 +29,13 @@ export const DnDContainer: FunctionComponent<IDraggableContainerOwnProps> = ({
     isDraggable = true,
     onMoveOver,
     id,
+    parentId,
 }) => {
+    const DraggableItemType = `MULTI_LINE_BOX_${parentId}`;
     const ref = useRef<HTMLDivElement>();
     const iconRef = useRef<HTMLDivElement>();
     const [, drop] = useDrop(() => ({
-        accept: DraggableContainerType,
+        accept: DraggableItemType,
         hover: ({id: draggedId}: DragItem) => {
             if (draggedId !== id) {
                 onMoveOver(draggedId);
@@ -43,7 +44,7 @@ export const DnDContainer: FunctionComponent<IDraggableContainerOwnProps> = ({
     }));
     const [{isDragging}, drag, dragPreview] = useDrag(() => ({
         item: (): DragItem => ({id}),
-        type: DraggableContainerType,
+        type: DraggableItemType,
         collect: (monitor) => ({
             isDragging: monitor.isDragging(),
         }),

--- a/packages/react/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
+++ b/packages/react/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
@@ -10,6 +10,10 @@ export interface IDraggableSelectedOptionOwnProps {
      * @param value the unique value of the option dragged over the current option
      */
     onMoveOver: (value: ISelectedOptionProps['value']) => void;
+    /**
+     * The unique identifier of the parent MultiSelect component
+     */
+    parentId: string;
 }
 
 type DragItem = Pick<ISelectedOptionProps, 'value'>;
@@ -19,12 +23,14 @@ export const DraggableSelectedOption: FunctionComponent<IDraggableSelectedOption
     selectedTooltip,
     readOnly,
     value,
+    parentId,
     onMoveOver,
     onRemoveClick,
 }) => {
+    const DraggableItemType = `MULTI_SELECT_OPTION_${parentId}`;
     const dropRef = useRef<HTMLDivElement>();
     const [, drop] = useDrop(() => ({
-        accept: 'MULTI_SELECT_OPTION',
+        accept: DraggableItemType,
         hover: ({value: draggedValue}: DragItem) => {
             if (draggedValue !== value) {
                 onMoveOver(draggedValue);
@@ -32,7 +38,7 @@ export const DraggableSelectedOption: FunctionComponent<IDraggableSelectedOption
         },
     }));
     const [{isDragging}, drag, dragPreview] = useDrag(() => ({
-        type: 'MULTI_SELECT_OPTION',
+        type: DraggableItemType,
         item: (): DragItem => ({value}),
         collect: (monitor) => ({
             isDragging: !!monitor.isDragging(),

--- a/packages/react/src/components/multilineBox/hoc/MultilineBoxWithDnD.tsx
+++ b/packages/react/src/components/multilineBox/hoc/MultilineBoxWithDnD.tsx
@@ -74,6 +74,7 @@ export const multilineBoxWithDnD = (supplier: ConfigSupplier<IMultilineBoxWithDn
                 return (
                     <DnDContainer
                         id={id}
+                        parentId={this.props.id}
                         key={`${id}DnD`}
                         onMoveOver={(draggedId: string) => {
                             // Triggered when another box is dragged over the current box

--- a/packages/react/src/components/multilineBox/tests/MultilineBoxWithDnD.spec.tsx
+++ b/packages/react/src/components/multilineBox/tests/MultilineBoxWithDnD.spec.tsx
@@ -44,4 +44,54 @@ describe('MultilineBoxWithDnD', () => {
         expect(boxes[1]).toHaveTextContent('🍌');
         expect(boxes[2]).toHaveTextContent('🍎');
     });
+
+    it('does not allow dragging items across different multi box components', () => {
+        render(
+            <>
+                <MultilineBoxWithDnD
+                    id="fruits"
+                    data={[{fruit: '🍍'}, {fruit: '🍎'}, {fruit: '🍌'}]}
+                    renderBody={(data) =>
+                        data.map(({id, props}) => (
+                            <div key={id} data-testid={props.fruit ? 'box' : undefined}>
+                                {props.fruit}
+                            </div>
+                        ))
+                    }
+                    defaultProps={{fruit: ''}}
+                />
+                <MultilineBoxWithDnD
+                    id="tools"
+                    data={[{tool: '🔨'}, {tool: '🔧'}, {tool: '🪚'}]}
+                    renderBody={(data) =>
+                        data.map(({id, props}) => (
+                            <div key={id} data-testid={props.tool ? 'box' : undefined}>
+                                {props.tool}
+                            </div>
+                        ))
+                    }
+                    defaultProps={{tool: ''}}
+                />
+            </>
+        );
+
+        let boxes = screen.getAllByTestId('box');
+        expect(boxes[0]).toHaveTextContent('🍍');
+        expect(boxes[1]).toHaveTextContent('🍎');
+        expect(boxes[2]).toHaveTextContent('🍌');
+        expect(boxes[3]).toHaveTextContent('🔨');
+        expect(boxes[4]).toHaveTextContent('🔧');
+        expect(boxes[5]).toHaveTextContent('🪚');
+
+        const dragIcons = screen.getAllByRole('img', {name: /dragdrop icon/i});
+        dragAndDrop(dragIcons[2], 3);
+
+        boxes = screen.getAllByTestId('box');
+        expect(boxes[0]).toHaveTextContent('🍍');
+        expect(boxes[1]).toHaveTextContent('🍎');
+        expect(boxes[2]).toHaveTextContent('🍌');
+        expect(boxes[3]).toHaveTextContent('🔨');
+        expect(boxes[4]).toHaveTextContent('🔧');
+        expect(boxes[5]).toHaveTextContent('🪚');
+    });
 });

--- a/packages/react/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react/src/components/select/MultiSelectConnected.tsx
@@ -154,6 +154,7 @@ class MultiSelect extends PureComponent<IMultiSelectProps & {connectDropTarget: 
             >
                 <span className="mr1">{index + 1}</span>
                 <DraggableSelectedOption
+                    parentId={this.props.id}
                     label={item.selectedDisplayValue ?? item.displayValue ?? item.value}
                     selectedTooltip={item.selectedTooltip}
                     value={item.value}

--- a/packages/react/src/components/select/tests/MultiSelectConnected.spec.tsx
+++ b/packages/react/src/components/select/tests/MultiSelectConnected.spec.tsx
@@ -235,12 +235,12 @@ describe('Select', () => {
             it('does not have the drag icon if the component is not sortable', () => {
                 const items = [{value: '🌱', selected: true}];
 
-                const {container} = render(<MultiSelectConnected id={id} items={items} sortable={false} />);
+                render(<MultiSelectConnected id={id} items={items} sortable={false} />);
 
                 const listitems = screen.getAllByRole('listitem');
                 expect(listitems[0]).toHaveTextContent('🌱');
 
-                const dragIcons = container.querySelector('[aria-grabbed=false] svg');
+                const dragIcons = screen.queryByRole('img', {name: /drag/i});
                 expect(dragIcons).not.toBeInTheDocument();
             });
 
@@ -251,14 +251,14 @@ describe('Select', () => {
                     {value: '🍟', selected: true},
                 ];
 
-                const {container} = render(<MultiSelectConnected id={id} items={items} sortable />);
+                render(<MultiSelectConnected id={id} items={items} sortable />);
 
                 let listitems = screen.getAllByRole('listitem');
                 expect(listitems[0]).toHaveTextContent('🌱');
                 expect(listitems[1]).toHaveTextContent('🥔');
                 expect(listitems[2]).toHaveTextContent('🍟');
 
-                const dragIcons = container.querySelectorAll('[aria-grabbed=false] svg');
+                const dragIcons = screen.getAllByRole('img', {name: /drag/i});
                 dragAndDrop(dragIcons[1], 2);
 
                 listitems = screen.getAllByRole('listitem');
@@ -280,6 +280,46 @@ describe('Select', () => {
                 listitems = screen.getAllByRole('listitem');
                 expect(listitems.length).toBe(1);
                 expect(listitems[0]).toHaveTextContent('🥔');
+            });
+
+            it('does not allow to drag items across different multi selects', () => {
+                render(
+                    <>
+                        <MultiSelectConnected
+                            id="fruits"
+                            items={[
+                                {value: '🍌', selected: true},
+                                {value: '🍊', selected: true},
+                            ]}
+                            sortable
+                        />
+                        ;
+                        <MultiSelectConnected
+                            id="tools"
+                            items={[
+                                {value: '🔨', selected: true},
+                                {value: '🔧', selected: true},
+                            ]}
+                            sortable
+                        />
+                        ;
+                    </>
+                );
+
+                let listitems = screen.getAllByRole('listitem');
+                expect(listitems[0]).toHaveTextContent('🍌');
+                expect(listitems[1]).toHaveTextContent('🍊');
+                expect(listitems[2]).toHaveTextContent('🔨');
+                expect(listitems[3]).toHaveTextContent('🔧');
+
+                const dragIcons = screen.getAllByRole('img', {name: /drag/i});
+                dragAndDrop(dragIcons[1], 2);
+
+                listitems = screen.getAllByRole('listitem');
+                expect(listitems[0]).toHaveTextContent('🍌');
+                expect(listitems[1]).toHaveTextContent('🍊');
+                expect(listitems[2]).toHaveTextContent('🔨');
+                expect(listitems[3]).toHaveTextContent('🔧');
             });
         });
     });


### PR DESCRIPTION
### Proposed Changes

Problem:

https://user-images.githubusercontent.com/35579930/170296843-6481ea0c-288b-41dd-96ff-ff2fbfd10edd.mp4

After this change, you should not be able to drag items across different instances of MultiLineBox and MultiSelectConnected anymore

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
