### PR TITLE
fix(mantine): add missing type exports

### DIFF
--- a/packages/mantine/src/components/modal-wizard/index.ts
+++ b/packages/mantine/src/components/modal-wizard/index.ts
@@ -1,1 +1,2 @@
 export * from './ModalWizard';
+export {type ModalWizardStepProps} from './ModalWizardStep';

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -2,7 +2,7 @@ import {Tuple} from '@mantine/core';
 
 import {PlasmaColors} from './theme/PlasmaColors';
 
-export {ColumnDef, createColumnHelper} from '@tanstack/table-core';
+export {type ColumnDef, createColumnHelper} from '@tanstack/table-core';
 
 export * from '@mantine/core';
 export * from '@mantine/form';


### PR DESCRIPTION
### Proposed Changes

I noticed some type exports were missing in the new plasma-mantine package so I added them
- adjust type export for ColumnDef
- add type export for ModalWizard.Step props

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
