### PR TITLE
feat(props-analyzer): generate props metadata for each component

### DIFF
--- a/packages/components-props-analyzer/bin/getPropsOfComponent.ts
+++ b/packages/components-props-analyzer/bin/getPropsOfComponent.ts
@@ -3,8 +3,13 @@ import ts from 'typescript';
 
 import {Component, ComponentMetadata} from '../src/ComponentsList';
 
-const getContent = ({name, packageName}: Component) =>
-    `import {ComponentProps} from 'react';import {${name}} from '${packageName}';const props: ComponentProps<typeof ${name}> = { `;
+const getContent = ({name, packageName, propsType = 'auto'}: Component) => {
+    if (propsType && propsType !== 'auto') {
+        return `import {${propsType}} from '${packageName}';const props: ${propsType} = { `;
+    } else {
+        return `import {ComponentProps} from 'react';import {${name}} from '${packageName}';const props: ComponentProps<typeof ${name}> = { `;
+    }
+};
 
 export const getPropsOfComponent = (component: Component, env: VirtualTypeScriptEnvironment): ComponentMetadata[] => {
     const fileName = `${component.name}.tsx`;

--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -7,6 +7,15 @@ export interface Component {
      * The name of the package from which the component is exported
      */
     packageName: string;
+    /**
+     * The props type or interface that contains all the props of this component.
+     *
+     * Most of the time you can use `'auto'`, which will use `React.ComponentProps<typeof name>`
+     * to infer the type.
+     *
+     * @default 'auto'
+     */
+    propsType?: 'auto' | string;
 }
 
 export interface ComponentMetadata {
@@ -33,6 +42,233 @@ const components: Component[] = [
     },
     {
         name: 'BlankSlate',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'BrowserPreview',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'ChartContainer',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'CollapsibleConnected',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'IconCard',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'LabeledValue',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Limit',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'ModalCompositeConnected',
+        packageName: '@coveord/plasma-react',
+        propsType: 'IModalCompositeProps',
+    },
+    {
+        name: 'ModalWizard',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'BasicHeader',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Section',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'SplitLayout',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'StickyFooter',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'TableHOC',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'ActionableItem',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Button',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Checkbox',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'CodeEditor',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'ColorPicker',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Countdown',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'DatePickerDropdownConnected',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'DiffViewer',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Facet',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Filepicker',
+        packageName: '@coveord/plasma-react',
+        propsType: 'FilepickerProps',
+    },
+    {
+        name: 'FilterBoxConnected',
+        packageName: '@coveord/plasma-react',
+        propsType: 'IFilterBoxOwnProps',
+    },
+    {
+        name: 'FlatSelectConnected',
+        packageName: '@coveord/plasma-react',
+        propsType: 'IFlatSelectOwnProps',
+    },
+    {
+        name: 'JSONEditorConnected',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'MultilineBox',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'NumericInputConnected',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'RadioSelectConnected',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'SearchBar',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'SingleSelectConnected',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'MultiSelectConnected',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Slider',
+        packageName: '@coveord/plasma-react',
+        propsType: 'SliderOwnProps',
+    },
+    {
+        name: 'TextArea',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'TextInput',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'BreadcrumbHeader',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'SideNavigation',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'SubNavigation',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Tab',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Badge',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'ColorBar',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'IconBadge',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'LastUpdated',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Loading',
+        packageName: '@coveord/plasma-react',
+        propsType: 'ILoadingOwnProps',
+    },
+    {
+        name: 'StepProgressBar',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'SyncFeedback',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Toast',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'Tooltip',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'ActionBarConnected',
+        packageName: '@coveord/plasma-react',
+        propsType: 'IActionBarProps',
+    },
+    {
+        name: 'InfoToken',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'LinkSvg',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'ListBox',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'OptionsCycleConnected',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'PartialStringMatch',
+        packageName: '@coveord/plasma-react',
+    },
+    {
+        name: 'SlideY',
         packageName: '@coveord/plasma-react',
     },
 ];


### PR DESCRIPTION
### Proposed Changes

Use the props analyzer to generate props metadata for each of the components used on the website demo pages

### Potential Breaking Changes

None, not merging in master

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
