### PR TITLE
feat(react): allow using dropdowns inside popover

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,6 +43,32 @@ import {Badge} from '@coveord/plasma-react';
 ReactDom.render(<Badge label="Hello Plasma!" />, document.getElementById('SomewhereInYourApp'));
 ```
 
+#### Dropdowns
+
+All components that implement a dropdown behaviour like the SingleSelect or the MultiSelect will render their content outside the normal DOM hierachy using react portals to avoid some overlapping issues.
+
+The target of that portal is given by the `Defaults.DROP_ROOT` selector, but you can change this value to something else if you need.
+
+```ts
+Defaults.DROP_ROOT = '#plasma-dropdowns'; // default
+```
+
+**If no DOM element match the specified selector an error will be thrown, so make sure this selector points to an element that always exists in the DOM. Preferably, that element should be outside the hierarchy of the whole app.**
+
+Example of a working DOM structure:
+
+```html
+<html>
+    <head>
+        <!-- ... -->
+    </head>
+    <body className="coveo-styleguide">
+        <div id="App"><!-- Your app renders here --></div>
+        <div id="plasma-dropdowns"></div>
+    </body>
+</html>
+```
+
 ## Contributing
 
 See [our main page](https://github.com/coveo/plasma#plasma).

--- a/packages/react/jest/utils.tsx
+++ b/packages/react/jest/utils.tsx
@@ -11,13 +11,11 @@ import {IDispatch} from '../src/utils/ReduxUtils';
 
 const TEST_CONTAINER_ID = 'app';
 const MODAL_ROOT_ID = 'modals';
-const DROP_ROOT_ID = 'dropdowns';
 
 const setup = () => {
-    document.body.innerHTML = `<div id="${TEST_CONTAINER_ID}"></div><div id="${MODAL_ROOT_ID}"></div><div id="${DROP_ROOT_ID}"></div>`;
+    document.body.innerHTML = `<div id="${TEST_CONTAINER_ID}"></div><div id="${MODAL_ROOT_ID}"></div><div id="plasma-dropdowns"></div>`;
     Defaults.APP_ELEMENT = '#' + TEST_CONTAINER_ID;
     Defaults.MODAL_ROOT = '#' + MODAL_ROOT_ID;
-    Defaults.DROP_ROOT = '#' + DROP_ROOT_ID;
     Defaults.MODAL_TIMEOUT = 0;
 };
 

--- a/packages/react/src/Defaults.ts
+++ b/packages/react/src/Defaults.ts
@@ -4,7 +4,7 @@ export abstract class Defaults {
     static MODAL_ROOT: string = 'body';
     static MODAL_TIMEOUT: number = 300;
 
-    static DROP_ROOT: string = 'body';
+    static DROP_ROOT: string = '#plasma-dropdowns';
     static DROP_PARENT_ROOT: string = 'body';
 
     static TOOLTIP_ROOT: string = 'body';

--- a/packages/react/src/components/drop/DropPod.tsx
+++ b/packages/react/src/components/drop/DropPod.tsx
@@ -105,8 +105,14 @@ const RDropPod: FunctionComponent<IRDropPodProps> = ({
 
     useEffect(() => {
         const element = document.createElement('div');
-        const portalRoot = document.querySelector(selector ?? Defaults.DROP_ROOT);
+        const rootSelector = selector ?? Defaults.DROP_ROOT;
+        const portalRoot = document.querySelector(rootSelector);
 
+        if (portalRoot === null) {
+            throw new Error(
+                `Plasma dropdowns' root element at "${rootSelector}" does not exist in the DOM. Make sure this element exists or change Defaults.DROP_ROOT to something else. More info at https://github.com/coveo/plasma/blob/master/packages/react/README.md#dropdowns`
+            );
+        }
         portalRoot.appendChild(element);
 
         setDropElement(element);

--- a/packages/react/src/components/drop/tests/DropPod.spec.tsx
+++ b/packages/react/src/components/drop/tests/DropPod.spec.tsx
@@ -96,7 +96,7 @@ describe('DropPod', () => {
 
             describe('portal creation selector', () => {
                 afterEach(() => {
-                    Defaults.DROP_ROOT = 'body';
+                    Defaults.DROP_ROOT = '#plasma-dropdowns';
                 });
 
                 it('should render the content inside of the selector', () => {

--- a/packages/react/src/components/popover/Popover.tsx
+++ b/packages/react/src/components/popover/Popover.tsx
@@ -24,20 +24,13 @@ export interface ITetherComponentCopiedProps {
     onRepositioned?: (...args: any[]) => void;
 }
 
-interface PopoverOwnProps {
-    /**
-     * Whether the popover has dropdowns components rendered in it. The goal of this prop is to prevent the popover from closing when selecting a dropdown value.
-     */
-    hasDropdowns?: boolean;
-}
-
 export interface IPopoverDispatchProps {
     onToggle?: (isOpen: boolean) => void;
     onMount?: (isOpen: boolean) => void;
     onUnmount?: () => void;
 }
 
-export interface IPopoverProps extends PopoverOwnProps, IPopoverDispatchProps, ITetherComponentCopiedProps {
+export interface IPopoverProps extends IPopoverDispatchProps, ITetherComponentCopiedProps {
     id?: string;
     /**
      * Optionnal, use it to specify the isOpen state of the Popover.
@@ -131,7 +124,7 @@ export class Popover extends Component<IPopoverProps, IPopoverState> {
             const tetherElement: Element | Text = findDOMNode(this.tetherElement.current);
             const target: Node = event.target as Node;
             const dropdownsContainer = document.querySelector(Defaults.DROP_ROOT);
-            const clickedInsideADropdown = this.props.hasDropdowns && dropdownsContainer.contains(target);
+            const clickedInsideADropdown = dropdownsContainer.contains(target);
 
             if (!tetherElement.contains(target) && !tetherToggle.contains(target) && !clickedInsideADropdown) {
                 if (this.props.isModal) {

--- a/packages/react/src/components/popover/tests/Popover.spec.tsx
+++ b/packages/react/src/components/popover/tests/Popover.spec.tsx
@@ -203,7 +203,6 @@ describe('<Popover>', () => {
                             targetAttachment="bottom left"
                             isOpen={isOpen}
                             onToggle={setOpen}
-                            hasDropdowns
                         >
                             <Button>Toggle</Button>
                             <div className="p3">

--- a/packages/react/src/components/popover/tests/Popover.spec.tsx
+++ b/packages/react/src/components/popover/tests/Popover.spec.tsx
@@ -1,7 +1,12 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as _ from 'underscore';
+import {render, screen} from '@test-utils';
 
+import userEvent from '@testing-library/user-event';
+import {useState} from 'react';
 import {IPopoverProps, Popover} from '../Popover';
+import {Button} from '../../button';
+import {SingleSelectConnected} from '../../select';
 
 describe('<Popover>', () => {
     let popoverProps: IPopoverProps;
@@ -187,6 +192,39 @@ describe('<Popover>', () => {
                 expect(toggleOpenedSpy.mock.calls.length).toBe(1);
 
                 expect(toggleOpenedSpy).toHaveBeenCalledWith(false);
+            });
+
+            it('does not close the popover when clicking on children dropdown values', () => {
+                const Fixture = () => {
+                    const [isOpen, setOpen] = useState(false);
+                    return (
+                        <Popover
+                            attachment="top left"
+                            targetAttachment="bottom left"
+                            isOpen={isOpen}
+                            onToggle={setOpen}
+                            hasDropdowns
+                        >
+                            <Button>Toggle</Button>
+                            <div className="p3">
+                                <SingleSelectConnected
+                                    id="single-select-1"
+                                    items={[
+                                        {value: 'one', displayValue: 'Option 1'},
+                                        {value: 'two', displayValue: 'Option 2'},
+                                        {value: 'three', displayValue: 'Option 3'},
+                                    ]}
+                                />
+                            </div>
+                        </Popover>
+                    );
+                };
+                render(<Fixture />);
+
+                userEvent.click(screen.getByRole('button', {name: /toggle/i}));
+                userEvent.click(screen.getByRole('button', {name: /select an option/i}));
+                userEvent.click(screen.getByRole('option', {name: /option 2/i}));
+                expect(screen.getByRole('button', {name: /option 2/i})).toBeInTheDocument();
             });
         });
 

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -52,7 +52,6 @@ const MyApp = ({Component, pageProps}: AppProps) => {
     React.useEffect(() => {
         PlasmaReact.Defaults.APP_ELEMENT = '#App';
         PlasmaReact.Defaults.MODAL_ROOT = '#Modals';
-        PlasmaReact.Defaults.DROP_ROOT = '#Drops';
 
         window.ReactDOM = ReactDOM;
         (window as any).jsxRuntime = jsxRuntime;

--- a/packages/website/src/pages/_document.tsx
+++ b/packages/website/src/pages/_document.tsx
@@ -11,7 +11,7 @@ const Document: FunctionComponent = () => (
                 <Main />
             </div>
             <div id="Modals" />
-            <div id="Drops" />
+            <div id="plasma-dropdowns" />
             <NextScript />
         </body>
     </Html>


### PR DESCRIPTION
### Proposed Changes

When using a dropdown inside a popover, it would toggle closed the whole popover when selecting a dropdown value.

To test in the demo:
1. copy the following code in a sandbox
2. try selecting a value in the dropdown inside the popover (the popover shouldn't close)
3. try removing the `hasDropdowns` prop and do step 2 (popover closes)

```tsx
import { Popover, SingleSelectConnected, Button } from '@coveord/plasma-react';
import { useState } from 'react';

export default () => {
    const [isOpen, setOpen] = useState(false);
    return (
        <Popover
            attachment="top left"
            targetAttachment="bottom left"
            isOpen={isOpen}
            onToggle={setOpen}
            hasDropdowns
        >
            <Button>Toggle</Button>
            <div className='p3'>
                <SingleSelectConnected
                    id="single-select-1"
                    items={[
                        { value: 'one', displayValue: 'Option 1' },
                        { value: 'two', displayValue: 'Option 2' },
                        { value: 'three', displayValue: 'Option 3' },
                    ]}
                />
            </div>
        </Popover>
    )
};

```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
