### PR TITLE
style(facets): removed border-right to facets column, will be applied…

### DIFF
--- a/packages/style/scss/components/facet.scss
+++ b/packages/style/scss/components/facet.scss
@@ -5,6 +5,9 @@
     margin-right: 0;
     padding: $facet-column-padding-y $facet-column-padding-right $facet-column-padding-y $facet-column-padding-left;
     border-right: $default-border;
+    &-activity {
+        border-right: none;
+    }
 }
 
 .facet {


### PR DESCRIPTION
… to table now

### Proposed Changes

Removed the border-right on the facets column for the activity table. The border will be applied to the table instead.
<img width="844" alt="image" src="https://user-images.githubusercontent.com/73316533/197582306-2683ac05-6e0f-4464-9fd1-49fb2a9f9d36.png">

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
