### PR TITLE
fix(style): inputs style remove border radius

### DIFF
--- a/packages/style/scss/controls/inputs.scss
+++ b/packages/style/scss/controls/inputs.scss
@@ -24,7 +24,6 @@ input[type='color'] {
     font-size: $input-font-size;
     font-family: var(--main-font);
     border: 1px solid var(--deprecated-medium-grey);
-    border-radius: 2px;
 
     &:focus-visible {
         @include focus-outline();


### PR DESCRIPTION
### Proposed Changes

[UITOOL-875](https://coveord.atlassian.net/browse/UITOOL-875?atlOrigin=eyJpIjoiODNhNGY5MDYyOTkwNDQ3Yzk5YmMxZDBhNjUyNzA1NWQiLCJwIjoiaiJ9)

Removing the border radius causing issues in admin-ui - there should be no noticeable change in any of the inputs.

I linked this locally and briefly checked for the inputs and they seem to be O.K

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
