### PR TITLE
refactor(website): rename PropsDoc to PropsTable

### DIFF
--- a/packages/website/src/building-blocs/PageLayout.tsx
+++ b/packages/website/src/building-blocs/PageLayout.tsx
@@ -6,7 +6,7 @@ import {useSelector} from 'react-redux';
 import {GuidelinesTab} from './GuidelinesTab';
 import {PageHeader, PageHeaderProps} from './PageHeader';
 import {PlasmaLoading} from './PlasmaLoading';
-import {PropsDoc, PropsTableProps} from './PropsTable';
+import {PropsTable, PropsTableProps} from './PropsTable';
 import {type SandboxProps} from './Sandbox';
 import {Tile, TileProps} from './Tile';
 
@@ -110,7 +110,7 @@ const Content: FunctionComponent<
         {withPropsTable && (
             <div className="plasma-page-layout__section">
                 <h4 className="h2 mb1">Props</h4>
-                <PropsDoc propsMetadata={propsMetadata} />
+                <PropsTable propsMetadata={propsMetadata} />
             </div>
         )}
         {examples && (

--- a/packages/website/src/building-blocs/PropsTable.tsx
+++ b/packages/website/src/building-blocs/PropsTable.tsx
@@ -5,13 +5,13 @@ export interface PropsTableProps {
     propsMetadata?: ComponentMetadata[];
 }
 
-export const PropsDoc: FunctionComponent<PropsTableProps> = ({propsMetadata = []}) => {
+export const PropsTable: FunctionComponent<PropsTableProps> = ({propsMetadata = []}) => {
     if (propsMetadata.length < 1) {
         return <p>This component has no props.</p>;
     }
 
     return (
-        <div className="props-doc">
+        <div className="props-table">
             <table className="full-content-x">
                 <thead className="body-m">
                     <tr>
@@ -40,7 +40,7 @@ export const PropsDoc: FunctionComponent<PropsTableProps> = ({propsMetadata = []
                                 <td className="py1">
                                     {deprecation !== null && <div>{deprecation}</div>}
                                     <div>{description}</div>
-                                    {params && (
+                                    {params?.length > 0 && (
                                         <ul className="mt1">
                                             {params.map(({parameterName, text}) => (
                                                 <li key={parameterName}>

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -6,7 +6,7 @@ import '../styles/main.scss';
 import '../styles/page-header.scss';
 import '../styles/page-layout.scss';
 import '../styles/plasmaSearchBar.scss';
-import '../styles/props-doc.scss';
+import '../styles/props-table.scss';
 import '../styles/sandbox.scss';
 import '../styles/spacing.scss';
 import '../styles/tile.scss';

--- a/packages/website/src/styles/props-table.scss
+++ b/packages/website/src/styles/props-table.scss
@@ -1,4 +1,4 @@
-.props-doc {
+.props-table {
     max-height: 500px;
     margin-left: -24px;
     overflow: auto;


### PR DESCRIPTION
### Proposed Changes

- Small renaming to remain consistent with the filename
- Removed unwanted empty `<ul>` when a prop has no params

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/35579930/201443983-fb9442ce-38c3-43da-9c2c-7ad28c66518e.png) | ![image](https://user-images.githubusercontent.com/35579930/201444015-2899cf45-b860-4721-aa7f-ff408771f114.png) |



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
