### PR TITLE
fix: 🐛 adding a fallback when maxWidth is a NaN

### DIFF
--- a/packages/react/src/components/drop/DropPod.tsx
+++ b/packages/react/src/components/drop/DropPod.tsx
@@ -213,9 +213,12 @@ const RDropPod: FunctionComponent<IRDropPodProps> = ({
             // Restrict the max-width to the inner width of the closest relatively positioned ancestor
             if (relativeParent) {
                 const {paddingLeft, paddingRight} = getComputedStyle(relativeParent) ?? {};
+                const fallbackMaxWidth = 850;
+                const calculatedMaxWidth = parentOffset.width - (parseFloat(paddingLeft) + parseFloat(paddingRight));
+                const maxWidth = !!isNaN(calculatedMaxWidth) ? fallbackMaxWidth : calculatedMaxWidth;
                 newDomPosition.style = {
                     ...newDomPosition.style,
-                    maxWidth: parentOffset.width - (parseFloat(paddingLeft) + parseFloat(paddingRight)),
+                    maxWidth: maxWidth,
                 };
 
                 // Don't show if no space to render the drop target inside the window

--- a/packages/react/src/components/drop/DropPod.tsx
+++ b/packages/react/src/components/drop/DropPod.tsx
@@ -215,7 +215,7 @@ const RDropPod: FunctionComponent<IRDropPodProps> = ({
                 const {paddingLeft, paddingRight} = getComputedStyle(relativeParent) ?? {};
                 const fallbackMaxWidth = 850;
                 const calculatedMaxWidth = parentOffset.width - (parseFloat(paddingLeft) + parseFloat(paddingRight));
-                const maxWidth = !!isNaN(calculatedMaxWidth) ? fallbackMaxWidth : calculatedMaxWidth;
+                const maxWidth = isNaN(calculatedMaxWidth) ? fallbackMaxWidth : calculatedMaxWidth;
                 newDomPosition.style = {
                     ...newDomPosition.style,
                     maxWidth: maxWidth,

--- a/packages/react/src/components/drop/tests/DropPod.spec.tsx
+++ b/packages/react/src/components/drop/tests/DropPod.spec.tsx
@@ -452,6 +452,23 @@ describe('DropPod', () => {
                     const {maxWidth} = screen.getByText('🚀').style;
                     expect(maxWidth).toBe('980px'); // 1000px width - (10px padding left + 10px padding right)
                 });
+
+                it('should set the fallback maxWidth to the inner width if the calculated one is a NaN', () => {
+                    setupReference({
+                        width: 0 / 0, // not a number
+                    });
+                    render(
+                        <DropPod
+                            isOpen
+                            renderDrop={(styleCalculated) => <div style={styleCalculated}>🚀</div>}
+                            positions={[DropPodPosition.bottom]}
+                            ref={buttonRef}
+                        />
+                    );
+
+                    const {maxWidth} = screen.getByText('🚀').style;
+                    expect(maxWidth).toBe('850px');
+                });
             });
 
             describe('events', () => {


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-8247

We have an issue in the admin where the Single select gets an error when trying to set the maxWidth value.
To patch this issue, i'm checking if the calculated value is a NaN and if so, I force a fallback value (I picked 850px but it could be bigger if needed ? 🙈 )

<img width="705" alt="image" src="https://user-images.githubusercontent.com/63734941/184214753-695f45a6-1431-4b89-b35e-8b2e5f6ba1bd.png">

I'm prenneuse of better idea also 😅 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
