### PR TITLE
feat(mantine): lazy-load monaco-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "reconstruct": "npx rimraf node_modules packages/*/node_modules && npm run setup && echo done",
         "setup": "pnpm install",
         "start": "pnpm build && pnpm --recursive --parallel start",
-        "test": "turbo run test"
+        "test": "turbo run test --concurrency=1"
     },
     "commitlint": {
         "extends": [

--- a/packages/mantine/jest.config.js
+++ b/packages/mantine/jest.config.js
@@ -4,7 +4,6 @@ module.exports = {
     globalSetup: '<rootDir>/src/__tests__/GlobalSetup.ts',
     moduleNameMapper: {
         '^@test-utils$': '<rootDir>/src/__tests__/Utils.tsx',
-        '^monaco-editor$': 'identity-obj-proxy',
     },
     testEnvironment: 'jsdom',
     transform: {

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -24,7 +24,8 @@
         "build": "node ../../scripts/build",
         "clean": "rimraf dist",
         "start": "node ../../scripts/start",
-        "test": "jest --maxWorkers=65%"
+        "test": "jest --maxWorkers=65%",
+        "test:watch": "jest --watchAll"
     },
     "dependencies": {
         "@coveord/plasma-react-icons": "workspace:*",

--- a/packages/mantine/src/components/code-editor/__mocks__/monaco-editor.ts
+++ b/packages/mantine/src/components/code-editor/__mocks__/monaco-editor.ts
@@ -1,0 +1,9 @@
+const editor = {
+    create: () => ({
+        dispose: (): void => null,
+    }),
+};
+
+export const monaco = {
+    editor,
+};

--- a/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
+++ b/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
@@ -1,14 +1,19 @@
 import {useForm} from '@mantine/form';
-import {render, screen, within} from '@test-utils';
+import {loader} from '@monaco-editor/react';
+import {render, screen, waitForElementToBeRemoved, within} from '@test-utils';
 
 import {CodeEditor} from '../CodeEditor';
 
-jest.mock('monaco-editor');
-jest.mock('@monaco-editor/react');
-
 describe('CodeEditor', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('renders the monaco editor and a copy to clipboard button', async () => {
+        jest.mock('monaco-editor');
         render(<CodeEditor label="label" description="description" />);
+
+        await waitForElementToBeRemoved(screen.queryByRole('presentation'));
 
         expect(screen.getByText(/label/)).toBeInTheDocument();
         expect(screen.getByText(/description/)).toBeInTheDocument();
@@ -16,7 +21,7 @@ describe('CodeEditor', () => {
         expect(await screen.findByRole('button', {name: /copy/i})).toBeInTheDocument();
     });
 
-    it('shows validation errors underneath the code editor', () => {
+    it('shows validation errors underneath the code editor', async () => {
         const Fixture = () => {
             const form = useForm({
                 initialValues: {
@@ -29,9 +34,23 @@ describe('CodeEditor', () => {
             return <CodeEditor {...form.getInputProps('myJsonCode')} />;
         };
         render(<Fixture />);
+        await waitForElementToBeRemoved(screen.queryByRole('presentation'));
 
         const errors = screen.getByRole('alert');
 
         expect(within(errors).getByText(/invalid configuration/i)).toBeInTheDocument();
+    });
+
+    it('loads the monaco editor files from node_modules when monacoLoader prop is "local"', async () => {
+        render(<CodeEditor label="label" description="description" monacoLoader="local" />);
+        await waitForElementToBeRemoved(screen.queryByRole('presentation'));
+        expect(loader.config).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId('monaco-editor')).toBeInTheDocument();
+    });
+
+    it('loads the monaco editor files via CDN when monacoLoader prop is "cnd"', async () => {
+        render(<CodeEditor label="label" description="description" monacoLoader="cdn" />);
+        expect(loader.config).not.toHaveBeenCalled();
+        expect(screen.getByTestId('monaco-editor')).toBeInTheDocument();
     });
 });

--- a/packages/mantine/tsconfig.json
+++ b/packages/mantine/tsconfig.json
@@ -4,8 +4,11 @@
         "outDir": "./dist",
         "declarationDir": "./dist/definitions",
         "rootDir": "src",
-        "tsBuildInfoFile": "./dist/.tsbuildinfo"
+        "tsBuildInfoFile": "./dist/.tsbuildinfo",
+        "baseUrl": ".",
+        "paths": {
+            "@test-utils": ["./src/__tests__/Utils.tsx"]
+        }
     },
-    "include": ["src"],
-    "exclude": ["*.spec.*"]
+    "include": ["src"]
 }


### PR DESCRIPTION
### Proposed Changes

Lazy-load the monaco editor files. Also allow to load monaco files via CDN for those who need it, if your CSP allows it, it might be simpler than configuring the web workers properly.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
