### PR TITLE
ci: 🎡 snyk scan fails only if high vulnerabilities if found

### DIFF
--- a/.github/actions/snyk-pnpm/action.yml
+++ b/.github/actions/snyk-pnpm/action.yml
@@ -29,7 +29,7 @@ runs:
           env:
               SNYK_TOKEN: ${{ inputs.SNYK_TOKEN }}
           run: |
-            npx --yes snyk test --org=coveo-admin-ui --file=./snyk/scan-me/package-lock.json --sarif-file-output=./sarifs/snyk-test.sarif
+            npx --yes snyk test --org=coveo-admin-ui --severity-threshold=high --file=./snyk/scan-me/package-lock.json --sarif-file-output=./sarifs/snyk-test.sarif
             npx --yes snyk monitor --org=coveo-admin-ui --file=./snyk/scan-me/package-lock.json
         - name: Snyk Code
           shell: bash


### PR DESCRIPTION
### Proposed Changes

We used to be able to merge even if medium vulnerabilities were found by snyk. I'm bringing this back.
doc: https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/advanced-failing-of-builds-in-snyk-cli

<img width="1144" alt="image" src="https://user-images.githubusercontent.com/63734941/200601142-547b7bdf-08cc-4f31-99fd-c60ebacd66e8.png">

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
