### PR TITLE
feat(loading-spinner): fix width that change the proportion of the spi…

### DIFF
--- a/packages/react/src/components/loading/LoadingSpinner.tsx
+++ b/packages/react/src/components/loading/LoadingSpinner.tsx
@@ -14,6 +14,6 @@ export const LoadingSpinner: FunctionComponent<LoadingSpinnerProps> = ({size = 2
         role="alert"
         aria-busy="true"
         className={classNames('loading-spinner', className)}
-        style={{width: size, height: size}}
+        style={{width: size, height: size, minWidth: size}}
     />
 );


### PR DESCRIPTION
### Proposed Changes
Fix the width of the spinner so it's always a square. I know there's a comment that we should not use this spinner anymore and used Mantine, but this is part of a bigger plasma component (download toast) and thus I just want to do a quick fix for this :) 

Before:
![Screenshot from 2022-09-16 08-55-38](https://user-images.githubusercontent.com/50334010/190643768-f2a94ec4-6545-4c4f-b318-b7216c33f455.png)

After:
![Screenshot from 2022-09-16 09-03-39](https://user-images.githubusercontent.com/50334010/190645246-3497e99c-d6eb-409d-9ec7-38621bac6c48.png)



### Potential Breaking Changes
None I can think of.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
