### PR TITLE
fix(theme, Mantine):  remove labelWrapper style for checkbox

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -135,12 +135,6 @@ export const plasmaTheme: MantineThemeOverride = {
             defaultProps: {
                 radius: 'sm',
             },
-            styles: {
-                labelWrapper: {
-                    display: 'flex',
-                    alignItems: 'center',
-                },
-            },
         },
         List: {
             styles: () => ({


### PR DESCRIPTION
### Proposed Changes

UITOOL-1020

Currently, the checkbox label and description are all on the same line but they should not so i'm removing the custom style.

![image](https://user-images.githubusercontent.com/63734941/201371298-6989ab03-f5fd-434f-89e8-c8bf0ea0bd7c.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
