### PR TITLE
perf(props-analyzer): speedup props metadata generation process

### DIFF
--- a/packages/components-props-analyzer/bin/buildTypeScriptEnvironment.ts
+++ b/packages/components-props-analyzer/bin/buildTypeScriptEnvironment.ts
@@ -1,0 +1,19 @@
+import {createFSBackedSystem, createVirtualTypeScriptEnvironment} from '@typescript/vfs';
+import ts from 'typescript';
+
+export const compilerOptions: ts.CompilerOptions = {
+    jsx: ts.JsxEmit.ReactJSX,
+    target: ts.ScriptTarget.ES2017,
+    skipLibCheck: true,
+    esModuleInterop: true,
+    strict: false,
+};
+
+const build = () => {
+    const fsMap = new Map<string, string>();
+    const system = createFSBackedSystem(fsMap, __dirname, ts);
+    const env = createVirtualTypeScriptEnvironment(system, [], ts, compilerOptions);
+    return env;
+};
+
+export default build;

--- a/packages/components-props-analyzer/bin/getPropsOfComponent.ts
+++ b/packages/components-props-analyzer/bin/getPropsOfComponent.ts
@@ -1,33 +1,20 @@
-import {createFSBackedSystem, createVirtualTypeScriptEnvironment} from '@typescript/vfs';
+import {VirtualTypeScriptEnvironment} from '@typescript/vfs';
 import ts from 'typescript';
 
 import {Component, ComponentMetadata} from '../src/ComponentsList';
 
-export const compilerOptions: ts.CompilerOptions = {
-    jsx: ts.JsxEmit.ReactJSX,
-    target: ts.ScriptTarget.ES2017,
-    skipLibCheck: true,
-    esModuleInterop: true,
-    strict: false,
-};
-
-const fileName = 'index.tsx';
-
 const getContent = ({name, packageName}: Component) =>
     `import {ComponentProps} from 'react';import {${name}} from '${packageName}';const props: ComponentProps<typeof ${name}> = { `;
 
-export const getPropsOfComponent = async (component: Component): Promise<ComponentMetadata[]> => {
-    const fsMap = new Map<string, string>();
+export const getPropsOfComponent = (component: Component, env: VirtualTypeScriptEnvironment): ComponentMetadata[] => {
+    const fileName = `${component.name}.tsx`;
     const content = getContent(component);
-    fsMap.set(fileName, content);
-    const system = createFSBackedSystem(fsMap, __dirname, ts);
-    const env = createVirtualTypeScriptEnvironment(system, [fileName], ts, compilerOptions);
-
-    const checker = env.languageService.getProgram()!.getTypeChecker();
+    env.createFile(fileName, content);
     const {entries} = env.languageService.getCompletionsAtPosition(fileName, content.length + 1, {
         triggerKind: ts.CompletionTriggerKind.Invoked,
     }) ?? {entries: []};
 
+    const checker = env.languageService.getProgram()!.getTypeChecker();
     const accumulator: ComponentMetadata[] = [];
 
     if (entries) {
@@ -75,6 +62,8 @@ export const getPropsOfComponent = async (component: Component): Promise<Compone
             }
         });
     }
+
+    env.sys.deleteFile?.(fileName);
 
     return accumulator;
 };

--- a/packages/components-props-analyzer/bin/index.ts
+++ b/packages/components-props-analyzer/bin/index.ts
@@ -3,24 +3,34 @@ import * as rimraf from 'rimraf';
 
 import componentsList from '../src/ComponentsList';
 import {getPropsOfComponent} from './getPropsOfComponent';
+import buildTypeScriptEnvironment from './buildTypeScriptEnvironment';
 
 const generateProps = async () => {
+    ensureDirSync('./src/components');
+    outputFileSync(
+        './src/components/index.ts',
+        "// Don't edit this file, it is automatically generated on each build\n"
+    );
+    const env = buildTypeScriptEnvironment();
+
     const promises = componentsList.map(async (component) => {
-        const props = await getPropsOfComponent(component);
-        await outputFile(
-            `./src/components/${component.name}.ts`,
-            `// Don't edit this file, it is automatically generated on each build
-            import {ComponentMetadata} from '../ComponentsList';
-            export const ${component.name}Metadata: ComponentMetadata[] = ${JSON.stringify(props)};`
+        const operations: Array<Promise<void>> = [];
+        const props = getPropsOfComponent(component, env);
+        operations.push(
+            outputFile(
+                `./src/components/${component.name}.ts`,
+                `// Don't edit this file, it is automatically generated on each build
+                import {ComponentMetadata} from '../ComponentsList';
+                export const ${component.name}Metadata: ComponentMetadata[] = ${JSON.stringify(props)};`
+            )
         );
-        appendFile('./src/components/index.ts', `export * from './${component.name}';\n`);
+        operations.push(appendFile('./src/components/index.ts', `export * from './${component.name}';\n`));
+        return Promise.all(operations);
     });
 
     await Promise.all(promises);
 };
 
 rimraf.sync('./src/components');
-ensureDirSync('./src/components');
-outputFileSync('./src/components/index.ts', '');
 
 generateProps();

--- a/packages/components-props-analyzer/package.json
+++ b/packages/components-props-analyzer/package.json
@@ -15,7 +15,7 @@
         "compile": "node ../../scripts/build",
         "gen:props": "ts-node --project ./bin/tsconfig.json ./bin/index.ts",
         "prettify": "prettier --write 'src/components/*.ts'",
-        "start": "node ../../scripts/start"
+        "start": "nodemon --watch 'src/ComponentsList.ts' --exec 'pnpm build'"
     },
     "dependencies": {
         "@coveord/plasma-mantine": "workspace:*",
@@ -34,6 +34,7 @@
         "@typescript/vfs": "1.3.5",
         "cross-fetch": "3.1.5",
         "fs-extra": "10.1.0",
+        "nodemon": "2.0.20",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "rimraf": "3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ importers:
       '@typescript/vfs': 1.3.5
       cross-fetch: 3.1.5
       fs-extra: 10.1.0
+      nodemon: 2.0.20
       react: 17.0.2
       react-dom: 17.0.2
       rimraf: 3.0.2
@@ -89,6 +90,7 @@ importers:
       '@typescript/vfs': 1.3.5
       cross-fetch: 3.1.5
       fs-extra: 10.1.0
+      nodemon: 2.0.20
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       rimraf: 3.0.2
@@ -4023,6 +4025,7 @@ packages:
       is-glob: 4.0.3
       semver: 7.3.8
       tsutils: 3.21.0
+      typescript: 4.6.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4357,6 +4360,10 @@ packages:
 
   /abab/2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+
+  /abbrev/1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    dev: true
 
   /acorn-globals/7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
@@ -6892,6 +6899,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+    dev: true
+
+  /debug/3.2.7_supports-color@5.5.0:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 5.5.0
     dev: true
 
   /debug/4.3.4:
@@ -9490,6 +9509,10 @@ packages:
 
   /iferr/0.1.5:
     resolution: {integrity: sha512-DUNFN5j7Tln0D+TxzloUjKB+CtVu6myn0JEFak6dG18mNt9YkQ6lzGCdafwofISZ1lLF3xRHJ98VKy9ynkcFaA==}
+    dev: true
+
+  /ignore-by-default/1.0.1:
+    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
     dev: true
 
   /ignore-walk/3.0.3:
@@ -12548,6 +12571,30 @@ packages:
     resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
     dev: true
 
+  /nodemon/2.0.20:
+    resolution: {integrity: sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==}
+    engines: {node: '>=8.10.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      debug: 3.2.7_supports-color@5.5.0
+      ignore-by-default: 1.0.1
+      minimatch: 3.1.2
+      pstree.remy: 1.1.8
+      semver: 5.7.1
+      simple-update-notifier: 1.0.7
+      supports-color: 5.5.0
+      touch: 3.1.0
+      undefsafe: 2.0.5
+    dev: true
+
+  /nopt/1.0.10:
+    resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
+    dev: true
+
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
@@ -13954,6 +14001,10 @@ packages:
 
   /psl/1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    dev: true
+
+  /pstree.remy/1.1.8:
+    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
     dev: true
 
   /public-encrypt/4.0.3:
@@ -15466,6 +15517,11 @@ packages:
     hasBin: true
     dev: true
 
+  /semver/7.0.0:
+    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
+    hasBin: true
+    dev: true
+
   /semver/7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
     engines: {node: '>=10'}
@@ -15566,6 +15622,13 @@ packages:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
       is-arrayish: 0.3.2
+    dev: true
+
+  /simple-update-notifier/1.0.7:
+    resolution: {integrity: sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      semver: 7.0.0
     dev: true
 
   /sisteransi/1.0.5:
@@ -16750,6 +16813,13 @@ packages:
       ieee754: 1.2.1
     dev: true
 
+  /touch/3.1.0:
+    resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
+    hasBin: true
+    dependencies:
+      nopt: 1.0.10
+    dev: true
+
   /tough-cookie/4.1.2:
     resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
     engines: {node: '>=6'}
@@ -17204,6 +17274,10 @@ packages:
       react: 18.2.0
       react-lifecycles-compat: 3.0.4
     dev: false
+
+  /undefsafe/2.0.5:
+    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
+    dev: true
 
   /underscore.string/3.3.6:
     resolution: {integrity: sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==}


### PR DESCRIPTION
### Proposed Changes

- Use nodemon to watch on the component list file and rebuild everything when it changes.
- Speedup the props analysis process by creating only one ts environment for the whole process, instead of one ts env per component.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
