### PR TITLE
fix(tooltip): arrow adjustment on position

### DIFF
--- a/packages/style/scss/components/tooltip.scss
+++ b/packages/style/scss/components/tooltip.scss
@@ -30,6 +30,7 @@
 
         .tooltip-arrow {
             bottom: 0;
+            left: 50%;
             margin-left: calc(-1 * var(--arrow-size));
             border-width: var(--arrow-size) var(--arrow-size) 0;
             border-top-color: var(--tooltip-color);
@@ -42,6 +43,7 @@
         padding: 0 var(--arrow-size);
 
         .tooltip-arrow {
+            top: 50%;
             left: 0;
             margin-top: calc(-1 * var(--arrow-size));
             border-width: var(--arrow-size) var(--arrow-size) var(--arrow-size) 0;
@@ -56,6 +58,7 @@
 
         .tooltip-arrow {
             top: 0;
+            left: 50%;
             margin-left: calc(-1 * var(--arrow-size));
             border-width: 0 var(--arrow-size) var(--arrow-size);
             border-bottom-color: var(--tooltip-color);
@@ -68,6 +71,7 @@
         padding: 0 var(--arrow-size);
 
         .tooltip-arrow {
+            top: 50%;
             right: 0;
             margin-top: calc(-1 * var(--arrow-size));
             border-width: var(--arrow-size) 0 var(--arrow-size) var(--arrow-size);


### PR DESCRIPTION
✅ Closes: 8020

### Proposed Changes

- Adjusted the positioning of arrow by adding their respective positions back to 50% - this will resolve the backbone component tooltips with the arrow being misaligned.

| Before | After |
| --- | ----------- |
| ![CleanShot 2022-06-21 at 13 29 30](https://user-images.githubusercontent.com/66333175/174861468-a18501b7-47ac-4cef-8200-44566733b105.png) | ![CleanShot 2022-06-21 at 13 04 03](https://user-images.githubusercontent.com/66333175/174861377-06ac4de3-db7b-45de-86cb-6f4b39fad36c.png) 


You can test this by linking up Admin-UI and Plasma and go to the following panels reported in [ADUI-8020](https://coveord.atlassian.net/browse/ADUI-8020).
 
Tooltips in UA are affected by this change and will be fixed with this PR.





### Potential Breaking Changes

- There should be none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
