### PR TITLE
fix(dropdown btn): fix focus style for btn dropdown

### DIFF
--- a/packages/style/scss/controls/dropdown.scss
+++ b/packages/style/scss/controls/dropdown.scss
@@ -20,6 +20,10 @@
 
     .btn {
         border-color: var(--default-border-color);
+
+        &:focus {
+            border: 1px solid var(--digital-blue-60);
+        }
     }
 }
 


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-723

I noticed that the focus style on the button dropdown for the single select did not had the blue border so i'm adding it.
This is to keep consistency with other forms components

Before:
![image](https://user-images.githubusercontent.com/63734941/170877558-4e8cd2eb-9da7-4660-a45b-ffb3e4d61869.png)

After:
![image](https://user-images.githubusercontent.com/63734941/170877528-af88b8e5-8bc9-42a9-9987-e5935e663e8c.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
