### PR TITLE
build(props-analyzer): avoid additional build on start

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "prepare": "husky install",
         "reconstruct": "npx rimraf node_modules packages/*/node_modules && npm run setup && echo done",
         "setup": "pnpm install",
-        "start": "pnpm build && pnpm --recursive --parallel start",
+        "start": "pnpm build --filter=!@coveord/plasma-website && pnpm --recursive --parallel start",
         "test": "turbo run test --concurrency=1"
     },
     "commitlint": {

--- a/packages/components-props-analyzer/package.json
+++ b/packages/components-props-analyzer/package.json
@@ -15,7 +15,7 @@
         "compile": "node ../../scripts/build",
         "gen:props": "ts-node --project ./bin/tsconfig.json ./bin/index.ts",
         "prettify": "prettier --write 'src/components/*.ts'",
-        "start": "nodemon --watch 'src/ComponentsList.ts' --exec 'pnpm build'"
+        "start": "nodemon --watch 'src/ComponentsList.ts' --exec 'pnpm build' --on-change-only"
     },
     "dependencies": {
         "@coveord/plasma-mantine": "workspace:*",


### PR DESCRIPTION
### Proposed Changes

I noticed we were building the website and the component-props-analyzer twice when running `pnpm start`

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
