### PR TITLE
fix(xyaxis): when few data points, the x axis would not display any l…

### DIFF
--- a/packages/react/src/components/chart/XYAxis.tsx
+++ b/packages/react/src/components/chart/XYAxis.tsx
@@ -80,7 +80,7 @@ export const XYAxis: FunctionComponent<XYAxisProps> = ({x, y, children}) => {
         .map((values: number[]) => values[Math.floor((values.length - 1) / 2)]);
 
     const xTicks = newXScale.domain().map((tick: number) => {
-        const text = _.contains(ticks, tick) && xFormat(tick);
+        const text = _.contains(ticks.length === 0 ? newXScale.domain() : ticks, tick) && xFormat(tick);
         const textX = newXScale(tick);
         return (
             <g


### PR DESCRIPTION
### Proposed Changes

On low data point, the tick labels dont show up so I changed the logic to accept the whole array of data when the value 
`const ticks = _.chunk(newXScale.domain(), Math.floor(newXScale.domain().length / xNumberOfTicks))` returns nothing (hence the no labels)

Go in plasma -> Chart and change the number of point in graph data from 25 to 1-2-3-4-5. it should still displays instead of not (as of now)
### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
