### PR TITLE
fix(style): remove root level style on inputs

### DIFF
--- a/packages/style/scss/controls/inputs.scss
+++ b/packages/style/scss/controls/inputs.scss
@@ -3,33 +3,6 @@ textarea {
     @include placeholder();
 }
 
-select,
-textarea,
-input[type='text'],
-input[type='password'],
-input[type='datetime'],
-input[type='datetime-local'],
-input[type='date'],
-input[type='month'],
-input[type='time'],
-input[type='week'],
-input[type='number'],
-input[type='email'],
-input[type='url'],
-input[type='search'],
-input[type='tel'],
-input[type='color'] {
-    padding: 3px 6px;
-    color: var(--deprecated-dark-grey);
-    font-size: $input-font-size;
-    font-family: var(--main-font);
-    border: 1px solid var(--deprecated-medium-grey);
-
-    &:focus-visible {
-        @include focus-outline();
-    }
-}
-
 input[type='text'],
 textarea {
     &.admin-invisible-textbox {


### PR DESCRIPTION
### Proposed Changes

Removing the root level css rules on inputs, any custom style should be scoped down otherwise it leaks into components from other libraries

### Potential Breaking Changes

Components relying on those rules could look a little bit different (I didn't personally notice any difference), but should still be usable

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
