### PR TITLE
fix(react, single select): memoize the button

### DIFF
--- a/packages/react/src/components/select/SingleSelectConnected.tsx
+++ b/packages/react/src/components/select/SingleSelectConnected.tsx
@@ -1,6 +1,6 @@
 import {svg} from '@coveord/plasma-style';
 import classNames from 'classnames';
-import {ReactNode, ComponentType, FunctionComponent, MouseEvent, useEffect} from 'react';
+import {ReactNode, ComponentType, FunctionComponent, MouseEvent, useEffect, useMemo} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import * as _ from 'underscore';
 
@@ -81,75 +81,6 @@ export const SingleSelectConnected: FunctionComponent<ISingleSelectProps> = ({
 
     const selectedOption = customSelected.length ? customSelected[customSelected.length - 1] : defaultSelected;
 
-    useEffect(() => {
-        if (selectedOption) {
-            props.onSelectOptionCallback?.(selectedOption);
-        }
-    }, [selectedOption]);
-
-    const Toggle: FunctionComponent<ISelectButtonProps> = ({onClick, onKeyDown, onKeyUp, selectedOptions, isOpen}) => {
-        const option = selectedOptions[0];
-        const showClear = !!option && props.canClear && !props.disabled;
-        const buttonClasses = classNames('btn dropdown-toggle', props.toggleClasses, {
-            'dropdown-toggle-placeholder': !option,
-            'single-select-fixed-width': !props.noFixedWidth,
-            'mod-append': showClear,
-        });
-
-        return (
-            <button
-                className={buttonClasses}
-                type="button"
-                onClick={onClick}
-                onKeyDown={onKeyDown}
-                onKeyUp={onKeyUp}
-                disabled={props.disabled}
-            >
-                {props.buttonPrepend}
-                {option?.prepend ? <Content {...option.prepend} /> : null}
-                {getSelectedOptionElement(option)}
-                {option?.append ? <Content {...option.append} /> : null}
-                <Svg
-                    svgName={isOpen ? svg.chartUp.name : svg.chartDown.name}
-                    svgClass={classNames('icon dropdown-toggle-arrow-size', {
-                        'dropdown-toggle-arrow-style': !showClear,
-                    })}
-                />
-                {showClear && getDeselectOptionButton()}
-            </button>
-        );
-    };
-
-    const getSelectedOptionElement = (option: IItemBoxProps): JSX.Element => {
-        if (option) {
-            const displayValue =
-                option.selectedDisplayValue || getReactNodeTextContent(option.displayValue) || option.value;
-            return (
-                <span
-                    key={option.value}
-                    className="dropdown-selected-value flex-auto left-align"
-                    data-value={option.value}
-                    title={displayValue}
-                >
-                    {displayValue}
-                </span>
-            );
-        }
-
-        return <span className="dropdown-no-value">{placeholder}</span>;
-    };
-
-    const getDeselectOptionButton = () => (
-        <Tooltip title={deselectTooltipText} placement={TooltipPlacement.Top} noSpanWrapper>
-            <Svg
-                svgName={svg.clear.name}
-                svgClass="icon mod-12"
-                className="btn-append center-align"
-                onClick={handleDeselect}
-            />
-        </Tooltip>
-    );
-
     const handleDeselect = (e: MouseEvent) => {
         e.stopPropagation();
         if (!props.disabled) {
@@ -157,13 +88,87 @@ export const SingleSelectConnected: FunctionComponent<ISingleSelectProps> = ({
         }
     };
 
+    useEffect(() => {
+        if (selectedOption) {
+            props.onSelectOptionCallback?.(selectedOption);
+        }
+    }, [selectedOption]);
+
+    const Toggle: FunctionComponent<ISelectButtonProps> = useMemo(
+        () => ({onClick, onKeyDown, onKeyUp, selectedOptions, isOpen}) => {
+            const option = selectedOptions[0];
+            const showClear = !!option && props.canClear && !props.disabled;
+            const buttonClasses = classNames('btn dropdown-toggle', props.toggleClasses, {
+                'dropdown-toggle-placeholder': !option,
+                'single-select-fixed-width': !props.noFixedWidth,
+                'mod-append': showClear,
+            });
+
+            return (
+                <button
+                    className={buttonClasses}
+                    type="button"
+                    onClick={onClick}
+                    onKeyDown={onKeyDown}
+                    onKeyUp={onKeyUp}
+                    disabled={props.disabled}
+                >
+                    {props.buttonPrepend}
+                    {option?.prepend ? <Content {...option.prepend} /> : null}
+                    <SelectedOption option={option} placeholder={placeholder} />
+                    {option?.append ? <Content {...option.append} /> : null}
+                    <Svg
+                        svgName={isOpen ? svg.chartUp.name : svg.chartDown.name}
+                        svgClass={classNames('icon dropdown-toggle-arrow-size', {
+                            'dropdown-toggle-arrow-style': !showClear,
+                        })}
+                    />
+                    {showClear && (
+                        <Tooltip title={deselectTooltipText} placement={TooltipPlacement.Top} noSpanWrapper>
+                            <Svg
+                                svgName={svg.clear.name}
+                                svgClass="icon mod-12"
+                                className="btn-append center-align"
+                                onClick={handleDeselect}
+                            />
+                        </Tooltip>
+                    )}
+                </button>
+            );
+        },
+        [props.canClear, props.disabled, props.toggleClasses, props.noFixedWidth, props.buttonPrepend]
+    );
+
     return (
         <SelectConnected
             {..._.pick(props, selectPropsKeys)}
+            placeholder={placeholder}
             button={props.customButton ?? Toggle}
             isLoading={props.isLoading}
         >
             {props.children}
         </SelectConnected>
     );
+};
+
+const SelectedOption: FunctionComponent<{placeholder: string; option: IItemBoxProps}> = ({
+    option,
+    placeholder,
+}): JSX.Element => {
+    if (option) {
+        const displayValue =
+            option.selectedDisplayValue || getReactNodeTextContent(option.displayValue) || option.value;
+        return (
+            <span
+                key={option.value}
+                className="dropdown-selected-value flex-auto left-align"
+                data-value={option.value}
+                title={displayValue}
+            >
+                {displayValue}
+            </span>
+        );
+    }
+
+    return <span className="dropdown-no-value">{placeholder}</span>;
 };


### PR DESCRIPTION
### Proposed Changes

Follow up on the conversion of the SingleSelect to a FunctionComponent. Now that it's a function the Toggle is re-declared every time which might causes issues. The main change is the use of the useMemo, the rest is just a bit of cleanup

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
