### PR TITLE
Add missing JSDocs for mantine components

### DIFF
--- a/packages/components-props-analyzer/nodemon.json
+++ b/packages/components-props-analyzer/nodemon.json
@@ -1,0 +1,6 @@
+{
+    "watch": ["./src/ComponentsList.ts"],
+    "exec": "pnpm build",
+    "ext": ".ts",
+    "runOnChangeOnly": true
+}

--- a/packages/components-props-analyzer/package.json
+++ b/packages/components-props-analyzer/package.json
@@ -15,7 +15,7 @@
         "compile": "node ../../scripts/build",
         "gen:props": "ts-node --project ./bin/tsconfig.json ./bin/index.ts",
         "prettify": "prettier --write 'src/components/*.ts'",
-        "start": "nodemon --watch 'src/ComponentsList.ts' --exec 'pnpm build' --on-change-only"
+        "start": "nodemon"
     },
     "dependencies": {
         "@coveord/plasma-mantine": "workspace:*",

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -19,19 +19,85 @@ import {CollectionItem} from './CollectionItem';
 import useStyles from './Colllection.styles';
 
 interface CollectionProps<T> extends DefaultProps<Selectors<typeof useStyles>> {
+    /**
+     * The default value each new item should have
+     */
     newItem: T;
+    /**
+     * A render function called for each item passed in the `value` prop.
+     *
+     * @param item The current item's value
+     * @param index The current item's index
+     */
     children: (item: T, index: number) => ReactNode;
-    defaultValue?: T[];
+    /**
+     * The list of items to display inside the collection
+     *
+     * @default []
+     */
     value?: T[];
+    /**
+     * The initial items of the collection (for uncontrolled usage only)
+     */
+    defaultValue?: T[];
+    /**
+     * Unused, has no effect
+     */
     onFocus?: () => void;
+    /**
+     * Function called whenever the value needs to be updated
+     *
+     * @param value The whole list of items after the change
+     */
     onChange?: (value: T[]) => void;
+    /**
+     * Function called after an item is removed from the collection using the remove button
+     *
+     * @param itemIndex The index of the item that was removed
+     */
     onRemoveItem?: (itemIndex: number) => void;
+    /**
+     * Whether the collection should have drag and drop behavior enabled
+     *
+     * @default false
+     */
     draggable?: boolean;
+    /**
+     * Whether the collection is disabled, or in other words in read only mode
+     *
+     * @default false
+     */
     disabled?: boolean;
+    /**
+     * Function that determines if the add item button should be enabled given the current items of the collection.
+     * The button is always enabled if this props remains undefined
+     *
+     * @param values The current items of the collection
+     */
     allowAdd?: (values: T[]) => boolean;
+    /**
+     * The label of the add item button
+     *
+     * @default "Add item"
+     */
     addLabel?: string;
+    /**
+     * The tooltip text displayed when hovering over the disabled add item button
+     *
+     * @default 'There is already an empty item'
+     */
     addDisabledTooltip?: string;
+    /**
+     * The spacing between the colleciton items
+     *
+     * @default 'xs'
+     */
     spacing?: MantineNumberSize;
+    /**
+     * Whether the collection is required. When required is true, the collection will hide the remove button if there is only one item
+     *
+     * @default false
+     */
     required?: boolean;
 }
 

--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -1,16 +1,37 @@
 import {QuestionSize24Px} from '@coveord/plasma-react-icons';
 import {Anchor, Breadcrumbs, DefaultProps, Divider, Group, Stack, Text, Title, Tooltip} from '@mantine/core';
-import {FunctionComponent, PropsWithChildren, ReactNode} from 'react';
+import {FunctionComponent, ReactNode} from 'react';
 
 interface HeaderProps extends DefaultProps {
+    /**
+     * The description text displayed inside the header underneath the title
+     */
     description?: ReactNode;
+    /**
+     * Action buttons that can be displayed on the right of the header
+     */
     actions?: ReactNode;
+    /**
+     * Whether the header should have a border on the bottom
+     */
     borderBottom?: boolean;
+    /**
+     * A href pointing to documentation related to the current panel.
+     * When provided, an info icon is rendered next to the title as link to this documentation
+     */
     docLink?: string;
+    /**
+     * The tooltip text shown when hovering over the doc link icon
+     */
     docLinkTooltipLabel?: string;
+    /**
+     * The title of the header.
+     * If more than one children are provided, each of them act as parts of a breadcrumb
+     */
+    children: ReactNode;
 }
 
-export const Header: FunctionComponent<PropsWithChildren<HeaderProps>> = ({
+export const Header: FunctionComponent<HeaderProps> = ({
     description,
     actions,
     borderBottom,

--- a/packages/website/src/building-blocs/PropsTable.tsx
+++ b/packages/website/src/building-blocs/PropsTable.tsx
@@ -1,4 +1,5 @@
 import {ComponentMetadata} from '@coveord/plasma-components-props-analyzer';
+import {Code, Text} from '@coveord/plasma-mantine';
 import {FunctionComponent} from 'react';
 
 export interface PropsTableProps {
@@ -27,30 +28,32 @@ export const PropsTable: FunctionComponent<PropsTableProps> = ({propsMetadata = 
                         .map(({name, type, description, optional, deprecation, defaultValue, params}) => (
                             <tr key={name}>
                                 <td>
-                                    <span className="code">{name}</span>
+                                    <Code>{name}</Code>
                                     {optional ? null : <span className="body-s-book-italic-subdued ml2">required</span>}
                                     {deprecation !== null ? (
                                         <span className="body-s-book-italic-subdued ml2">deprecated</span>
                                     ) : null}
                                 </td>
                                 <td>
-                                    <span className="code">{type}</span>
+                                    <Code>{type}</Code>
                                 </td>
-                                <td>{defaultValue}</td>
+                                <td>{defaultValue ? <Code>{defaultValue}</Code> : null}</td>
                                 <td className="py1">
-                                    {deprecation !== null && <div>{deprecation}</div>}
-                                    <div>{description}</div>
-                                    {params?.length > 0 && (
-                                        <ul className="mt1">
-                                            {params.map(({parameterName, text}) => (
-                                                <li key={parameterName}>
-                                                    <span className="code">{parameterName}</span>
-                                                    <span className="mx1">&ndash;</span>
-                                                    {text}
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    )}
+                                    <Text size="sm">
+                                        {deprecation !== null && <div>{deprecation}</div>}
+                                        {description}
+                                        {params?.length > 0 && (
+                                            <ul>
+                                                {params.map(({parameterName, text}) => (
+                                                    <li key={parameterName}>
+                                                        <span className="code">{parameterName}</span>
+                                                        <span className="mx1">&ndash;</span>
+                                                        {text}
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                    </Text>
                                 </td>
                             </tr>
                         ))}


### PR DESCRIPTION
### Proposed Changes

Improved the props table styles and added missing jsdocs for header and collection components.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
