### PR TITLE
fix(react, single select): call onSelectOptionCallback if there is a selected option

### DIFF
--- a/packages/react/src/components/select/SingleSelectConnected.tsx
+++ b/packages/react/src/components/select/SingleSelectConnected.tsx
@@ -82,7 +82,9 @@ export const SingleSelectConnected: FunctionComponent<ISingleSelectProps> = ({
     const selectedOption = customSelected.length ? customSelected[customSelected.length - 1] : defaultSelected;
 
     useEffect(() => {
-        props.onSelectOptionCallback?.(selectedOption);
+        if (selectedOption) {
+            props.onSelectOptionCallback?.(selectedOption);
+        }
     }, [selectedOption]);
 
     const Toggle: FunctionComponent<ISelectButtonProps> = ({onClick, onKeyDown, onKeyUp, selectedOptions, isOpen}) => {

--- a/packages/react/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/packages/react/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -207,6 +207,7 @@ describe('Select', () => {
 
             userEvent.click(screen.getByText('to select value'));
 
+            expect(onSelectOptionCallbackSpy).toHaveBeenCalledTimes(1);
             expect(onSelectOptionCallbackSpy).toHaveBeenCalledWith('b');
         });
         describe('keyboard events', () => {


### PR DESCRIPTION
### Proposed Changes

Small fix related to #2798, it was calling the method on mount

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
