### PR TITLE
feat(mantine, table):  reset row selection if user click outside the table

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -1,4 +1,4 @@
-import {Center, Collapse, createStyles, Loader, Skeleton, Table as MantineTable} from '@mantine/core';
+import {Box, Center, Collapse, createStyles, Loader, Skeleton, Table as MantineTable} from '@mantine/core';
 import {useForm} from '@mantine/form';
 import {useClickOutside, useDidUpdate} from '@mantine/hooks';
 import {
@@ -175,7 +175,7 @@ export const Table: TableType = <T,>({
         onMount?.({...state, ...form.values});
     }, []);
 
-    const outSideClickRef = useClickOutside(() => {
+    const outsideClickRef = useClickOutside(() => {
         table.resetRowSelection(true);
     });
 
@@ -248,46 +248,42 @@ export const Table: TableType = <T,>({
     });
 
     return (
-        <TableContext.Provider
-            value={{
-                onChange: triggerChange,
-                state,
-                setState,
-                clearFilters,
-                getSelectedRow,
-                clearSelection,
-                form,
-            }}
-        >
-            {header}
-            <MantineTable
-                ref={outSideClickRef}
-                className={classes.table}
-                horizontalSpacing="sm"
-                verticalSpacing="xs"
-                pb="sm"
+        <Box ref={outsideClickRef}>
+            <TableContext.Provider
+                value={{
+                    onChange: triggerChange,
+                    state,
+                    setState,
+                    clearFilters,
+                    getSelectedRow,
+                    clearSelection,
+                    form,
+                }}
             >
-                <thead className={classes.header}>
-                    {table.getHeaderGroups().map((headerGroup) => (
-                        <tr key={headerGroup.id}>
-                            {headerGroup.headers.map((columnHeader) => (
-                                <Th key={columnHeader.id} header={columnHeader} />
-                            ))}
-                        </tr>
-                    ))}
-                </thead>
-                <tbody>
-                    {rows.length ? (
-                        rows
-                    ) : (
-                        <tr>
-                            <td colSpan={columns.length}>{noDataChildren}</td>
-                        </tr>
-                    )}
-                </tbody>
-            </MantineTable>
-            {footer}
-        </TableContext.Provider>
+                {header}
+                <MantineTable className={classes.table} horizontalSpacing="sm" verticalSpacing="xs" pb="sm">
+                    <thead className={classes.header}>
+                        {table.getHeaderGroups().map((headerGroup) => (
+                            <tr key={headerGroup.id}>
+                                {headerGroup.headers.map((columnHeader) => (
+                                    <Th key={columnHeader.id} header={columnHeader} />
+                                ))}
+                            </tr>
+                        ))}
+                    </thead>
+                    <tbody>
+                        {rows.length ? (
+                            rows
+                        ) : (
+                            <tr>
+                                <td colSpan={columns.length}>{noDataChildren}</td>
+                            </tr>
+                        )}
+                    </tbody>
+                </MantineTable>
+                {footer}
+            </TableContext.Provider>
+        </Box>
     );
 };
 

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -1,6 +1,6 @@
 import {Center, Collapse, createStyles, Loader, Skeleton, Table as MantineTable} from '@mantine/core';
 import {useForm} from '@mantine/form';
-import {useDidUpdate} from '@mantine/hooks';
+import {useClickOutside, useDidUpdate} from '@mantine/hooks';
 import {
     ColumnDef,
     defaultColumnSizing,
@@ -175,6 +175,10 @@ export const Table: TableType = <T,>({
         onMount?.({...state, ...form.values});
     }, []);
 
+    const outSideClickRef = useClickOutside(() => {
+        table.resetRowSelection(true);
+    });
+
     useDidUpdate(() => {
         triggerChange();
         clearSelection();
@@ -256,7 +260,13 @@ export const Table: TableType = <T,>({
             }}
         >
             {header}
-            <MantineTable className={classes.table} horizontalSpacing="sm" verticalSpacing="xs" pb="sm">
+            <MantineTable
+                ref={outSideClickRef}
+                className={classes.table}
+                horizontalSpacing="sm"
+                verticalSpacing="xs"
+                pb="sm"
+            >
                 <thead className={classes.header}>
                     {table.getHeaderGroups().map((headerGroup) => (
                         <tr key={headerGroup.id}>

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -125,4 +125,31 @@ describe('Table', () => {
         const allRows = screen.getAllByRole('button', {name: 'arrowHeadDown'});
         expect(allRows).toHaveLength(2);
     });
+
+    it('reset row selection when user click outside the table', () => {
+        render(
+            <div>
+                <div>I'm a header</div>
+                <Table
+                    data={[
+                        {firstName: 'first', lastName: 'last'},
+                        {firstName: 'patate', lastName: 'king'},
+                    ]}
+                    columns={columns}
+                />
+            </div>
+        );
+
+        const row = screen.getByRole('row', {name: 'patate king'});
+
+        expect(row).not.toHaveClass('__mantine-ref-rowSelected');
+
+        userEvent.click(row);
+
+        expect(row).toHaveClass('__mantine-ref-rowSelected');
+
+        userEvent.click(screen.getByText(/i'm a header/i));
+
+        expect(row).not.toHaveClass('__mantine-ref-rowSelected');
+    });
 });


### PR DESCRIPTION
### Proposed Changes

UITOOL-956

A comment was raised in a pr that the Mantine table was not unselecting row if the user click outside the table. 
Now it does 😄 

No demo in Plasma website here but here's a video from me hacking a bit the Badge demo page 😆 


https://user-images.githubusercontent.com/63734941/199560856-46f68b13-ff93-4585-95fe-73596043b911.mp4


### Potential Breaking Changes

None

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
