### PR TITLE
chore: 🤖 remove next-fonts

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -38,7 +38,6 @@
         "monaco-editor": "0.33.0",
         "next": "12.1.5",
         "next-compose-plugins": "2.2.1",
-        "next-fonts": "1.5.1",
         "next-global-css": "1.3.1",
         "next-images": "1.8.4",
         "next-sitemap": "3.1.10 ",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,7 +551,6 @@ importers:
       monaco-editor: 0.33.0
       next: 12.1.5
       next-compose-plugins: 2.2.1
-      next-fonts: 1.5.1
       next-global-css: 1.3.1
       next-images: 1.8.4
       next-sitemap: '3.1.10 '
@@ -595,7 +594,6 @@ importers:
       monaco-editor: 0.33.0
       next: 12.1.5_dmi2t66wvavvdsdvw6dn5lzaaa
       next-compose-plugins: 2.2.1
-      next-fonts: 1.5.1
       next-global-css: 1.3.1
       next-images: 1.8.4
       next-sitemap: 3.1.10_next@12.1.5
@@ -6158,8 +6156,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -12725,15 +12723,6 @@ packages:
 
   /next-compose-plugins/2.2.1:
     resolution: {integrity: sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==}
-    dev: false
-
-  /next-fonts/1.5.1:
-    resolution: {integrity: sha512-pgEJ40xO1oRhM6RqhQJ9CzuZOFp6Zq+aAD/V1P9sq/wdepvLzhFxDm3lCZNoE7+78NSuMKgT6b1qeXSsqWuUMQ==}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      file-loader: 6.2.0
-      url-loader: 4.1.1_file-loader@6.2.0
     dev: false
 
   /next-global-css/1.3.1:


### PR DESCRIPTION
### Proposed Changes

ADUI-8345

This is a fix for this snyk issue: 

<img width="927" alt="image" src="https://user-images.githubusercontent.com/63734941/200060992-a93df5f9-e95b-473f-a7eb-2962dd390edb.png">

Did some digging and turns out NextJs does not need next-fonts anymore to work properly so I just removed it 😄 
https://github.com/rohanray/next-fonts/issues/34

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
