### PR TITLE
style(mantine, collection):  align  item at baseline

### DIFF
--- a/packages/mantine/src/components/collection/Colllection.styles.ts
+++ b/packages/mantine/src/components/collection/Colllection.styles.ts
@@ -6,6 +6,7 @@ export default createStyles((theme) => ({
     root: {},
     item: {
         backgroundColor: theme.colorScheme === 'light' ? theme.white : theme.black,
+        alignItems: 'baseline',
     },
     itemDragging: {
         boxShadow: theme.shadows.sm,


### PR DESCRIPTION
### Proposed Changes

UITOOL-923

Setting the Collection item alignement at baseline to avoid misalignment caused by validation errors.

Before:

<img width="910" alt="image" src="https://user-images.githubusercontent.com/63734941/199580900-d83fca0a-2efc-4447-87b7-ef52255ac4cd.png">

After:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/63734941/199580979-61cdc336-7a7d-41d5-83a1-1990e6181822.png">

<img width="684" alt="image" src="https://user-images.githubusercontent.com/63734941/199581031-f03e3c36-deff-424a-aeb1-8451c1f988bc.png">




### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
