### PR TITLE
chore(deps): make renovate less eager to update packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,10 +11,12 @@
   "commitBody": "UITOOL-284",
   "packageRules": [
     {
-      "description": "Automatically merge minor and patch-level updates",
-      "updateTypes": ["minor", "patch"],
-      "automerge": true,
-      "semanticCommitType": "chore"
+        "description": "Automatically merge minor and patch-level updates",
+        "updateTypes": ["minor", "patch"],
+        "automerge": true,
+        "semanticCommitType": "chore",
+        "stabilityDays": 7,
+        "internalChecksFilter": "strict"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
### Proposed Changes

https://docs.renovatebot.com/configuration-options/#internalchecksfilter

> If you combine stabilityDays=3 and internalChecksFilter="strict" then Renovate will hold back from creating branches until 3 or more days have elapsed since the version was released.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
