### PR TITLE
fix(table, Mantine):  removed rounded corners on selected text in table row

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -224,7 +224,7 @@ export const Table: TableType = <T,>({
                         const width = size !== defaultColumnSizing.size ? size : undefined;
                         return (
                             <td key={cell.id} style={{width}}>
-                                <Skeleton visible={loading}>
+                                <Skeleton visible={loading} sx={!loading ? {borderRadius: 0} : undefined}>
                                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                 </Skeleton>
                             </td>


### PR DESCRIPTION
### Proposed Changes

UITOOL-1010

The Skeleton style is bleeding out in the table cells. I think it's because the skeleton is always render and only hidden if `loading` is false.

Before:

<img width="779" alt="image" src="https://user-images.githubusercontent.com/63734941/200670049-924a6b60-b55e-481c-aa00-493804d18711.png">

After:

<img width="734" alt="image" src="https://user-images.githubusercontent.com/63734941/200669960-28f1884f-6d90-4a8c-b268-40453befc332.png">


### Potential Breaking Changes

None, Skeleton style works has before ☠️ 

<img width="800" alt="image" src="https://user-images.githubusercontent.com/63734941/200670375-d35a59b0-ae37-4097-b44c-a3f4c481f194.png">


### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
