### PR TITLE
fix(datepickerreducer): removed appliedLower and UpperLimit to ternar…

### DIFF
--- a/packages/react/src/components/datePicker/DatePickerReducers.ts
+++ b/packages/react/src/components/datePicker/DatePickerReducers.ts
@@ -91,14 +91,8 @@ const selectDate = (state: IDatePickerState, action: IReduxAction<IReduxActionsP
     state.id !== action.payload.id ? state : _.extend({}, state, {selected: action.payload.limit});
 
 const applyDates = (state: IDatePickerState, action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
-    const lowerLimit: Date =
-        state.lowerLimit || !state.isClearable
-            ? state.lowerLimit || state.inputLowerLimit || state.appliedLowerLimit
-            : null;
-    let upperLimit: Date =
-        state.upperLimit || !state.isClearable
-            ? state.upperLimit || state.inputUpperLimit || state.appliedUpperLimit
-            : null;
+    const lowerLimit: Date = state.lowerLimit || !state.isClearable ? state.lowerLimit || state.inputLowerLimit : null;
+    let upperLimit: Date = state.upperLimit || !state.isClearable ? state.upperLimit || state.inputUpperLimit : null;
 
     if (state.isRange && !upperLimit) {
         upperLimit = lowerLimit ? moment(lowerLimit).endOf('day').toDate() : upperLimit;

--- a/packages/react/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/packages/react/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -654,31 +654,6 @@ describe('Date picker', () => {
             expect(newDatePicker.appliedUpperLimit).toBe(oldDatePicker.inputUpperLimit);
         });
 
-        it(
-            'should apply the already applied limit if the new limits are not valid and neither are the input limits ' +
-                ' and the datepicker is not clearable',
-            () => {
-                const oldDatePicker: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
-                    upperLimit: undefined,
-                    lowerLimit: undefined,
-                    inputUpperLimit: undefined,
-                    inputLowerLimit: undefined,
-                    appliedUpperLimit: new Date(new Date().setHours(2, 0, 1, 1)),
-                    appliedLowerLimit: new Date(new Date().setHours(0, 0, 1, 1)),
-                });
-                const action: IReduxAction<IDatePickerPayload> = {
-                    type: DatePickerActions.apply,
-                    payload: {
-                        id: 'some-date',
-                    },
-                };
-                const newDatePicker: IDatePickerState = datePickerReducer(oldDatePicker, action);
-
-                expect(newDatePicker.appliedLowerLimit).toBe(oldDatePicker.appliedLowerLimit);
-                expect(newDatePicker.appliedUpperLimit).toBe(oldDatePicker.appliedUpperLimit);
-            }
-        );
-
         it('should allows to apply null limits when the datepicker is clearable', () => {
             const oldDatePicker: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
                 isClearable: true,
@@ -827,16 +802,6 @@ describe('Date picker', () => {
                 expect(newDatePicker.appliedLowerLimit).toBe(oldDatePicker.inputLowerLimit);
             });
 
-            it('should return the appliedLowerLimit if the lowerLimit and inputLowerLimits are not defined', () => {
-                oldDatePicker = _.extend({}, BASE_DATE_PICKER_STATE, {
-                    lowerLimit: undefined,
-                    inputLowerLimit: undefined,
-                });
-                newDatePicker = datePickerReducer(oldDatePicker, action);
-
-                expect(newDatePicker.appliedLowerLimit).toBe(oldDatePicker.appliedLowerLimit);
-            });
-
             it('should return the lowerLimit if the lowerLimit is defined', () => {
                 oldDatePicker = _.extend({}, BASE_DATE_PICKER_STATE);
                 newDatePicker = datePickerReducer(oldDatePicker, action);
@@ -851,16 +816,6 @@ describe('Date picker', () => {
                 newDatePicker = datePickerReducer(oldDatePicker, action);
 
                 expect(newDatePicker.appliedUpperLimit).toBe(oldDatePicker.inputUpperLimit);
-            });
-
-            it('should return the appliedUpperLimit if the upperLimit and inputUpperLimit are not defined', () => {
-                oldDatePicker = _.extend({}, BASE_DATE_PICKER_STATE, {
-                    upperLimit: undefined,
-                    inputUpperLimit: undefined,
-                });
-                newDatePicker = datePickerReducer(oldDatePicker, action);
-
-                expect(newDatePicker.appliedUpperLimit).toBe(oldDatePicker.appliedUpperLimit);
             });
 
             it('should return the upperLimit if its greater than the lowerLimit', () => {


### PR DESCRIPTION
### Proposed Changes

applied lower and applied upper limits wont be used to set upper/lower limits in the state so
invalid dates cant be set

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
