### PR TITLE
[plasma-react] handle null limits in Limits component

### DIFF
--- a/packages/react/src/components/limit/Limit.tsx
+++ b/packages/react/src/components/limit/Limit.tsx
@@ -54,6 +54,8 @@ export interface LimitOwnProps {
     onHistoryIconClick?: () => void;
 }
 
+const isANumber = (n: any): n is number => typeof n === 'number' && !Number.isNaN(n);
+
 /**
  * @deprecated Use Mantine instead
  */
@@ -100,12 +102,13 @@ const ContentDivision: FunctionComponent<Omit<LimitOwnProps, 'title'>> = ({
     </div>
 );
 
-const UsageDivision: FunctionComponent<Omit<LimitOwnProps, 'title'>> = ({usage}) => (
-    <div className="limit-box-usage">
-        <label className="form-control-label">Usage</label>
-        <span className="limit-box-usage-value">{Number(usage ?? 0).toLocaleString()}</span>
-    </div>
-);
+const UsageDivision: FunctionComponent<Omit<LimitOwnProps, 'title'>> = ({usage}) =>
+    isANumber(usage) ? (
+        <div className="limit-box-usage">
+            <label className="form-control-label">Usage</label>
+            <span className="limit-box-usage-value">{usage.toLocaleString()}</span>
+        </div>
+    ) : null;
 
 const LimitDivision: FunctionComponent<Omit<LimitOwnProps, 'title'>> = ({
     id,
@@ -114,25 +117,30 @@ const LimitDivision: FunctionComponent<Omit<LimitOwnProps, 'title'>> = ({
     isLimitEditable,
     limitLabel,
 }) => {
-    const limitValueString: string = limit?.toString();
-    const minLimitValue: number = usage ?? 0;
     const dispatch: IDispatch = useDispatch();
-    return isLimitEditable ? (
-        <InputConnected
-            id={id}
-            type="number"
-            labelTitle={limitLabel}
-            defaultValue={limitValueString}
-            min={minLimitValue}
-            classes="limit-box-limit form-group input-field validate"
-            onChange={(limitValue: string) => dispatch(changeInputValue(id, limitValue, true))}
-        />
-    ) : (
+
+    if (isLimitEditable) {
+        const limitValueString: string = limit?.toString() ?? '';
+        const minLimitValue: number = usage ?? 0;
+        return (
+            <InputConnected
+                id={id}
+                type="number"
+                labelTitle={limitLabel}
+                defaultValue={limitValueString}
+                min={minLimitValue}
+                classes="limit-box-limit form-group input-field validate"
+                onChange={(limitValue: string) => dispatch(changeInputValue(id, limitValue, true))}
+            />
+        );
+    }
+
+    return isANumber(limit) ? (
         <div className="limit-box-limit">
             <label className="form-control-label">{limitLabel}</label>
-            <span className="limit-box-limit-value">{Number(limit ?? 0).toLocaleString()}</span>
+            <span className="limit-box-limit-value">{limit.toLocaleString()}</span>
         </div>
-    );
+    ) : null;
 };
 
 const ProgressBar: FunctionComponent<Omit<LimitOwnProps, 'title'>> = ({usage, isLimitTheGoalToReach, limit}) => {

--- a/packages/react/src/components/limit/tests/Limit.spec.tsx
+++ b/packages/react/src/components/limit/tests/Limit.spec.tsx
@@ -12,9 +12,7 @@ describe('Limit', () => {
     });
 
     it('renders Limit component with custom values', () => {
-        render(
-            <Limit id="🆔" title="My limit" usage={33} limit={130} limitLabel="Threshold" isHistoryIncluded={true} />
-        );
+        render(<Limit id="🆔" title="My limit" usage={33} limit={130} limitLabel="Threshold" isHistoryIncluded />);
 
         expect(screen.getByText(/usage/i)).toBeInTheDocument();
         expect(screen.getByText(/threshold/i)).toBeInTheDocument();
@@ -24,7 +22,7 @@ describe('Limit', () => {
     });
 
     it('renders an editable Limit component when editable', () => {
-        render(<Limit id="🆔" title="My limit" limit={100} usage={33} isLimitEditable={true} />);
+        render(<Limit id="🆔" title="My limit" limit={100} usage={33} isLimitEditable />);
         expect(
             screen.getByRole('spinbutton', {
                 name: /limit/i,
@@ -41,7 +39,7 @@ describe('Limit', () => {
 
     it('calls the onClick method on history icon onClick', () => {
         const clickSpy = jest.fn();
-        render(<Limit id="🆔" title="My limit" limit={100} isHistoryIncluded={true} onHistoryIconClick={clickSpy} />);
+        render(<Limit id="🆔" title="My limit" limit={100} isHistoryIncluded onHistoryIconClick={clickSpy} />);
         const historyIcon = screen.getByLabelText(/menuanalytics icon/i);
         userEvent.click(historyIcon);
 
@@ -59,5 +57,56 @@ describe('Limit', () => {
         render(<Limit id="🆔" title="My limit" limit={0} limitLabel="abcde" />);
 
         expect(screen.getByText(/abcde/i)).toBeInTheDocument();
+    });
+
+    it('hides the limit label when the limit value is undefined', () => {
+        render(<Limit id="🆔" title="My limit" limit={undefined} limitLabel="abcde" />);
+
+        expect(screen.queryByText(/abcde/i)).not.toBeInTheDocument();
+    });
+
+    it('hides the usage label when the usage value is undefined', () => {
+        render(<Limit id="🆔" title="My limit" usage={undefined} />);
+
+        expect(screen.queryByText(/usage/i)).not.toBeInTheDocument();
+    });
+
+    it('hides both the usage and the limit when they are undefined', () => {
+        const {container} = render(<Limit id="🆔" title="My limit" />);
+
+        expect(container).toMatchInlineSnapshot(`
+            <div
+              id="app"
+            >
+              <div
+                class="limit-box mb2"
+              >
+                <div
+                  class="limit-box-main p2 pb1"
+                >
+                  <div
+                    class="flex space-between"
+                  >
+                    <label
+                      class="form-control-label"
+                    >
+                       
+                      My limit
+                    </label>
+                  </div>
+                  <div
+                    class="limit-box-numbers pt1 flex"
+                  />
+                </div>
+                <div
+                  class="limit-box-footer no-limit"
+                >
+                  <div
+                    class=""
+                  />
+                </div>
+              </div>
+            </div>
+        `);
     });
 });

--- a/packages/style/scss/components/limit-box.scss
+++ b/packages/style/scss/components/limit-box.scss
@@ -1,6 +1,11 @@
+$limit-box-width: 300px;
+$limit-box-height: 124px;
+$limit-progress-bar-height: 10px;
+
 .limit-box {
     width: $limit-box-width;
     min-width: $limit-box-width;
+    min-height: $limit-box-height;
     border: $default-border;
     border-radius: $border-radius;
 }

--- a/packages/style/scss/variables.scss
+++ b/packages/style/scss/variables.scss
@@ -478,10 +478,6 @@ $list-box-max-height: 300px;
 $list-box-vertical-spacing: 8px;
 $list-box-box-shadow: var(--low-elevation-on-light);
 
-// Limit Box
-$limit-box-width: 300px;
-$limit-progress-bar-height: 10px;
-
 // Slider
 $slider-rail-height: 4px;
 $slider-rail-margin-top: 2px;


### PR DESCRIPTION
### Proposed Changes

Null or undefined limit and usage values should not be rounded out to 0 and the label should be hidden when that occurs

![image](https://user-images.githubusercontent.com/35579930/190009166-912a92a9-bae9-46aa-89cf-761b8dccf7a9.png)

![image](https://user-images.githubusercontent.com/35579930/190009081-de3e8007-82c4-48b1-9424-b7d8c682ef3b.png)

![image](https://user-images.githubusercontent.com/35579930/190009020-7789c712-794a-4bba-b966-1a6b5664cb29.png)

![image](https://user-images.githubusercontent.com/35579930/190008965-67d94328-d90a-406c-91a2-d89d0dbfed6d.png)

I also took the time to improve the dev setup 🤖 

### Potential Breaking Changes

None expected

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
