### PR TITLE
feat(website): populate all props table

### DIFF
--- a/packages/react/src/components/loading/Loading.tsx
+++ b/packages/react/src/components/loading/Loading.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
-import {ClassAttributes, HTMLProps, Component} from 'react';
+import {Component, HTMLProps} from 'react';
 import {omit} from 'underscore';
 
-export interface ILoadingOwnProps extends ClassAttributes<Loading> {
+export interface ILoadingOwnProps {
     /**
      * Unique identifier. Only needed when using LoadingConnected
      */

--- a/packages/react/src/components/optionsCycle/OptionsCycleConnected.tsx
+++ b/packages/react/src/components/optionsCycle/OptionsCycleConnected.tsx
@@ -1,10 +1,12 @@
+import {ComponentType} from 'react';
 import {connect} from 'react-redux';
 
-import {PlasmaState, IReduxActionsPayload} from '../../PlasmaState';
+import {IReduxActionsPayload, PlasmaState} from '../../PlasmaState';
 import {IReduxAction, ReduxUtils} from '../../utils/ReduxUtils';
 import {
     IOptionsCycleConnectedOwnProps,
     IOptionsCycleDispatchProps,
+    IOptionsCycleOwnProps,
     IOptionsCycleStateProps,
     OptionsCycle,
 } from './OptionsCycle';
@@ -27,4 +29,8 @@ const mapDispatchToProps = (
 /**
  * @deprecated Use Mantine instead
  */
-export const OptionsCycleConnected = connect(mapStateToProps, mapDispatchToProps, ReduxUtils.mergeProps)(OptionsCycle);
+export const OptionsCycleConnected: ComponentType<IOptionsCycleOwnProps & IOptionsCycleConnectedOwnProps> = connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    ReduxUtils.mergeProps
+)(OptionsCycle);

--- a/packages/website/src/pages/advanced/ActionBar.tsx
+++ b/packages/website/src/pages/advanced/ActionBar.tsx
@@ -1,4 +1,14 @@
+import {ActionBarConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/ActionBar/ActionBar.example.tsx';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
-export default () => <PageLayout id="ActionBarConnected" title="Action Bar" section="Advanced" code={code} />;
+export default () => (
+    <PageLayout
+        id="ActionBarConnected"
+        title="Action Bar"
+        section="Advanced"
+        code={code}
+        propsMetadata={ActionBarConnectedMetadata}
+    />
+);

--- a/packages/website/src/pages/advanced/InfoToken.tsx
+++ b/packages/website/src/pages/advanced/InfoToken.tsx
@@ -1,3 +1,4 @@
+import {InfoTokenMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/InfoToken/main.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -16,6 +17,7 @@ export default () => (
         description="An InfoToken is a visual representation of the status of something."
         componentSourcePath="/info-token/InfoToken.tsx"
         code={code}
+        propsMetadata={InfoTokenMetadata}
         examples={{
             info: {code: infoExample, title: 'Information'},
             success: {code: successExample, title: 'Success'},

--- a/packages/website/src/pages/advanced/LinkSvg.tsx
+++ b/packages/website/src/pages/advanced/LinkSvg.tsx
@@ -1,3 +1,5 @@
+import {LinkSvgMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -19,5 +21,6 @@ export default () => (
         description="A SVG that acts as a link."
         componentSourcePath="/svg/LinkSvg.tsx"
         code={code}
+        propsMetadata={LinkSvgMetadata}
     />
 );

--- a/packages/website/src/pages/advanced/ListBox.tsx
+++ b/packages/website/src/pages/advanced/ListBox.tsx
@@ -1,9 +1,10 @@
-import code from '@examples/ListBox/main.example.tsx';
+import {ListBoxMetadata} from '@coveord/plasma-components-props-analyzer';
 import emptyExample from '@examples/ListBox/empty.example.tsx';
+import code from '@examples/ListBox/main.example.tsx';
 import withFooterExample from '@examples/ListBox/withFooter.example.tsx';
-import loadingExample from '../../examples/ListBox/loading.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
+import loadingExample from '../../examples/ListBox/loading.example.tsx';
 
 export default () => (
     <PageLayout
@@ -13,6 +14,7 @@ export default () => (
         description="A list of items from which to choose from."
         componentSourcePath="/listBox/ListBox.tsx"
         code={code}
+        propsMetadata={ListBoxMetadata}
         examples={{
             loading: {code: loadingExample, title: 'Loading'},
             empty: {code: emptyExample, title: 'Empty state'},

--- a/packages/website/src/pages/advanced/OptionsCycle.tsx
+++ b/packages/website/src/pages/advanced/OptionsCycle.tsx
@@ -1,3 +1,5 @@
+import {OptionsCycleConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -28,6 +30,7 @@ export default () => (
         description="Allows to cycle through an ordered list of options using right-left arrow buttons."
         componentSourcePath="/optionsCycle/OptionsCycle.tsx"
         code={code}
+        propsMetadata={OptionsCycleConnectedMetadata}
         examples={{
             buttonStyle: {code: buttonStyle, title: 'Styles like the Button'},
         }}

--- a/packages/website/src/pages/advanced/PartialStringMatch.tsx
+++ b/packages/website/src/pages/advanced/PartialStringMatch.tsx
@@ -1,3 +1,5 @@
+import {PartialStringMatchMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -20,6 +22,7 @@ export default () => (
         id="PartialStringMatch"
         title="Partial String Match"
         section="Advanced"
+        propsMetadata={PartialStringMatchMetadata}
         description="Highlights a string searched for in any DOM tree."
         componentSourcePath="/partial-string-match/PartialStringMatch.tsx"
         code={code}

--- a/packages/website/src/pages/advanced/SlideY.tsx
+++ b/packages/website/src/pages/advanced/SlideY.tsx
@@ -1,3 +1,4 @@
+import {SlideYMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/SlideY/main.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -10,5 +11,6 @@ export default () => (
         description="Allows to hide and show content using a vertical expand animation."
         sourcePath="packages/react/src/animations/SlideY.tsx"
         code={code}
+        propsMetadata={SlideYMetadata}
     />
 );

--- a/packages/website/src/pages/feedback/Badge.tsx
+++ b/packages/website/src/pages/feedback/Badge.tsx
@@ -1,3 +1,5 @@
+import {BadgeMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 import BadgeExample from '../../examples/Badge/Badge.example.tsx';
 import BadgeSmallExample from '../../examples/Badge/BadgeSmall.example.tsx';
@@ -12,6 +14,7 @@ export const BadgeExamples = () => (
         description="A badge is a small label that displays a short yet important piece of information."
         thumbnail="badge"
         code={BadgeExample}
+        propsMetadata={BadgeMetadata}
         examples={{
             BadgeWithIconsExample: {code: BadgeWithIconsExample, title: 'Badge with icon'},
             BadgeSmallExample: {code: BadgeSmallExample, title: 'Badge small'},

--- a/packages/website/src/pages/feedback/ColorBar.tsx
+++ b/packages/website/src/pages/feedback/ColorBar.tsx
@@ -1,6 +1,7 @@
+import {ColorBarMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/ColorBar/ColorBar.example.tsx';
-import partial from '@examples/ColorBar/ColorBarPartial.example.tsx';
 import overflow from '@examples/ColorBar/ColorBarOverflow.example.tsx';
+import partial from '@examples/ColorBar/ColorBarPartial.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -12,6 +13,7 @@ export default () => (
         description="A color bar is used to indicate the ratio between things."
         componentSourcePath="/colorBar/ColorBar.tsx"
         code={code}
+        propsMetadata={ColorBarMetadata}
         examples={{
             partial: {code: partial, title: 'Partially filled'},
             overflow: {code: overflow, title: 'Overflow'},

--- a/packages/website/src/pages/feedback/IconBadge.tsx
+++ b/packages/website/src/pages/feedback/IconBadge.tsx
@@ -1,3 +1,5 @@
+import {IconBadgeMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -34,6 +36,7 @@ export const IconBadgeExamples = () => (
         section="Feedback"
         thumbnail="placeholder"
         code={code}
+        propsMetadata={IconBadgeMetadata}
     />
 );
 

--- a/packages/website/src/pages/feedback/LastUpdated.tsx
+++ b/packages/website/src/pages/feedback/LastUpdated.tsx
@@ -1,5 +1,7 @@
+import {LastUpdatedMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/LastUpdated/LastUpdated.example.tsx';
 import specificTime from '@examples/LastUpdated/LastUpdatedSpecifiedTime.example.tsx';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 export default () => (
@@ -10,6 +12,7 @@ export default () => (
         description="A “last updated” string displays the time a set of data has been last updated by a system."
         componentSourcePath="/lastUpdated/LastUpdated.tsx"
         code={code}
+        propsMetadata={LastUpdatedMetadata}
         examples={{specificTime: {code: specificTime, title: 'Specific date'}}}
     />
 );

--- a/packages/website/src/pages/feedback/Loading.tsx
+++ b/packages/website/src/pages/feedback/Loading.tsx
@@ -1,3 +1,5 @@
+import {LoadingMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -32,6 +34,7 @@ export default () => (
         description="A loading spinner indicates that content or data is actively being loaded."
         componentSourcePath="/loading/Loading.tsx"
         code={code}
+        propsMetadata={LoadingMetadata}
         examples={{
             fullContent: {code: fullContent, title: 'Vertically centered'},
             loadingSpinner: {code: loadingSpinner, title: 'Loading spinner that can be used in other components'},

--- a/packages/website/src/pages/feedback/StepProgressBar.tsx
+++ b/packages/website/src/pages/feedback/StepProgressBar.tsx
@@ -1,3 +1,5 @@
+import {StepProgressBarMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -14,5 +16,6 @@ export default () => (
         description="A step progress bar visualizes a user’s progress as they complete a task by representing the number of steps left to complete the task."
         componentSourcePath="/stepProgressBar/StepProgressBar.tsx"
         code={code}
+        propsMetadata={StepProgressBarMetadata}
     />
 );

--- a/packages/website/src/pages/feedback/SyncFeedback.tsx
+++ b/packages/website/src/pages/feedback/SyncFeedback.tsx
@@ -1,5 +1,7 @@
+import {SyncFeedbackMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/SyncFeedback/SyncFeedback.example.tsx';
 import label from '@examples/SyncFeedback/SyncFeedbackLabel.example.tsx';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 export default () => (
@@ -10,6 +12,7 @@ export default () => (
         description="A sync feedback indicates the status of an operation to the user."
         componentSourcePath="/numericInput/NumericInputConnected.tsx"
         code={code}
+        propsMetadata={SyncFeedbackMetadata}
         examples={{label: {code: label, title: 'Custom Labels'}}}
     />
 );

--- a/packages/website/src/pages/feedback/Toast.tsx
+++ b/packages/website/src/pages/feedback/Toast.tsx
@@ -1,3 +1,5 @@
+import {ToastMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -53,6 +55,7 @@ export const ToastExamples = () => (
         section="Feedback"
         description="A toast displays a short message related to an action performed by a user."
         code={code}
+        propsMetadata={ToastMetadata}
         examples={{
             download: {code: downloadToast, title: 'Download Toast'},
             container: {code: notifier, title: 'Toast Notifier'},

--- a/packages/website/src/pages/feedback/Tooltip.tsx
+++ b/packages/website/src/pages/feedback/Tooltip.tsx
@@ -1,3 +1,5 @@
+import {TooltipMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -21,6 +23,7 @@ export const TooltipExamples = () => (
         description="A tooltip is a floating label that provides brief additional information about an interface component."
         thumbnail="tooltip"
         code={code}
+        propsMetadata={TooltipMetadata}
     />
 );
 

--- a/packages/website/src/pages/form/ActionableItem.tsx
+++ b/packages/website/src/pages/form/ActionableItem.tsx
@@ -1,4 +1,6 @@
+import {ActionableItemMetadata} from '@coveord/plasma-components-props-analyzer';
 import {FunctionComponent} from 'react';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -25,6 +27,7 @@ const ActionableItemExamples: FunctionComponent = () => (
         section="Form"
         description="An actionable item is a dropdown menu listing actions associated with an element."
         code={code}
+        propsMetadata={ActionableItemMetadata}
         componentSourcePath="/actionable-item/ActionableItem.tsx"
     />
 );

--- a/packages/website/src/pages/form/Button.tsx
+++ b/packages/website/src/pages/form/Button.tsx
@@ -1,3 +1,4 @@
+import {ButtonMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/button/Button.example.tsx';
 import disabled from '@examples/button/Disabled.example.tsx';
 import iconAndLink from '@examples/button/IconAndLink.example.tsx';
@@ -27,5 +28,6 @@ export default () => (
             withTooltip: {code: withTooltip, title: 'With tooltop'},
         }}
         componentSourcePath="/button/Button.tsx"
+        propsMetadata={ButtonMetadata}
     />
 );

--- a/packages/website/src/pages/form/Checkbox.tsx
+++ b/packages/website/src/pages/form/Checkbox.tsx
@@ -1,3 +1,5 @@
+import {CheckboxMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -67,6 +69,7 @@ const CheckboxExamples = () => (
             disabled: {code: disabled, title: 'Disabled'},
             group: {code: group, title: 'A group of checkboxes'},
         }}
+        propsMetadata={CheckboxMetadata}
     />
 );
 

--- a/packages/website/src/pages/form/CodeEditor.tsx
+++ b/packages/website/src/pages/form/CodeEditor.tsx
@@ -1,3 +1,5 @@
+import {CodeEditorMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -33,6 +35,7 @@ export default () => (
         thumbnail="codeEditor"
         code={code}
         componentSourcePath="/editor/CodeEditor.tsx"
+        propsMetadata={CodeEditorMetadata}
         examples={{
             readOnly: {code: readOnly, title: 'Read only'},
         }}

--- a/packages/website/src/pages/form/ColorPicker.tsx
+++ b/packages/website/src/pages/form/ColorPicker.tsx
@@ -1,3 +1,5 @@
+import {ColorPickerMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -53,6 +55,7 @@ const ColorPickerExamples = () => (
         }
         componentSourcePath="/color-picker/ColorPicker.tsx"
         code={code}
+        propsMetadata={ColorPickerMetadata}
         examples={{
             hiddenControls: {code: hiddenControls, title: 'Hidden Controls'},
             selector: {code: selector, title: 'Selector'},

--- a/packages/website/src/pages/form/Countdown.tsx
+++ b/packages/website/src/pages/form/Countdown.tsx
@@ -1,3 +1,5 @@
+import {CountdownMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -14,5 +16,6 @@ export default () => (
         componentSourcePath="/calendar/Countdown.tsx"
         description="A Countdown illustrates how much time there is left until an end date is reached."
         code={code}
+        propsMetadata={CountdownMetadata}
     />
 );

--- a/packages/website/src/pages/form/DatePicker.tsx
+++ b/packages/website/src/pages/form/DatePicker.tsx
@@ -1,3 +1,5 @@
+import {DatePickerDropdownConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -114,6 +116,7 @@ export default () => (
         description="A date picker is a calendar interface that allows users to select a single date or a date range."
         componentSourcePath="/datePicker/DatePickerDropdown.tsx"
         code={code}
+        propsMetadata={DatePickerDropdownConnectedMetadata}
         examples={{
             singleDate: {code: singleDate, title: 'Single Date'},
             readOnly: {code: readOnly, title: 'Disabled'},

--- a/packages/website/src/pages/form/DiffViewer.tsx
+++ b/packages/website/src/pages/form/DiffViewer.tsx
@@ -1,3 +1,4 @@
+import {DiffViewerMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/diff-viewer/DiffViewer.example.tsx';
 import manyChanges from '@examples/diff-viewer/ManyChanges.example.tsx';
 import noChanges from '@examples/diff-viewer/NoChanges.example.tsx';
@@ -13,6 +14,7 @@ export default () => (
         description="A diff viewer allows users to compare code files by showing them side by side and highlighting differences between them."
         componentSourcePath="/diffViewer/DiffViewer.tsx"
         code={code}
+        propsMetadata={DiffViewerMetadata}
         examples={{
             splitView: {code: splitView, title: 'Split view'},
             manyChanges: {code: manyChanges, title: 'Many changes'},

--- a/packages/website/src/pages/form/Facet.tsx
+++ b/packages/website/src/pages/form/Facet.tsx
@@ -1,3 +1,5 @@
+import {FacetMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -81,6 +83,7 @@ export default () => (
         description="A facet is a set of options used to filter a list of content items."
         componentSourcePath="/facets/FacetConnected.tsx"
         code={code}
+        propsMetadata={FacetMetadata}
         examples={{
             withExclude: {code: withExclude, title: 'Allow exclusion'},
             withMore: {code: withMore, title: 'Show more'},

--- a/packages/website/src/pages/form/Filepicker.tsx
+++ b/packages/website/src/pages/form/Filepicker.tsx
@@ -1,3 +1,5 @@
+import {FilepickerMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -16,5 +18,6 @@ export default () => (
         description="A file picker is a dialog that allows users to upload a file."
         componentSourcePath="/filepicker/FilePicker.tsx"
         code={code}
+        propsMetadata={FilepickerMetadata}
     />
 );

--- a/packages/website/src/pages/form/FilterBox.tsx
+++ b/packages/website/src/pages/form/FilterBox.tsx
@@ -1,3 +1,5 @@
+import {FilterBoxConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -26,6 +28,7 @@ export default () => (
         description="A filter box allows users to enter text to filter data. It is frequently used with tables and dropdown menus."
         componentSourcePath="/filterBox/FilterBoxConnected.tsx"
         code={code}
+        propsMetadata={FilterBoxConnectedMetadata}
         examples={{
             maxWidth: {code: maxWidth, title: 'Maximum width'},
             disabled: {code: disabled, title: 'Disabled'},

--- a/packages/website/src/pages/form/FlatSelect.tsx
+++ b/packages/website/src/pages/form/FlatSelect.tsx
@@ -1,9 +1,10 @@
+import {FlatSelectConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/FlatSelect/FlatSelect.example.tsx';
-import group from '@examples/FlatSelect/FlatSelectGroup.example.tsx';
-import disabled from '@examples/FlatSelect/FlatSelectDisabled.example.tsx';
-import optionPicker from '@examples/FlatSelect/FlatSelectOptionPicker.example.tsx';
 import appendPrepend from '@examples/FlatSelect/FlatSelectAppendPrepend.example.tsx';
+import disabled from '@examples/FlatSelect/FlatSelectDisabled.example.tsx';
+import group from '@examples/FlatSelect/FlatSelectGroup.example.tsx';
 import iconOnly from '@examples/FlatSelect/FlatSelectIconsOnly.example.tsx';
+import optionPicker from '@examples/FlatSelect/FlatSelectOptionPicker.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -15,6 +16,7 @@ export default () => (
         description="A flat select is a group of mutually exclusive buttons aligned horizontally. It is used to allow users to switch between interface displays or binary options."
         componentSourcePath="/flatSelect/FlatSelect.tsx"
         code={code}
+        propsMetadata={FlatSelectConnectedMetadata}
         examples={{
             disabled: {code: disabled, title: 'Disabled'},
             group: {code: group, title: 'Grouped'},

--- a/packages/website/src/pages/form/JSONEditor.tsx
+++ b/packages/website/src/pages/form/JSONEditor.tsx
@@ -1,6 +1,7 @@
+import {JSONEditorConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
+import inError from '@examples/JSONEditor/InError.example.tsx';
 import code from '@examples/JSONEditor/JSONEditor.example.tsx';
 import readOnly from '@examples/JSONEditor/ReadOnly.example.tsx';
-import inError from '@examples/JSONEditor/InError.example.tsx';
 import valueFromState from '@examples/JSONEditor/ValueState.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -13,6 +14,7 @@ export default () => (
         description="A JSON editor is a text area where users can enter and edit data in JSON format."
         componentSourcePath="/editor/JSONEditor.tsx"
         code={code}
+        propsMetadata={JSONEditorConnectedMetadata}
         examples={{
             readOnly: {code: readOnly, title: 'Read only'},
             inError: {code: inError, title: 'Error Message'},

--- a/packages/website/src/pages/form/MultiSelect.tsx
+++ b/packages/website/src/pages/form/MultiSelect.tsx
@@ -1,3 +1,4 @@
+import {MultiSelectConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/MultiSelect/main.example.tsx';
 import withFilter from '@examples/MultiSelect/withFilter.example.tsx';
 import withPredicates from '@examples/MultiSelect/withPredicates.example.tsx';
@@ -12,6 +13,7 @@ export default () => (
         description="A multi select allows users to select multiple options from a list. It is typically used when there are a large number of options."
         componentSourcePath="/select/MultiSelectConnected.tsx"
         code={code}
+        propsMetadata={MultiSelectConnectedMetadata}
         examples={{
             withFilter: {code: withFilter, title: 'With a filter and custom values'},
             withPredicates: {code: withPredicates, title: 'With predicates'},

--- a/packages/website/src/pages/form/MultilineBox.tsx
+++ b/packages/website/src/pages/form/MultilineBox.tsx
@@ -1,8 +1,9 @@
+import {MultilineBoxMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/multiline-box/MultilineBox.example.tsx';
-import withContainer from '@examples/multiline-box/MultilineBoxWithContainer.example.tsx';
-import withRemove from '@examples/multiline-box/MultilineBoxWithRemove.example.tsx';
-import withDragAndDrop from '@examples/multiline-box/MultilineBoxWithDragAndDrop.example.tsx';
 import complex from '@examples/multiline-box/MultilineBoxComplex.example.tsx';
+import withContainer from '@examples/multiline-box/MultilineBoxWithContainer.example.tsx';
+import withDragAndDrop from '@examples/multiline-box/MultilineBoxWithDragAndDrop.example.tsx';
+import withRemove from '@examples/multiline-box/MultilineBoxWithRemove.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -13,6 +14,7 @@ export default () => (
         description="A multiline box allows users to provide multiple inputs for the same parameter. Each input appears on a different line."
         section="Form"
         code={code}
+        propsMetadata={MultilineBoxMetadata}
         examples={{
             withContainer: {code: withContainer, title: 'Custom container'},
             withRemove: {code: withRemove, title: 'Remove button'},

--- a/packages/website/src/pages/form/NumericInput.tsx
+++ b/packages/website/src/pages/form/NumericInput.tsx
@@ -1,3 +1,5 @@
+import {NumericInputConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -31,6 +33,7 @@ const NumericInputExamples = () => (
         section="Form"
         description="A numeric input allows users to enter and edit numerical values, either manually or using an input stepper."
         componentSourcePath="/numericInput/NumericInputConnected.tsx"
+        propsMetadata={NumericInputConnectedMetadata}
         code={code}
         examples={{disabled: {code: disabled, title: 'Disabled'}}}
     />

--- a/packages/website/src/pages/form/RadioButton.tsx
+++ b/packages/website/src/pages/form/RadioButton.tsx
@@ -1,3 +1,4 @@
+import {RadioSelectConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/RadioButton/main.example.tsx';
 import radioCard from '@examples/RadioButton/radioCard.example.tsx';
 
@@ -11,6 +12,7 @@ export default () => (
         description="A radio button allows users to select exactly one option from a list of mutually exclusive options."
         componentSourcePath="/radio/RadioSelectConnected.tsx"
         code={code}
+        propsMetadata={RadioSelectConnectedMetadata}
         examples={{
             radioCard: {code: radioCard, title: 'Radio cards'},
         }}

--- a/packages/website/src/pages/form/SearchBar.tsx
+++ b/packages/website/src/pages/form/SearchBar.tsx
@@ -1,3 +1,4 @@
+import {SearchBarMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/SearchBar/main.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -8,6 +9,7 @@ export default () => (
         title="Search Bar"
         section="Form"
         componentSourcePath="/searchBar/SearchBar.tsx"
+        propsMetadata={SearchBarMetadata}
         description="A search bar allows users to search a large set of data by entering keywords. A list of matching items is then returned."
         code={code}
     />

--- a/packages/website/src/pages/form/SingleSelect.tsx
+++ b/packages/website/src/pages/form/SingleSelect.tsx
@@ -1,7 +1,8 @@
+import {SingleSelectConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/SingleSelect/main.example.tsx';
 import withFilter from '@examples/SingleSelect/withFilter.example.tsx';
-import withPredicate from '@examples/SingleSelect/withPredicates.example.tsx';
 import withInfiniteScroll from '@examples/SingleSelect/withInfiniteScroll.example.tsx';
+import withPredicate from '@examples/SingleSelect/withPredicates.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -13,6 +14,7 @@ export default () => (
         description="A single select allows users to select only one option from a list. It is typically used when there are a large number of options."
         componentSourcePath="/select/SingleSelectConnected.tsx"
         code={code}
+        propsMetadata={SingleSelectConnectedMetadata}
         examples={{
             withFilter: {code: withFilter, title: 'With a filter box'},
             withPredicate: {code: withPredicate, title: 'With predicates options'},

--- a/packages/website/src/pages/form/Slider.tsx
+++ b/packages/website/src/pages/form/Slider.tsx
@@ -1,7 +1,8 @@
+import {SliderMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/Slider/Slider.example.tsx';
+import append from '@examples/Slider/SliderAppend.example.tsx';
 import asymetric from '@examples/Slider/SliderAsymetric.example.tsx';
 import onChange from '@examples/Slider/SliderOnChange.example.tsx';
-import append from '@examples/Slider/SliderAppend.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -13,6 +14,7 @@ export default () => (
         description="A slider offers a quick and visual way for users to select a value within a given range."
         componentSourcePath="/slider/Slider.tsx"
         code={code}
+        propsMetadata={SliderMetadata}
         examples={{
             asymetric: {code: asymetric, title: 'Asymetric'},
             onChange: {code: onChange, title: 'Change handler'},

--- a/packages/website/src/pages/form/TextArea.tsx
+++ b/packages/website/src/pages/form/TextArea.tsx
@@ -1,3 +1,4 @@
+import {TextAreaMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/TextArea/main.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -10,5 +11,6 @@ export default () => (
         description="A text area allows users to enter and edit longer text, often on multiple lines or in a paragraph."
         componentSourcePath="/textarea/TextArea.tsx"
         code={code}
+        propsMetadata={TextAreaMetadata}
     />
 );

--- a/packages/website/src/pages/form/TextInput.tsx
+++ b/packages/website/src/pages/form/TextInput.tsx
@@ -1,3 +1,4 @@
+import {TextInputMetadata} from '@coveord/plasma-components-props-analyzer';
 import {FunctionComponent} from 'react';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -100,6 +101,7 @@ export const TextInputExamples: FunctionComponent = () => (
         componentSourcePath="/textInput/TextInput.tsx"
         code={code}
         examples={{hookUsage: {code: hookUsage, title: 'useTextInput hook usage'}}}
+        propsMetadata={TextInputMetadata}
     />
 );
 export default TextInputExamples;

--- a/packages/website/src/pages/layout/BlankSlate.tsx
+++ b/packages/website/src/pages/layout/BlankSlate.tsx
@@ -1,3 +1,5 @@
+import {BlankSlateMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -105,6 +107,7 @@ export const BlankSlateExample = () => (
         section="Layout"
         description="A blank slate informs users that a section doesn’t contain any data and provides a way to address it."
         thumbnail="placeholder"
+        propsMetadata={BlankSlateMetadata}
         code={code}
         examples={{
             inError: {code: inError, title: 'With error'},

--- a/packages/website/src/pages/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/layout/BrowserPreview.tsx
@@ -1,3 +1,5 @@
+import {BrowserPreviewMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -44,6 +46,7 @@ export const BrowserPreviewExamples = () => (
         thumbnail="placeholder"
         description="A browser preview shows the result of configuration changes in a simplified representation of a browser interface."
         componentSourcePath="/browserPreview/BrowserPreview.tsx"
+        propsMetadata={BrowserPreviewMetadata}
         code={code}
         examples={{
             withError: {code: withError, title: 'With error'},

--- a/packages/website/src/pages/layout/Chart.tsx
+++ b/packages/website/src/pages/layout/Chart.tsx
@@ -1,3 +1,5 @@
+import {ChartContainerMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -268,6 +270,7 @@ export const ChartExamples = () => (
         section="Layout"
         description="A chart compares sets of complex data to provide insights on their relationship and status."
         code={code}
+        propsMetadata={ChartContainerMetadata}
         examples={{
             scatterSeries: {code: scatterSeries, title: 'Scatter series'},
             barSeries: {code: barSeries, title: 'Bar series'},

--- a/packages/website/src/pages/layout/Collapsible.tsx
+++ b/packages/website/src/pages/layout/Collapsible.tsx
@@ -1,3 +1,5 @@
+import {CollapsibleConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -72,6 +74,7 @@ const CollapsibleExamples = () => (
         section="Layout"
         description="A collapsible allows users to hide or display a section of content."
         code={code}
+        propsMetadata={CollapsibleConnectedMetadata}
         examples={{
             infoBoxWrapper: {code: infoBoxWrapper, title: 'Info box wrapper'},
             expanded: {code: expanded, title: 'Expanded on mount'},

--- a/packages/website/src/pages/layout/IconCard.tsx
+++ b/packages/website/src/pages/layout/IconCard.tsx
@@ -1,4 +1,6 @@
+import {IconCardMetadata} from '@coveord/plasma-components-props-analyzer';
 import {FunctionComponent} from 'react';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -94,6 +96,7 @@ export const IconCardExamples: FunctionComponent = () => (
         section="Layout"
         description="An icon card is an element that regroups related pieces of information together. It can be either static or interactive."
         componentSourcePath="/iconCard/IconCard.tsx"
+        propsMetadata={IconCardMetadata}
         code={code}
         examples={{
             choices: {code: choices, title: 'With multiple choices'},

--- a/packages/website/src/pages/layout/LabeledValue.tsx
+++ b/packages/website/src/pages/layout/LabeledValue.tsx
@@ -1,3 +1,5 @@
+import {LabeledValueMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -40,6 +42,7 @@ const LabeledValueExamples = () => (
         title="Labeled value"
         section="Layout"
         thumbnail="placeholder"
+        propsMetadata={LabeledValueMetadata}
         code={code}
         examples={{
             withInformation: {code: withInformation, title: 'With more information (tooltip)'},

--- a/packages/website/src/pages/layout/Limit.tsx
+++ b/packages/website/src/pages/layout/Limit.tsx
@@ -1,3 +1,5 @@
+import {LimitMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -49,6 +51,7 @@ const LimitExamples = () => (
         section="Layout"
         description="A limit card displays the limit and usage of a resource. It includes a bar illustrating the usage against the limit."
         code={code}
+        propsMetadata={LimitMetadata}
         examples={{
             withGoal: {code: withGoal, title: 'With goal to reach'},
             withHistory: {code: withHistory, title: 'With History'},

--- a/packages/website/src/pages/layout/ModalWindow.tsx
+++ b/packages/website/src/pages/layout/ModalWindow.tsx
@@ -1,3 +1,5 @@
+import {ModalCompositeConnectedMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -226,6 +228,7 @@ const ModalWindowExamples = () => (
         section="Layout"
         description="A modal appears over the current context to have users focus on a particular task or information."
         componentSourcePath="/modal/ModalComposite.tsx"
+        propsMetadata={ModalCompositeConnectedMetadata}
         code={code}
         examples={{
             prompts: {code: prompts, title: 'Prompts'},

--- a/packages/website/src/pages/layout/ModalWizard.tsx
+++ b/packages/website/src/pages/layout/ModalWizard.tsx
@@ -1,3 +1,5 @@
+import {ModalWizardMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -171,6 +173,7 @@ export const ModalWizardExamples = () => (
         description="A modal wizard guides users through a task by presenting a succession of actions to complete."
         componentSourcePath="/modalWizard/ModalWizard.tsx"
         code={code}
+        propsMetadata={ModalWizardMetadata}
         examples={{withValidationIds: {code: withValidationIds, title: 'Using validation ids'}}}
     />
 );

--- a/packages/website/src/pages/layout/PageHeader.tsx
+++ b/packages/website/src/pages/layout/PageHeader.tsx
@@ -1,5 +1,6 @@
-import code from '@examples/Header/main.example.tsx';
+import {BasicHeaderMetadata} from '@coveord/plasma-components-props-analyzer';
 import loading from '@examples/Header/loading.example.tsx';
+import code from '@examples/Header/main.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -12,6 +13,7 @@ export const PageHeaderExamples = () => (
         description="A page header informs a user of the section of the product they are currently in. It includes a breadcrumb and optional tabs."
         thumbnail="header"
         code={code}
+        propsMetadata={BasicHeaderMetadata}
         examples={{
             loading: {code: loading, title: 'Loading'},
         }}

--- a/packages/website/src/pages/layout/Section.tsx
+++ b/packages/website/src/pages/layout/Section.tsx
@@ -1,3 +1,5 @@
+import {SectionMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -48,6 +50,7 @@ const SectionExamples = () => (
             withLevel: {code: withLevel, title: 'With Level option'},
             withMods: {code: withMods, title: 'With Mods option'},
         }}
+        propsMetadata={SectionMetadata}
     />
 );
 

--- a/packages/website/src/pages/layout/SplitLayout.tsx
+++ b/packages/website/src/pages/layout/SplitLayout.tsx
@@ -1,3 +1,5 @@
+import {SplitLayoutMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -32,6 +34,7 @@ const SplitLayoutExamples = () => (
         componentSourcePath="/splitlayout/SplitLayout.tsx"
         code={code}
         layout="vertical"
+        propsMetadata={SplitLayoutMetadata}
         examples={{noBorder: {code: noBorder, title: 'Without a border'}}}
     />
 );

--- a/packages/website/src/pages/layout/StickyFooter.tsx
+++ b/packages/website/src/pages/layout/StickyFooter.tsx
@@ -1,3 +1,4 @@
+import {StickyFooterMetadata} from '@coveord/plasma-components-props-analyzer';
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const code = `
@@ -32,6 +33,7 @@ const StickyFooterExample = () => (
         section="Layout"
         description="A page footer that sticks to the bottom of the screen"
         componentSourcePath="/stickyFooter/StickyFooter.tsx"
+        propsMetadata={StickyFooterMetadata}
         code={code}
     />
 );

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -1,13 +1,14 @@
+import {TableHOCMetadata} from '@coveord/plasma-components-props-analyzer';
 import code from '@examples/Table/main.example.tsx';
-import withLoading from '@examples/Table/withLoading.example.tsx';
+import withAction from '@examples/Table/withAction.example.tsx';
 import withBlankslate from '@examples/Table/withBlankslate.example.tsx';
+import withDatePicker from '@examples/Table/withDatePicker.example.tsx';
+import withFilter from '@examples/Table/withFilter.example.tsx';
+import withLoading from '@examples/Table/withLoading.example.tsx';
 import withPagination from '@examples/Table/withPagination.example.tsx';
 import withPredicate from '@examples/Table/withPredicate.example.tsx';
-import withAction from '@examples/Table/withAction.example.tsx';
-import withSort from '@examples/Table/withSort.example.tsx';
-import withFilter from '@examples/Table/withFilter.example.tsx';
-import withDatePicker from '@examples/Table/withDatePicker.example.tsx';
 import withServer from '@examples/Table/withServer.example.tsx';
+import withSort from '@examples/Table/withSort.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -19,6 +20,7 @@ const TableExamples = () => (
         section="Layout"
         description="A table displays large quantities of items or data in a list format. Filtering features and actions may be added."
         code={code}
+        propsMetadata={TableHOCMetadata}
         examples={{
             withLoading: {code: withLoading, title: 'Loading table'},
             withBlankslate: {code: withBlankslate, title: 'Table blankslate'},

--- a/packages/website/src/pages/navigation/Breadcrumbs.tsx
+++ b/packages/website/src/pages/navigation/Breadcrumbs.tsx
@@ -1,6 +1,8 @@
+import {BreadcrumbHeaderMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
-import code from '../../examples/Breadcrumbs/main.example.tsx';
 import complex from '../../examples/Breadcrumbs/complex.example.tsx';
+import code from '../../examples/Breadcrumbs/main.example.tsx';
 
 const BreadcrumbsExamples = () => (
     <PageLayout
@@ -11,6 +13,7 @@ const BreadcrumbsExamples = () => (
         description="A breadcrumb is a secondary navigation that helps users to understand the hierarchy of interfaces and navigate through them."
         thumbnail="breadcrumb"
         code={code}
+        propsMetadata={BreadcrumbHeaderMetadata}
         examples={{complex: {code: complex, title: 'With documentation link and tabs'}}}
     />
 );

--- a/packages/website/src/pages/navigation/SideNavigation.tsx
+++ b/packages/website/src/pages/navigation/SideNavigation.tsx
@@ -1,3 +1,5 @@
+import {SideNavigationMetadata} from '@coveord/plasma-components-props-analyzer';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 import collapsible from '../../examples/SideNavigation/collapsible.example.tsx';
 import loading from '../../examples/SideNavigation/loading.example.tsx';
@@ -12,6 +14,7 @@ export const SideNavigationExamples = () => (
         description="A sidebar navigation is a primary navigation element that displays the architecture of the product’s features."
         thumbnail="sideNav"
         code={code}
+        propsMetadata={SideNavigationMetadata}
         examples={{
             loading: {code: loading, title: 'Loading section'},
             collapsible: {code: collapsible, title: 'Collapsible section'},

--- a/packages/website/src/pages/navigation/SubNavigation.tsx
+++ b/packages/website/src/pages/navigation/SubNavigation.tsx
@@ -1,3 +1,4 @@
+import {SubNavigationMetadata} from '@coveord/plasma-components-props-analyzer';
 import custom from '@examples/SubNavigation/custom.example.tsx';
 import customWithDesc from '@examples/SubNavigation/customWithDesc.example.tsx';
 import defaultSelected from '@examples/SubNavigation/defaultSelected.example.tsx';
@@ -13,6 +14,7 @@ export const SubNavigationExamples = () => (
         section="Navigation"
         description="A subnavigation is a secondary vertical navigation component that allows users to navigate between sections of the same interface."
         thumbnail="subNavigation"
+        propsMetadata={SubNavigationMetadata}
         code={code}
         examples={{
             defaultSelected: {code: defaultSelected, title: 'Default selected'},

--- a/packages/website/src/pages/navigation/Tabs.tsx
+++ b/packages/website/src/pages/navigation/Tabs.tsx
@@ -1,4 +1,6 @@
+import {TabMetadata} from '@coveord/plasma-components-props-analyzer';
 import {FunctionComponent} from 'react';
+
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const withIcons = `
@@ -65,6 +67,7 @@ export const TabsExamples: FunctionComponent = () => (
         description="A set of tabs allows users to navigate between sections of the same interface."
         thumbnail="tab"
         code={code}
+        propsMetadata={TabMetadata}
         examples={{withIcons: {code: withIcons, title: 'Tab with icons'}}}
     />
 );


### PR DESCRIPTION
### Proposed Changes

Use the generated props metadata from the component props analyzer to populate all the props table of the website. You should be able to see the props of each component as usual now.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
