### PR TITLE
ci(publish): use coveobot user as publish user

### DIFF
--- a/.github/actions/publish/index.mjs
+++ b/.github/actions/publish/index.mjs
@@ -36,8 +36,8 @@ export default async ({github, context, exec}, {
     branch = 'master', 
     bump = null
 } = {}) => {
-    const GIT_USERNAME = 'plasma-bot';
-    const GIT_EMAIL = 'plasma-bot@users.noreply.github.com';
+    const GIT_USERNAME = 'coveobot';
+    const GIT_EMAIL = 'coveobot@coveo.com';
     const GIT_SSH_REMOTE = 'deploy';
 
     await gitSetupSshRemote(context.repo.owner, context.repo.repo, process.env.DEPLOY_KEY, GIT_SSH_REMOTE);


### PR DESCRIPTION
### Proposed Changes

Replacing the random user plasma-bot by the actual [coveobot](https://github.com/coveobot).

Sometimes GitHub links "plasma-bot" with [this user](https://github.com/plasma-bot)
 
![image](https://user-images.githubusercontent.com/35579930/199098290-4712819f-7654-4c08-82e1-d62f39b4b094.png)

This is pretty random and could induce confusion, so using the coveobot makes a lot more sense

![image](https://user-images.githubusercontent.com/35579930/199098463-344ba2d6-2238-40c4-9d0d-e0a1b267ff43.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
