### PR TITLE
ci(cd): add write permissions on security events

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,10 @@ jobs:
         permissions:
             pull-requests: write
             id-token: write
+            actions: read
             contents: read
+            security-events: write
+            statuses: write
         steps:
             - name: Checkout
               uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3


### PR DESCRIPTION
### Proposed Changes

Snyk now successfully scans and create sarif files, but fail to upload them because the github runner isn't allowed to push to security events and statuses, it needs write permissions to do so.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
