### PR TITLE
style: add CSS class for align-items: baseline

### DIFF
--- a/packages/style/scss/utility/flex.scss
+++ b/packages/style/scss/utility/flex.scss
@@ -14,6 +14,10 @@
     flex-wrap: wrap;
 }
 
+.flex-baseline {
+    align-items: baseline;
+}
+
 .flex-center {
     align-items: center;
 }


### PR DESCRIPTION
### Proposed Changes

Adds new CSS class that gives flex `align-items: baseline`.  I am using this in an upcoming feature and it could be added to Plasma.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
