### PR TITLE
feat(react, button): add new loading option

### DIFF
--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -2,9 +2,15 @@ import classNames from 'classnames';
 import {ButtonHTMLAttributes, Component} from 'react';
 import * as _ from 'underscore';
 
-import {IBaseActionOptions} from '../actions/Action';
-import {Tooltip} from '../tooltip/Tooltip';
+import {IBaseActionOptions} from '../actions';
+import {LoadingSpinner} from '../loading';
+import {Tooltip} from '../tooltip';
+
 export interface IButtonProps extends IBaseActionOptions {
+    /**
+     * If set to true, forces the button to display a spinner to the left of the text
+     */
+    isLoading?: boolean;
     /**
      * If set to true, forces the button to have a smaller size
      */
@@ -19,6 +25,7 @@ const ButtonPropsToOmit = [
     'classes',
     'enabled',
     'hideDisabled',
+    'isLoading',
     'link',
     'name',
     'onClick',
@@ -32,6 +39,7 @@ const ButtonPropsToOmit = [
 export class Button extends Component<IButtonProps & ButtonHTMLAttributes<HTMLButtonElement>> {
     static defaultProps: Partial<IButtonProps> = {
         enabled: true,
+        isLoading: false,
         name: '',
         tooltip: '',
         primary: false,
@@ -58,6 +66,9 @@ export class Button extends Component<IButtonProps & ButtonHTMLAttributes<HTMLBu
 
             buttonElement = (
                 <a className={`${this.className}`} {...buttonAttrs}>
+                    {this.props.isLoading && !this.props.enabled && (
+                        <LoadingSpinner size={this.props.small ? 16 : undefined} />
+                    )}
                     {this.props.name}
                     {this.props.children}
                 </a>
@@ -65,6 +76,9 @@ export class Button extends Component<IButtonProps & ButtonHTMLAttributes<HTMLBu
         } else {
             buttonElement = (
                 <button className={this.className} {...buttonAttrs}>
+                    {this.props.isLoading && !this.props.enabled && (
+                        <LoadingSpinner size={this.props.small ? 16 : undefined} />
+                    )}
                     {this.props.name}
                     {this.props.children}
                 </button>
@@ -91,6 +105,7 @@ export class Button extends Component<IButtonProps & ButtonHTMLAttributes<HTMLBu
             'btn',
             {
                 'mod-primary': this.props.primary,
+                'mod-loading': this.props.isLoading && !this.props.enabled,
                 'mod-small': this.props.small,
                 'state-disabled disabled': !this.props.enabled,
             },

--- a/packages/react/src/components/button/tests/Button.spec.tsx
+++ b/packages/react/src/components/button/tests/Button.spec.tsx
@@ -1,6 +1,7 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as _ from 'underscore';
-import {Tooltip} from '../../tooltip/Tooltip';
+
+import {Tooltip} from '../../tooltip';
 import {Button, IButtonProps} from '../Button';
 
 describe('Button', () => {
@@ -160,6 +161,43 @@ describe('Button', () => {
                 buttonComponent.find('a').simulate('click');
 
                 expect(spyOnClick).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        describe('with the isLoading props', () => {
+            it("shouldn't render the loading button by default", () => {
+                showButton({isLoading: false});
+
+                expect(buttonComponent.find('button').hasClass('mod-loading')).toBe(false);
+                expect(buttonComponent.find('[role="alert"]')[0]).not.toBeDefined();
+            });
+
+            it("shouldn't render the loading button for a standard button", () => {
+                showButton({isLoading: true});
+
+                expect(buttonComponent.find('button').hasClass('mod-loading')).toBe(false);
+                expect(buttonComponent.find('[role="alert"]')[0]).not.toBeDefined();
+            });
+
+            it('should render the loading button for a disabled button', () => {
+                showButton({isLoading: true, enabled: false});
+
+                expect(buttonComponent.find('button').hasClass('mod-loading')).toBe(true);
+                expect(buttonComponent.find('[role="alert"]').hasClass('loading-spinner')).toBe(true);
+            });
+
+            it("shouldn't render the loading button for a primary button", () => {
+                showButton({isLoading: true, primary: true});
+
+                expect(buttonComponent.find('button').hasClass('mod-loading')).toBe(false);
+                expect(buttonComponent.find('[role="alert"]')[0]).not.toBeDefined();
+            });
+
+            it('should render the loading button for a primary disabled button', () => {
+                showButton({isLoading: true, primary: true, enabled: false});
+
+                expect(buttonComponent.find('button').hasClass('mod-loading')).toBe(true);
+                expect(buttonComponent.find('[role="alert"]').hasClass('loading-spinner')).toBe(true);
             });
         });
     });

--- a/packages/style/scss/components/loading.scss
+++ b/packages/style/scss/components/loading.scss
@@ -1,3 +1,5 @@
+@import '../tools/loading';
+
 .spinner {
     width: $loading-size;
     margin: 0 auto;
@@ -91,24 +93,7 @@
 }
 
 .loading-spinner {
-    position: relative;
-    display: inline-block;
-    background: var(--gradient);
-    border-radius: 50%;
-    animation: rotationAnimation 2s linear infinite;
-
-    &:before {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        width: 80%;
-        height: 80%;
-        background: var(--white);
-        border: 3px solid white;
-        border-radius: 50%;
-        transform: translate(-50%, -50%);
-        content: '';
-    }
+    @include spinner();
 }
 
 @keyframes rotationAnimation {

--- a/packages/style/scss/elements/btn.scss
+++ b/packages/style/scss/elements/btn.scss
@@ -249,6 +249,22 @@
     &.collapsible-header {
         border-radius: 0;
     }
+
+    &.mod-loading {
+        .loading-spinner {
+            display: none;
+        }
+
+        &:disabled .loading-spinner,
+        &.state-disabled .loading-spinner {
+            display: inline-block;
+        }
+
+        &.mod-primary:disabled .loading-spinner,
+        &.mod-primary.state-disabled .loading-spinner {
+            --loading-spinner-color-inside: var(--grey-40);
+        }
+    }
 }
 
 button {

--- a/packages/style/scss/guide.scss
+++ b/packages/style/scss/guide.scss
@@ -10,6 +10,7 @@
 @import 'animations';
 @import 'slide-animation';
 @import 'helpers';
+@import 'tools/loading';
 @import 'placeholders';
 @import 'typekit';
 

--- a/packages/style/scss/tools/loading.scss
+++ b/packages/style/scss/tools/loading.scss
@@ -1,0 +1,25 @@
+/// @output Create an animated spinner
+///
+/// @param {Color} $colorInside [var(--white)] - color inside spinner
+@mixin spinner($colorInside: var(--white)) {
+    --loading-spinner-color-inside: #{$colorInside};
+
+    position: relative;
+    display: inline-block;
+    background: var(--gradient);
+    border-radius: 50%;
+    animation: rotationAnimation 2s linear infinite;
+
+    &:before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 80%;
+        height: 80%;
+        background: var(--loading-spinner-color-inside);
+        border: 3px solid var(--loading-spinner-color-inside);
+        border-radius: 50%;
+        transform: translate(-50%, -50%);
+        content: '';
+    }
+}

--- a/packages/website/src/examples/button/Button.example.tsx
+++ b/packages/website/src/examples/button/Button.example.tsx
@@ -1,0 +1,3 @@
+import {Button} from '@coveord/plasma-react';
+
+export default () => <Button>Hello World!</Button>;

--- a/packages/website/src/examples/button/Disabled.example.tsx
+++ b/packages/website/src/examples/button/Disabled.example.tsx
@@ -1,0 +1,7 @@
+import {Button} from '@coveord/plasma-react';
+
+export default () => (
+    <Button primary enabled={false}>
+        Hello World!
+    </Button>
+);

--- a/packages/website/src/examples/button/IconAndLink.example.tsx
+++ b/packages/website/src/examples/button/IconAndLink.example.tsx
@@ -1,0 +1,8 @@
+import {Button} from '@coveord/plasma-react';
+import {ZombieSize24Px} from '@coveord/plasma-react-icons';
+
+export default () => (
+    <Button link="https://www.coveo.com">
+        <ZombieSize24Px height={24} aria-label="zombie" />
+    </Button>
+);

--- a/packages/website/src/examples/button/Loading.example.tsx
+++ b/packages/website/src/examples/button/Loading.example.tsx
@@ -1,0 +1,12 @@
+import {Button} from '@coveord/plasma-react';
+
+export default () => (
+    <>
+        <Button isLoading enabled={false}>
+            Disabled
+        </Button>
+        <Button isLoading primary enabled={false}>
+            Primary disabled
+        </Button>
+    </>
+);

--- a/packages/website/src/examples/button/Prepend.example.tsx
+++ b/packages/website/src/examples/button/Prepend.example.tsx
@@ -1,0 +1,8 @@
+import {Button} from '@coveord/plasma-react';
+
+export default () => (
+    <Button classes={['mod-prepend']}>
+        <span className="btn-prepend">P</span>
+        Hello World!
+    </Button>
+);

--- a/packages/website/src/examples/button/Primary.example.tsx
+++ b/packages/website/src/examples/button/Primary.example.tsx
@@ -1,0 +1,3 @@
+import {Button} from '@coveord/plasma-react';
+
+export default () => <Button primary>Hello World!</Button>;

--- a/packages/website/src/examples/button/Small.example.tsx
+++ b/packages/website/src/examples/button/Small.example.tsx
@@ -1,0 +1,3 @@
+import {Button} from '@coveord/plasma-react';
+
+export default () => <Button small>Hello World!</Button>;

--- a/packages/website/src/pages/form/Button.tsx
+++ b/packages/website/src/pages/form/Button.tsx
@@ -1,49 +1,14 @@
-import {FunctionComponent} from 'react';
+import code from '@examples/button/Button.example.tsx';
+import disabled from '@examples/button/Disabled.example.tsx';
+import iconAndLink from '@examples/button/IconAndLink.example.tsx';
+import loading from '@examples/button/Loading.example.tsx';
+import prepend from '@examples/button/Prepend.example.tsx';
+import primary from '@examples/button/Primary.example.tsx';
+import small from '@examples/button/Small.example.tsx';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
-const code = `
-    import {Button} from "@coveord/plasma-react";
-
-    export default () => <Button>Hello World!</Button>;
-`;
-
-const primary = `
-    import {Button} from "@coveord/plasma-react";
-
-    export default () => <Button primary>Hello World!</Button>;
-`;
-
-const small = `
-    import {Button} from "@coveord/plasma-react";
-
-    export default () => <Button small>Hello World!</Button>;
-`;
-
-const iconAndLink = `
-    import {Button} from "@coveord/plasma-react";
-    import {ZombieSize24Px} from '@coveord/plasma-react-icons';
-
-    export default () => <Button link="https://www.coveo.com"><ZombieSize24Px height={24} aria-label="zombie" /></Button>;
-`;
-
-const disabled = `
-    import {Button} from "@coveord/plasma-react";
-
-    export default () => <Button primary enabled={false}>Hello World!</Button>;
-    `;
-
-const prepend = `
-    import { Button, Svg } from '@coveord/plasma-react';
-
-    export default () => (
-        <Button classes={['mod-prepend']}>
-            <span className="btn-prepend">P</span>
-            Hello World!
-        </Button>
-    );
-`;
-
-export const ButtonExamples: FunctionComponent = () => (
+export default () => (
     <PageLayout
         id="Button"
         title="Button"
@@ -55,10 +20,10 @@ export const ButtonExamples: FunctionComponent = () => (
             primary: {code: primary, title: 'Primary, Default size'},
             small: {code: small, title: 'Secondary, Small size'},
             disabled: {code: disabled, title: 'Disabled'},
+            loading: {code: loading, title: 'Loading'},
             prepend: {code: prepend, title: 'Prepended icon'},
             iconAndLink: {code: iconAndLink, title: 'Icon only with an hyperlink'},
         }}
         componentSourcePath="/button/Button.tsx"
     />
 );
-export default ButtonExamples;


### PR DESCRIPTION
### Proposed Changes

Added `isLoading` props on buttons to show `LoadingSpinner` component.

![image](https://user-images.githubusercontent.com/966550/172290944-8df37ab7-09a2-4558-be22-1a560c109e7e.png)

### Potential Breaking Changes

NO

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
