### PR TITLE
fix(react): make tableWithNewPagination work with tableWithUrlState

### DIFF
--- a/packages/react/src/components/table-hoc/TableWithUrlState.tsx
+++ b/packages/react/src/components/table-hoc/TableWithUrlState.tsx
@@ -7,9 +7,11 @@ import {IDispatch, IThunkAction} from '../../utils/ReduxUtils';
 import {UrlUtils} from '../../utils/UrlUtils';
 import {applyDatePicker, changeDatePickerLowerLimit, changeDatePickerUpperLimit} from '../datePicker/DatePickerActions';
 import {filterThrough} from '../filterBox/FilterBoxActions';
+import {selectFlatSelect} from '../flatSelect';
 import {selectListBoxOption} from '../listBox/ListBoxActions';
 import {changePage} from '../navigation/pagination/NavigationPaginationActions';
 import {changePerPage} from '../navigation/perPage/NavigationPerPageActions';
+import {PaginationUtils} from '../pagination';
 import {TableHeaderActions} from './actions/TableHeaderActions';
 import {ITableHOCOwnProps} from './TableHOC';
 import {ITableHOCPredicateValue, TableHOCUtils} from './utils/TableHOCUtils';
@@ -149,6 +151,7 @@ const updateTableStateFromUrl = (tableId: string): IThunkAction => (dispatch: ID
 
     if (urlParams.hasOwnProperty(Params.pageSize)) {
         dispatch(changePerPage(tableId, urlParams[Params.pageSize]));
+        dispatch(selectFlatSelect(PaginationUtils.getPaginationPerPageId(tableId), urlParams[Params.pageSize] + ''));
     }
 
     if (urlParams.hasOwnProperty(Params.pageNumber)) {

--- a/packages/react/src/components/table-hoc/tests/TableWithUrlState.spec.tsx
+++ b/packages/react/src/components/table-hoc/tests/TableWithUrlState.spec.tsx
@@ -22,6 +22,7 @@ import {tableWithPredicate} from '../TableWithPredicate';
 import {tableWithSort} from '../TableWithSort';
 import {tableWithUrlState} from '../TableWithUrlState';
 import {TableHOCUtils} from '../utils/TableHOCUtils';
+import {selectFlatSelect} from '../../flatSelect';
 
 describe('Table HOC', () => {
     describe('tableWithUrlState', () => {
@@ -128,6 +129,7 @@ describe('Table HOC', () => {
                     .dive();
 
                 expect(store.getActions()).toContainEqual(changePerPage('💎', 3));
+                expect(store.getActions()).toContainEqual(selectFlatSelect('💎_PerPage', '3'));
             });
         });
 


### PR DESCRIPTION
### Proposed Changes

Handle `tableWithNewPagination` in `tableWithUrlState`.

`tableWithUrlState` was not loading properly the pageSize from the url if the table was using the new pagination instead of the old one.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
