### PR TITLE
fix(react, date picker): make sure the date are dynamics

### DIFF
--- a/packages/react/src/components/calendar/Calendar.tsx
+++ b/packages/react/src/components/calendar/Calendar.tsx
@@ -126,7 +126,6 @@ export class Calendar extends Component<ICalendarProps, any> {
         years: DEFAULT_YEARS,
         months: DEFAULT_MONTHS,
         days: DEFAULT_DAYS,
-        startingMonth: DateUtils.currentMonth,
         startingDay: 0,
         showHeader: true,
         defaultLanguage: 'en',
@@ -251,6 +250,7 @@ export class Calendar extends Component<ICalendarProps, any> {
     }
 
     render() {
+        const startingMonth = this.props.startingMonth || DateUtils.currentMonth;
         const monthPickerProps: IOptionsCycleProps = {
             options: this.props.months,
             isInline: true,
@@ -282,13 +282,9 @@ export class Calendar extends Component<ICalendarProps, any> {
         }));
 
         const monthPicker = this.props.withReduxState ? (
-            <OptionsCycleConnected
-                id={this.props.id + MONTH_PICKER_ID}
-                startAt={this.props.startingMonth}
-                {...monthPickerProps}
-            />
+            <OptionsCycleConnected id={this.props.id + MONTH_PICKER_ID} startAt={startingMonth} {...monthPickerProps} />
         ) : (
-            <OptionsCycle currentOption={this.props.startingMonth} {...monthPickerProps} />
+            <OptionsCycle currentOption={startingMonth} {...monthPickerProps} />
         );
 
         const yearPicker = this.props.withReduxState ? (
@@ -299,9 +295,7 @@ export class Calendar extends Component<ICalendarProps, any> {
 
         const selectedYearOption = !_.isUndefined(this.props.selectedYear) ? this.props.selectedYear : startingYear;
         const year = parseInt(this.props.years[selectedYearOption], 10);
-        const selectedMonth = !_.isUndefined(this.props.selectedMonth)
-            ? this.props.selectedMonth
-            : this.props.startingMonth;
+        const selectedMonth = !_.isUndefined(this.props.selectedMonth) ? this.props.selectedMonth : startingMonth;
         const month: IDay[][] = DateUtils.getMonthWeeks(new Date(year, selectedMonth), this.props.startingDay);
         const weeks: JSX.Element[] = _.map(month, (week: IDay[]) => {
             const days: JSX.Element[] = _.map(week, (day: IDay) => {

--- a/packages/react/src/components/datePicker/DatePickerReducers.ts
+++ b/packages/react/src/components/datePicker/DatePickerReducers.ts
@@ -22,7 +22,7 @@ export interface IDatePickerState {
     simple: boolean;
 }
 
-export const datePickerInitialState: IDatePickerState = {
+export const datePickerInitialState: () => IDatePickerState = () => ({
     id: undefined,
     calendarId: undefined,
     isRange: false,
@@ -35,7 +35,7 @@ export const datePickerInitialState: IDatePickerState = {
     inputUpperLimit: moment().endOf('day').toDate(),
     appliedLowerLimit: moment().startOf('day').toDate(),
     appliedUpperLimit: moment().endOf('day').toDate(),
-};
+});
 export const datePickersInitialState: IDatePickerState[] = [];
 
 const addDatePicker = (state: IDatePickerState, action: IReduxAction<IAddDatePickerPayload>): IDatePickerState => {
@@ -136,7 +136,7 @@ const clearSelection = (state: IDatePickerState, action: IReduxAction<IReduxActi
           });
 
 export const datePickerReducer = (
-    state: IDatePickerState = datePickerInitialState,
+    state: IDatePickerState = datePickerInitialState(),
     action: IReduxAction<any>
 ): IDatePickerState => {
     switch (action.type) {

--- a/packages/react/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/packages/react/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -86,13 +86,14 @@ describe('Date picker', () => {
             it('should return the old state with default lowerlimit and upperlimit state properties if initialDateRange is not passed', () => {
                 const datePickersState: IDatePickerState[] = datePickersReducer(undefined, action);
 
-                expect(datePickersState[0].lowerLimit as Date).toBe(datePickerInitialState.lowerLimit);
-                expect(datePickersState[0].inputLowerLimit as Date).toBe(datePickerInitialState.inputLowerLimit);
-                expect(datePickersState[0].appliedLowerLimit as Date).toBe(datePickerInitialState.appliedLowerLimit);
+                const initialState = datePickerInitialState();
+                expect(datePickersState[0].lowerLimit as Date).toStrictEqual(initialState.lowerLimit);
+                expect(datePickersState[0].inputLowerLimit as Date).toStrictEqual(initialState.inputLowerLimit);
+                expect(datePickersState[0].appliedLowerLimit as Date).toStrictEqual(initialState.appliedLowerLimit);
 
-                expect(datePickersState[0].upperLimit as Date).toBe(datePickerInitialState.upperLimit);
-                expect(datePickersState[0].inputUpperLimit as Date).toBe(datePickerInitialState.inputUpperLimit);
-                expect(datePickersState[0].appliedUpperLimit as Date).toBe(datePickerInitialState.appliedUpperLimit);
+                expect(datePickersState[0].upperLimit as Date).toStrictEqual(initialState.upperLimit);
+                expect(datePickersState[0].inputUpperLimit as Date).toStrictEqual(initialState.inputUpperLimit);
+                expect(datePickersState[0].appliedUpperLimit as Date).toStrictEqual(initialState.appliedUpperLimit);
             });
 
             it('should return the old state with initialDateRange set properly in the state if passed', () => {
@@ -322,7 +323,7 @@ describe('Date picker', () => {
         it('should return the default state if the action is not defined and the state is undefined', () => {
             const datePickerState: IDatePickerState = datePickerReducer(undefined, GENERIC_ACTION);
 
-            expect(datePickerState).toBe(datePickerInitialState);
+            expect(datePickerState).toStrictEqual(datePickerInitialState());
         });
 
         it('should return the old state when the action is not defined', () => {
@@ -333,7 +334,7 @@ describe('Date picker', () => {
         });
 
         it('should return a new date picker with the specified id when the action is "ADD_DATE_PICKER"', () => {
-            const oldDatePicker: IDatePickerState = datePickerInitialState;
+            const oldDatePicker: IDatePickerState = datePickerInitialState();
             const action: IReduxAction<IAddDatePickerPayload> = {
                 type: DatePickerActions.add,
                 payload: {
@@ -353,7 +354,7 @@ describe('Date picker', () => {
             'should return a new datepicker state that is unselected when the actions is "ADD_DATE_PICKER" ' +
                 'and the payload contains initiallyUnselected true',
             () => {
-                const oldDatePicker: IDatePickerState = datePickerInitialState;
+                const oldDatePicker: IDatePickerState = datePickerInitialState();
                 const action: IReduxAction<IAddDatePickerPayload> = {
                     type: DatePickerActions.add,
                     payload: {
@@ -375,7 +376,7 @@ describe('Date picker', () => {
         );
 
         it('should return a new date picker with the rangeLimit when the action is "ADD_DATE_PICKER"', () => {
-            const oldDatePicker: IDatePickerState = datePickerInitialState;
+            const oldDatePicker: IDatePickerState = datePickerInitialState();
             const rangeLimit: IRangeLimit = {
                 weeks: 1,
                 days: 1,
@@ -790,7 +791,7 @@ describe('Date picker', () => {
         );
 
         it('should not change the original state', () => {
-            const expectedState = _.extend({}, datePickerInitialState);
+            const expectedState = _.extend({}, datePickerInitialState());
             const action: IReduxAction<IChangeDatePickerPayload> = {
                 type: DatePickerActions.changeUpperLimit,
                 payload: {
@@ -798,9 +799,9 @@ describe('Date picker', () => {
                     date: new Date(new Date().setHours(3, 3, 3, 3)),
                 },
             };
-            datePickerReducer(datePickerInitialState, action);
+            datePickerReducer(datePickerInitialState(), action);
 
-            expect(expectedState).toEqual(datePickerInitialState);
+            expect(expectedState).toEqual(datePickerInitialState());
         });
 
         describe('reducer for the action "APPLY_DATE"', () => {


### PR DESCRIPTION
### Proposed Changes

Made sure the calendar initial date is dynamic

### How to Test

Open the demo, put that in the console (it overrides the date and set Jan 1 2022). 

```javascript
Date = class extends Date{
     constructor(options) {
         if (options) {
         super(options);
       } else {
          super(1641013200000);
         }
     }
   };
```

type `new Date()` in your console to make sure it worked.

Open the date picker demo, the initially selected month should be January

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
