### PR TITLE
feat: 🎸 itembox apply full-content-x

### DIFF
--- a/packages/react/src/components/itemBox/ItemBox.tsx
+++ b/packages/react/src/components/itemBox/ItemBox.tsx
@@ -87,7 +87,7 @@ export class ItemBox extends Component<IItemBoxProps> {
                     role="option"
                     onMouseDown={(event) => event.preventDefault()}
                 >
-                    <span className="truncate">
+                    <span className="truncate full-content-x">
                         {this.props.prepend ? <Content {...this.props.prepend} /> : null}
                         <PartialStringMatch partialMatch={this.props.highlight} caseInsensitive>
                             {this.props.displayValue || (!this.props.divider ? this.props.value : '')}


### PR DESCRIPTION
expand the itembox to full width

✅ Required for: PLEX-77

### Proposed Changes

Itembox to have `full-content-x`

This is required for the changes needed in PLEX-77 where we would like to add an SVG and badge to the org picker. With this change, it will allow us to create a div element and flex it according to the design.

There should be no changes observed in the Itembox

Before:
<img width="600" alt="CleanShot 2022-07-22 at 14 33 55@2x" src="https://user-images.githubusercontent.com/66333175/180503454-e149a8a8-2d42-4134-b39e-1bd9be2120b6.png">

After:
<img width="759" alt="CleanShot 2022-07-22 at 11 51 17@2x" src="https://user-images.githubusercontent.com/66333175/180480228-a5c02246-1b1f-4374-ad5b-9cb46eb5c6dc.png">

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
