### PR TITLE
fix(toast): add gap in toast-title

### DIFF
--- a/packages/style/scss/components/toast.scss
+++ b/packages/style/scss/components/toast.scss
@@ -150,6 +150,7 @@ $toast-close-padding-left: 20px;
 .toast-title {
     display: flex;
     flex-direction: row;
+    gap: 16px;
     align-items: center;
     justify-content: space-between;
     overflow-wrap: anywhere;


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-731

I noticed in the admin that when the title in the toast has a certain lenght, the space between the title and the X icon is existent 😆 

Adding a gap fix that issue 😄 

Before:
![image](https://user-images.githubusercontent.com/63734941/172009613-b9d1c474-2cfb-4100-b03e-a0cfacbdf0a1.png)

After:
![image](https://user-images.githubusercontent.com/63734941/172009654-2f5382c1-107d-40ae-8d56-5180e76082c7.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
