### PR TITLE
chore: 🤖 bump semantic-monorepo-tools

### DIFF
--- a/build/getLastTag.mjs
+++ b/build/getLastTag.mjs
@@ -2,7 +2,7 @@ import {getLastTag} from '@coveo/semantic-monorepo-tools';
 import url from 'url';
 
 const VERSION_PREFIX = 'v';
-const lastTag = getLastTag(VERSION_PREFIX)?.[0];
+const lastTag = await getLastTag(VERSION_PREFIX)?.[0];
 
 export default function() {
     return lastTag;

--- a/build/getLastTag.mjs
+++ b/build/getLastTag.mjs
@@ -2,7 +2,7 @@ import {getLastTag} from '@coveo/semantic-monorepo-tools';
 import url from 'url';
 
 const VERSION_PREFIX = 'v';
-const lastTag = await getLastTag(VERSION_PREFIX)?.[0];
+const lastTag = await getLastTag(VERSION_PREFIX);
 
 export default function() {
     return lastTag;

--- a/build/publishNewVersion.mjs
+++ b/build/publishNewVersion.mjs
@@ -48,18 +48,18 @@ const outputProcess = (process) => {
 (async () => {
     const convention = await angularChangelogConvention;
 
-    const lastTag = getLastTag();
+    const lastTag = await getLastTag();
     console.log('Last tag: %s', lastTag);
 
-    const [remote] = getRemoteName();
+    const [remote] = await getRemoteName();
 
-    const changedPackages = pnpmGetChangedPackages(lastTag);
+    const changedPackages = await pnpmGetChangedPackages(lastTag);
     if (!changedPackages.includes('root')) {
         changedPackages.push('root');
     }
 
     if (changedPackages.length > 0) {
-        const [commits] = getCommits(PATH, lastTag);
+        const [commits] = await getCommits(PATH, lastTag);
 
         const parsedCommits = parseCommits(commits, convention.parserOpts);
         let bumpInfo;
@@ -74,7 +74,7 @@ const outputProcess = (process) => {
 
         if (newVersion !== currentVersion) {
             console.log('Bumping %s to version %s', changedPackages.join(', '), newVersion);
-            pnpmBumpVersion(newVersion, lastTag, ['root']);
+            await pnpmBumpVersion(newVersion, lastTag, ['root']);
 
             if (parsedCommits.length > 0) {
                 const changelog = await generateChangelog(
@@ -92,19 +92,19 @@ const outputProcess = (process) => {
 
             const versionTag = `${VERSION_PREFIX}${newVersion}`;
             if (!options.dry) {
-                outputProcess(gitCommit(`chore(release): publish version ${versionTag} [version bump]`, '.'));
-                gitTag(versionTag);
+                outputProcess(await gitCommit(`chore(release): publish version ${versionTag} [version bump]`, '.'));
+                await gitTag(versionTag);
 
                 if (remote) {
                     console.log(`Pushing version ${versionTag} on git`);
-                    outputProcess(gitPush());
-                    outputProcess(gitPushTags());
+                    outputProcess(await gitPush());
+                    outputProcess(await gitPushTags());
                 }
 
                 outputProcess(spawnSync('git', ['status'], {encoding: 'utf-8'}));
 
                 console.log(`Publishing version ${versionTag} on NPM`);
-                outputProcess(pnpmPublish(options.tag, options.branch));
+                outputProcess(await pnpmPublish(options.tag, options.branch));
             } else {
                 console.log('Would have called pnpmPublish with the following arguments:');
                 console.log(`pnpmPublish(${options.tag}, ${options.branch})`);

--- a/build/publishNewVersion.mjs
+++ b/build/publishNewVersion.mjs
@@ -51,7 +51,7 @@ const outputProcess = (process) => {
     const lastTag = await getLastTag();
     console.log('Last tag: %s', lastTag);
 
-    const [remote] = await getRemoteName();
+    const remote = await getRemoteName();
 
     const changedPackages = await pnpmGetChangedPackages(lastTag);
     if (!changedPackages.includes('root')) {
@@ -59,7 +59,7 @@ const outputProcess = (process) => {
     }
 
     if (changedPackages.length > 0) {
-        const [commits] = await getCommits(PATH, lastTag);
+        const commits = await getCommits(PATH, lastTag);
 
         const parsedCommits = parseCommits(commits, convention.parserOpts);
         let bumpInfo;
@@ -69,7 +69,7 @@ const outputProcess = (process) => {
             bumpInfo = convention.recommendedBumpOpts.whatBump(parsedCommits);
         }
 
-        const currentVersion = {version: lastTag.replace(VERSION_PREFIX, '')};
+        const currentVersion = lastTag.replace(VERSION_PREFIX, '');
         const newVersion = getNextVersion(currentVersion, bumpInfo);
 
         if (newVersion !== currentVersion) {
@@ -92,19 +92,19 @@ const outputProcess = (process) => {
 
             const versionTag = `${VERSION_PREFIX}${newVersion}`;
             if (!options.dry) {
-                outputProcess(await gitCommit(`chore(release): publish version ${versionTag} [version bump]`, '.'));
+                await gitCommit(`chore(release): publish version ${versionTag} [version bump]`, '.');
                 await gitTag(versionTag);
 
                 if (remote) {
                     console.log(`Pushing version ${versionTag} on git`);
-                    outputProcess(await gitPush());
-                    outputProcess(await gitPushTags());
+                    await gitPush();
+                    await gitPushTags();
                 }
 
-                outputProcess(spawnSync('git', ['status'], {encoding: 'utf-8'}));
+                spawnSync('git', ['status'], {encoding: 'utf-8'});
 
                 console.log(`Publishing version ${versionTag} on NPM`);
-                outputProcess(await pnpmPublish(options.tag, options.branch));
+                await pnpmPublish(options.tag, options.branch);
             } else {
                 console.log('Would have called pnpmPublish with the following arguments:');
                 console.log(`pnpmPublish(${options.tag}, ${options.branch})`);

--- a/build/publishNewVersion.mjs
+++ b/build/publishNewVersion.mjs
@@ -104,10 +104,10 @@ const outputProcess = (process) => {
                 outputProcess(spawnSync('git', ['status'], {encoding: 'utf-8'}));
 
                 console.log(`Publishing version ${versionTag} on NPM`);
-                outputProcess(pnpmPublish(lastTag, options.tag, options.branch));
+                outputProcess(pnpmPublish(options.tag, options.branch));
             } else {
                 console.log('Would have called pnpmPublish with the following arguments:');
-                console.log(`pnpmPublish(${lastTag}, ${options.tag}, ${options.branch})`);
+                console.log(`pnpmPublish(${options.tag}, ${options.branch})`);
             }
         }
     } else {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "@commitlint/cli": "16.2.4",
         "@commitlint/config-conventional": "16.2.4",
-        "@coveo/semantic-monorepo-tools": "0.4.0",
+        "@coveo/semantic-monorepo-tools": "1.1.0",
         "@sindresorhus/slugify": "2.1.0",
         "aws-sdk": "2.1125.0",
         "axios": "0.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     specifiers:
       '@commitlint/cli': 16.2.4
       '@commitlint/config-conventional': 16.2.4
-      '@coveo/semantic-monorepo-tools': 0.4.0
+      '@coveo/semantic-monorepo-tools': 1.1.0
       '@sindresorhus/slugify': 2.1.0
       aws-sdk: 2.1125.0
       axios: 0.27.2
@@ -32,7 +32,7 @@ importers:
     devDependencies:
       '@commitlint/cli': 16.2.4
       '@commitlint/config-conventional': 16.2.4
-      '@coveo/semantic-monorepo-tools': 0.4.0
+      '@coveo/semantic-monorepo-tools': 1.1.0
       '@sindresorhus/slugify': 2.1.0
       aws-sdk: 2.1125.0
       axios: 0.27.2
@@ -1350,8 +1350,8 @@ packages:
       - react-redux
     dev: false
 
-  /@coveo/semantic-monorepo-tools/0.4.0:
-    resolution: {integrity: sha512-KAoS6KTFA54Bl55zl58w8EvhMHRjn0dOTKe+40rDvBULfNpXv/d5KPDwnpoEB5boZ4SMpY1hc9P9qRP+A3Hp1Q==}
+  /@coveo/semantic-monorepo-tools/1.1.0:
+    resolution: {integrity: sha512-b72LA1ue3Q9ZGs83d2qOgjJlX9ADNS5u/qXAl3s5ejeT3gyB32hR9Ly5R0wrBv/ZK6E1eZVaFRmBg0uGtsWEUQ==}
     dependencies:
       conventional-changelog-writer: 5.0.1
       conventional-commits-parser: 3.2.4


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-829

This is an attempt to make sure we always publish all packages not published yet on NPM.
I'm simply removing the `--filter` option from the pnpm command.

Expected behavior --->
<img width="919" alt="image" src="https://user-images.githubusercontent.com/63734941/180304141-f6873910-00eb-408a-baab-538eff955fc7.png">
 
We'll see if it works 🤞 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
