### PR TITLE
feat(props-analyzer): add suffix option to avoid collisions

### DIFF
--- a/packages/components-props-analyzer/bin/index.ts
+++ b/packages/components-props-analyzer/bin/index.ts
@@ -16,15 +16,16 @@ const generateProps = async () => {
     const promises = componentsList.map(async (component) => {
         const operations: Array<Promise<void>> = [];
         const props = getPropsOfComponent(component, env);
+        const name = component.name + (component?.suffix ?? '');
         operations.push(
             outputFile(
-                `./src/components/${component.name}.ts`,
+                `./src/components/${name}.ts`,
                 `// Don't edit this file, it is automatically generated on each build
                 import {ComponentMetadata} from '../ComponentsList';
-                export const ${component.name}Metadata: ComponentMetadata[] = ${JSON.stringify(props)};`
+                export const ${name}Metadata: ComponentMetadata[] = ${JSON.stringify(props)};`
             )
         );
-        operations.push(appendFile('./src/components/index.ts', `export * from './${component.name}';\n`));
+        operations.push(appendFile('./src/components/index.ts', `export * from './${name}';\n`));
         return Promise.all(operations);
     });
 

--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -16,6 +16,11 @@ export interface Component {
      * @default 'auto'
      */
     propsType?: 'auto' | string;
+    /**
+     * Suffix to add to the exported name.
+     * Usefull to avoid name collisions
+     */
+    suffix?: string;
 }
 
 export interface ComponentMetadata {

--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -18,7 +18,7 @@ export interface Component {
     propsType?: 'auto' | string;
     /**
      * Suffix to add to the exported name.
-     * Usefull to avoid name collisions
+     * Useful to avoid name collisions
      */
     suffix?: string;
 }


### PR DESCRIPTION
### Proposed Changes

This will get usefull when a mantine component has the same name as a plasma-react component

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
