### PR TITLE
build(npm): fix typo in esm exports configuration

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,7 +20,7 @@
     "exports": {
         ".": {
             "types": "./dist/definitions/Entry.d.ts",
-            "import": "./dist/cjs/esm.js",
+            "import": "./dist/esm/Entry.js",
             "require": "./dist/cjs/Entry.js"
         }
     },


### PR DESCRIPTION
### Proposed Changes

I noticed a small typo in the exports configuration that certainly break tools that use that configuration.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
