### PR TITLE
Mantine code editor demo page

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -285,6 +285,11 @@ const components: Component[] = [
         name: 'Collection',
         packageName: '@coveord/plasma-mantine',
     },
+    {
+        name: 'CodeEditor',
+        packageName: '@coveord/plasma-mantine',
+        suffix: 'Mantine',
+    },
 ];
 
 export default components;

--- a/packages/website/.eslintrc.js
+++ b/packages/website/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
         tsconfigRootDir: __dirname,
         sourceType: 'module',
     },
-    ignorePatterns: ['build', '.eslintrc.js'],
+    ignorePatterns: ['build', '.eslintrc.js', 'next.config.js'],
     overrides: [
         {
             files: ['src/examples/**/*.tsx'],

--- a/packages/website/build/demo-loader.js
+++ b/packages/website/build/demo-loader.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+module.exports = function (source) {
+    const name = path.basename(this.resourcePath).split('.')[0];
+    const content = `
+import Demo from '@demo';
+
+${source.replace('export default', `const ${name}Preview =`)}
+
+const snippet = \`${source.replace(/\\|`|\$/g, '\\$&')}\`;
+const ${name}Demo = () => (
+    <Demo snippet={snippet}>
+        <${name}Preview />
+    </Demo>
+);
+export default ${name}Demo;
+`;
+    return content;
+};

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -23,6 +23,10 @@ module.exports = withPlugins([withTM, withImages], {
             test: /\.example.tsx$/,
             loader: 'raw-loader',
         });
+        config.module.rules.push({
+            test: /\.demo.tsx$/,
+            use: [options.defaultLoaders.babel, path.resolve(__dirname, 'build/demo-loader.js')],
+        });
         config.experiments = {topLevelAwait: true};
         return config;
     },

--- a/packages/website/src/SideNavigation.tsx
+++ b/packages/website/src/SideNavigation.tsx
@@ -87,6 +87,7 @@ export const Navigation: FunctionComponent = () => {
             <CollapsibleSideSection title="Mantine">
                 <NavLink href="/mantine/Collection" label="Collection" />
                 <NavLink href="/mantine/Header" label="Page Header" />
+                <NavLink href="/mantine/CodeEditor" label="Code Editor" />
             </CollapsibleSideSection>
             <CollapsibleSideSection title="Layout">
                 <NavLink href="/layout/Banner" label="Banner" />

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -1,0 +1,66 @@
+import {ActionIcon, createStyles, ScrollArea, SimpleGrid, Stack, Tooltip, useClipboard} from '@coveord/plasma-mantine';
+import {CheckSize16Px, CopySize16Px} from '@coveord/plasma-react-icons';
+import {Prism} from '@mantine/prism';
+import vsDark from 'prism-react-renderer/themes/vsDark';
+import vsLight from 'prism-react-renderer/themes/vsLight';
+import {ReactNode} from 'react';
+
+export interface StaticDemoProps {
+    snippet?: string;
+    children?: ReactNode;
+}
+
+const useStyles = createStyles((theme) => ({
+    root: {
+        position: 'relative',
+    },
+    actions: {
+        position: 'absolute',
+        top: theme.spacing.xs,
+        right: theme.spacing.xs,
+        zIndex: 2,
+        'button:hover': {
+            backgroundColor: theme.colors.gray[8],
+        },
+    },
+}));
+
+const height = 500;
+
+const Demo = ({children, snippet}: StaticDemoProps) => {
+    const {classes} = useStyles();
+    const clipboard = useClipboard();
+    return (
+        <SimpleGrid cols={2} className={classes.root}>
+            <ScrollArea style={{height}}>{children}</ScrollArea>
+            <Prism
+                withLineNumbers
+                language="tsx"
+                colorScheme="dark"
+                getPrismTheme={(_theme, colorScheme) => (colorScheme === 'light' ? vsLight : vsDark)}
+                styles={{scrollArea: {height}}}
+                radius="md"
+                noCopy
+            >
+                {snippet}
+            </Prism>
+            <Stack className={classes.actions} spacing="xs">
+                <Tooltip label={clipboard.copied ? 'Copied' : 'Copy'} position="left">
+                    <ActionIcon radius="sm" onClick={() => clipboard.copy(snippet)}>
+                        {clipboard.copied ? <CheckSize16Px height={16} /> : <CopySize16Px height={16} />}
+                    </ActionIcon>
+                </Tooltip>
+                {/* 
+                    // TODO
+                    <Tooltip label="Open in CodeSanbox" position="left">
+                        <ActionIcon radius="sm">
+                            <PlaySize16Px height={16} />
+                        </ActionIcon>
+                    </Tooltip> 
+                */}
+            </Stack>
+        </SimpleGrid>
+    );
+};
+
+export default Demo;

--- a/packages/website/src/building-blocs/PageLayout.tsx
+++ b/packages/website/src/building-blocs/PageLayout.tsx
@@ -6,7 +6,7 @@ import {GuidelinesTab} from './GuidelinesTab';
 import {PageHeader, PageHeaderProps} from './PageHeader';
 import {PlasmaLoading} from './PlasmaLoading';
 import {PropsTable, PropsTableProps} from './PropsTable';
-import {type SandboxProps} from './Sandbox';
+import {SandboxProps} from './Sandbox';
 import {Tile, TileProps} from './Tile';
 
 const Sandbox = dynamic<SandboxProps>(
@@ -17,6 +17,7 @@ const Sandbox = dynamic<SandboxProps>(
 interface PlaygroundProps {
     title: string;
     code?: string;
+    Demo?: () => JSX.Element;
     layout?: 'horizontal' | 'vertical';
 }
 
@@ -72,10 +73,19 @@ export const PageLayout = ({
 const Content: FunctionComponent<
     Pick<
         PageLayoutProps,
-        'code' | 'examples' | 'id' | 'relatedComponents' | 'layout' | 'withPropsTable' | 'propsMetadata' | 'children'
+        | 'code'
+        | 'Demo'
+        | 'examples'
+        | 'id'
+        | 'relatedComponents'
+        | 'layout'
+        | 'withPropsTable'
+        | 'propsMetadata'
+        | 'children'
     >
 > = ({
     code,
+    Demo,
     examples,
     id,
     relatedComponents,
@@ -93,6 +103,12 @@ const Content: FunctionComponent<
             </div>
         )}
 
+        {Demo && (
+            <div className="plasma-page-layout__main-code plasma-page-layout__section">
+                <Demo />
+            </div>
+        )}
+
         {withPropsTable && (
             <div className="plasma-page-layout__section">
                 <h4 className="h2 mb1">Props</h4>
@@ -103,16 +119,22 @@ const Content: FunctionComponent<
             <div className="plasma-page-layout__section">
                 <h4 className="h2 mb5">Examples</h4>
                 {Object.entries(examples).map(
-                    ([exampleId, {code: exampleCode, title, layout: exampleLayout = 'horizontal'}]) => (
-                        <Sandbox
-                            key={id + exampleId}
-                            id={exampleId}
-                            title={title}
-                            horizontal={exampleLayout === 'horizontal'}
-                        >
-                            {exampleCode}
-                        </Sandbox>
-                    )
+                    ([
+                        exampleId,
+                        {code: exampleCode, Demo: ExampleDemo, title, layout: exampleLayout = 'horizontal'},
+                    ]) =>
+                        Demo ? (
+                            <ExampleDemo key={id + exampleId} />
+                        ) : (
+                            <Sandbox
+                                key={id + exampleId}
+                                id={exampleId}
+                                title={title}
+                                horizontal={exampleLayout === 'horizontal'}
+                            >
+                                {exampleCode}
+                            </Sandbox>
+                        )
                 )}
             </div>
         )}

--- a/packages/website/src/examples/code-editor/CodeEditor.demo.tsx
+++ b/packages/website/src/examples/code-editor/CodeEditor.demo.tsx
@@ -1,5 +1,4 @@
-import {useForm} from '@mantine/form';
-import {CodeEditor} from './CodeEditor';
+import {CodeEditor, useForm} from '@coveord/plasma-mantine';
 
 export default () => {
     const form = useForm({
@@ -19,6 +18,7 @@ export default () => {
                 return null;
             },
         },
+        validateInputOnBlur: true,
     });
 
     return (
@@ -26,6 +26,7 @@ export default () => {
             language="json"
             label="Configuration"
             description="This JSON configuration is very important"
+            monacoLoader="cdn"
             {...form.getInputProps('config')}
         />
     );

--- a/packages/website/src/pages/mantine/CodeEditor.tsx
+++ b/packages/website/src/pages/mantine/CodeEditor.tsx
@@ -1,0 +1,19 @@
+import {CodeEditorMantineMetadata} from '@coveord/plasma-components-props-analyzer';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
+import MainExample from '../../examples/code-editor/CodeEditor.demo.tsx';
+
+const CodeEditorPage = () => (
+    <PageLayout
+        id="CodeEditor"
+        section="Mantine"
+        title="Code Editor"
+        sourcePath="/packages/mantine/src/components/code-editor/CodeEditor.tsx"
+        description="A code editor is a text area that allows users to edit code. A coding syntax is built in."
+        thumbnail="codeEditor"
+        propsMetadata={CodeEditorMantineMetadata}
+        Demo={MainExample}
+    />
+);
+
+export default CodeEditorPage;

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -9,7 +9,8 @@
         "baseUrl": ".",
         "paths": {
             "@coveord/plasma-react/dist/*": ["../react/dist/*"],
-            "@examples/*": ["./src/examples/*"]
+            "@examples/*": ["./src/examples/*"],
+            "@demo": ["./src/building-blocs/Demo.tsx"]
         },
         "lib": ["ES2020", "dom"],
         "typeRoots": ["./types", "./node_modules/@types"],

--- a/packages/website/types/custom/index.d.ts
+++ b/packages/website/types/custom/index.d.ts
@@ -16,6 +16,11 @@ declare module '*.example.tsx' {
     export default content;
 }
 
+declare module '*.demo.tsx' {
+    const DemoComponent: () => JSX.Element;
+    export default DemoComponent;
+}
+
 declare module 'tsjs/prettier-config.js' {
     const content: any;
     export default content;


### PR DESCRIPTION
### Proposed Changes

Added a demo page for the CodeEditor from plasma-mantine package. It uses the new demo-loader which is a static demo for now, but will eventually have a "Open in CodeSandbox" feature.

![image](https://user-images.githubusercontent.com/35579930/201963735-1531105a-240f-44bb-ae2a-e70a3153891f.png)

Removing the live sandbox allows the page to load instantly compared to the other pages, and also fixes the conflict with the monaco instance.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
