### PR TITLE
feat(mantine): add "allowAdd" prop to Collection

### DIFF
--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -27,6 +27,7 @@ interface CollectionProps<T> extends DefaultProps<Selectors<typeof useStyles>> {
     onChange?: (value: T[]) => void;
     draggable?: boolean;
     disabled?: boolean;
+    allowAdd?: (values: T[]) => boolean;
     addLabel?: string;
     addDisabledTooltip?: string;
     spacing?: MantineNumberSize;
@@ -47,7 +48,6 @@ export const Collection = <T,>(props: CollectionProps<T>) => {
         value,
         defaultValue,
         onChange,
-        onFocus,
         disabled,
         draggable,
         children,
@@ -56,6 +56,7 @@ export const Collection = <T,>(props: CollectionProps<T>) => {
         newItem,
         addLabel,
         addDisabledTooltip,
+        allowAdd,
 
         // Style props
         classNames,
@@ -84,17 +85,17 @@ export const Collection = <T,>(props: CollectionProps<T>) => {
         </CollectionItem>
     ));
 
-    const hasEmptyItem = values.some((item) => JSON.stringify(item) === JSON.stringify(newItem));
+    const addAllowed = allowAdd?.(values) ?? true;
 
     const _addButton = disabled ? null : (
         <Group>
-            <Tooltip label={addDisabledTooltip} disabled={!hasEmptyItem}>
+            <Tooltip label={addDisabledTooltip} disabled={addAllowed}>
                 <Box>
                     <Button
                         variant="subtle"
                         leftIcon={<AddSize16Px height={16} />}
                         onClick={() => append(newItem)}
-                        disabled={hasEmptyItem}
+                        disabled={!addAllowed}
                     >
                         {addLabel}
                     </Button>

--- a/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
+++ b/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
@@ -96,12 +96,13 @@ describe('Collection', () => {
         expect(screen.getByTestId('form-state')).toHaveTextContent('{"fruits":["banana","orange","new"]}');
     });
 
-    it('disallows from adding more than one new item at once', () => {
+    it('disables the add button whenever allowAdd callback returns false', () => {
+        const allowAdd = jest.fn().mockImplementation(() => false);
         const Fixture = () => {
             const form = useForm({initialValues: {fruits: ['banana', 'orange']}});
             return (
                 <>
-                    <Collection newItem="new" {...form.getInputProps('fruits')}>
+                    <Collection newItem="new" {...form.getInputProps('fruits')} allowAdd={allowAdd}>
                         {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
@@ -109,10 +110,13 @@ describe('Collection', () => {
             );
         };
 
-        render(<Fixture />);
-        const addItem = screen.getByRole('button', {name: /add/i});
-        userEvent.click(addItem);
-        expect(addItem).toBeDisabled();
+        const {rerender} = render(<Fixture />);
+        expect(screen.getByRole('button', {name: /add/i})).toBeDisabled();
+        expect(allowAdd).toHaveBeenCalledWith(['banana', 'orange']);
+
+        allowAdd.mockImplementation(() => true);
+        rerender(<Fixture />);
+        expect(screen.getByRole('button', {name: /add/i})).toBeEnabled();
     });
 
     describe('when required is true', () => {


### PR DESCRIPTION
### Proposed Changes

Use the allowAdd prop to tell the Collection whether the add button should be enabled

### Potential Breaking Changes

The Collection component will no longer disable its add button automatically if the newly added prop isn't provided

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
