### PR TITLE
feat(table pagination, Mantine):  scroll back up the table when changing pages

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -258,6 +258,7 @@ export const Table: TableType = <T,>({
                     getSelectedRow,
                     clearSelection,
                     form,
+                    containerRef: outsideClickRef,
                 }}
             >
                 {header}

--- a/packages/mantine/src/components/table/TableContext.tsx
+++ b/packages/mantine/src/components/table/TableContext.tsx
@@ -1,7 +1,7 @@
 import {DateRangePickerValue} from '@mantine/dates';
 import {UseFormReturnType} from '@mantine/form';
 import {TableState} from '@tanstack/react-table';
-import {createContext, Dispatch} from 'react';
+import {createContext, Dispatch, RefObject} from 'react';
 
 export type onTableChangeEvent = (params: TableState & TableFormType) => void;
 
@@ -51,6 +51,10 @@ type TableContextType = {
      * Form used to handle predicates and dateRange
      */
     form: UseFormReturnType<TableFormType>;
+    /**
+     * Table container ref
+     */
+    containerRef: RefObject<HTMLDivElement>;
 };
 
 export const TableContext = createContext<TableContextType | null>(null);

--- a/packages/mantine/src/components/table/TablePagination.tsx
+++ b/packages/mantine/src/components/table/TablePagination.tsx
@@ -11,12 +11,13 @@ interface TablePaginationProps {
 }
 
 export const TablePagination: FunctionComponent<TablePaginationProps> = ({totalPages}) => {
-    const {state, setState} = useTable();
+    const {state, setState, containerRef} = useTable();
     const updatePage = (newPage: number) => {
         setState((prevState: TableState) => ({
             ...prevState,
             pagination: {...prevState.pagination, pageIndex: newPage - 1},
         }));
+        containerRef.current.scrollIntoView({behavior: 'smooth'});
     };
 
     return (

--- a/packages/mantine/src/components/table/__tests__/TablePagination.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TablePagination.spec.tsx
@@ -9,6 +9,14 @@ const columnHelper = createColumnHelper<RowData>();
 const columns: Array<ColumnDef<RowData>> = [columnHelper.accessor('name', {enableSorting: false})];
 
 describe('Table.Pagination', () => {
+    beforeEach(() => {
+        if (!HTMLElement.prototype.scrollIntoView) {
+            HTMLElement.prototype.scrollIntoView = () => {
+                jest.fn();
+            };
+        }
+    });
+
     it('displays the number of pages', () => {
         render(
             <Table data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns}>


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-1011

There's was nothing implemented to scroll back up the table when changing pages. It now does 😄 

Demo:

https://user-images.githubusercontent.com/63734941/201192641-08548631-dc24-4f44-b73d-91cf3dc379c8.mp4


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
