### PR TITLE
ci(cd): fallback on REF_NAME when defining the base path

### DIFF
--- a/packages/website/build/getBasePath.js
+++ b/packages/website/build/getBasePath.js
@@ -1,5 +1,5 @@
 const isCI = !!process.env.JENKINS_HOME || process.env.CI === 'true';
-const branchName = process.env.BRANCH_NAME || process.env.GITHUB_HEAD_REF;
+const branchName = process.env.BRANCH_NAME || process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME;
 
 let basePath = '/';
 if (isCI && branchName !== 'master') {


### PR DESCRIPTION
### Proposed Changes

Fixing the [build error](https://github.com/coveo/plasma/actions/runs/3329940221/jobs/5507790433#step:5:145) we see in the CD workflow for the master branch

```
@coveord/plasma-website:build: > Build error occurred
@coveord/plasma-website:build: Error: Specified basePath should not end with /, found "/feature/"
@coveord/plasma-website:build:     at assignDefaults (/home/runner/work/plasma/plasma/node_modules/.pnpm/next@12.1.5_dmi2t66wvavvdsdvw6dn5lzaaa/node_modules/next/dist/server/config.js:251:23)
@coveord/plasma-website:build:     at Object.loadConfig [as default] (/home/runner/work/plasma/plasma/node_modules/.pnpm/next@12.1.5_dmi2t66wvavvdsdvw6dn5lzaaa/node_modules/next/dist/server/config.js:94:16)
@coveord/plasma-website:build:     at async Span.traceAsyncFn (/home/runner/work/plasma/plasma/node_modules/.pnpm/next@12.1.5_dmi2t66wvavvdsdvw6dn5lzaaa/node_modules/next/dist/trace/trace.js:79:20)
@coveord/plasma-website:build:     at async /home/runner/work/plasma/plasma/node_modules/.pnpm/next@12.1.5_dmi2t66wvavvdsdvw6dn5lzaaa/node_modules/next/dist/build/index.js:59:24
@coveord/plasma-website:build:     at async Span.traceAsyncFn (/home/runner/work/plasma/plasma/node_modules/.pnpm/next@12.1.5_dmi2t66wvavvdsdvw6dn5lzaaa/node_modules/next/dist/trace/trace.js:79:20)
@coveord/plasma-website:build:     at async Object.build [as default] (/home/runner/work/plasma/plasma/node_modules/.pnpm/next@12.1.5_dmi2t66wvavvdsdvw6dn5lzaaa/node_modules/next/dist/build/index.js:55:25)
```

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
