### PR TITLE
[MLX-170] fix(infotoken): allow passing classes to override svg properties

### DIFF
--- a/packages/react/src/components/info-token/InfoToken.tsx
+++ b/packages/react/src/components/info-token/InfoToken.tsx
@@ -28,6 +28,7 @@ export interface InfoTokenProps {
     type: InfoTokenType;
     size: InfoTokenSize;
     mode: InfoTokenMode;
+    svgClassName?: string;
     className?: string;
 }
 
@@ -84,10 +85,10 @@ const ModeClassMapping: Record<InfoTokenMode, string> = {
     [InfoTokenMode.Filled]: 'filled',
 };
 
-export const InfoToken: FunctionComponent<InfoTokenProps> = ({mode, size, type, className}) => (
+export const InfoToken: FunctionComponent<InfoTokenProps> = ({mode, size, type, className, svgClassName}) => (
     <Svg
         className={classNames('info-token', ModeClassMapping[mode], SizeClassMapping[size], className)}
         svgName={SvgMapping[type][size]}
-        svgClass={classNames('icon mod-stroke', SizeClassMapping[size], TypeColorMapping[type])}
+        svgClass={classNames('icon mod-stroke', SizeClassMapping[size], TypeColorMapping[type], svgClassName)}
     />
 );

--- a/packages/react/src/components/info-token/tests/InfoToken.spec.tsx
+++ b/packages/react/src/components/info-token/tests/InfoToken.spec.tsx
@@ -181,4 +181,21 @@ describe('InfoToken', () => {
 
         expect(container.querySelector('.filled')).not.toBeInTheDocument();
     });
+
+    it('allows additional classes to be passed down to the token through svgClassName', () => {
+        render(
+            <InfoToken
+                type={InfoTokenType.Tip}
+                mode={InfoTokenMode.Stroked}
+                size={InfoTokenSize.Large}
+                svgClassName="no-link"
+                className="class-on-span"
+            />
+        );
+
+        const largeToken = screen.getByRole('img', {name: 'ideaStrokedLarge icon'});
+        expect(largeToken).toBeInTheDocument();
+        expect(largeToken).toHaveClass('no-link');
+        expect(largeToken).not.toHaveClass('class-on-span');
+    });
 });


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

Added the possibility to pass classes directly to the svg. So that the look of it can be overriden.
(Need to override color on svg)

### Potential Breaking Changes

:no_entry: 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
