### PR TITLE
Add semantic color aliases in the theme

### DIFF
--- a/packages/mantine/src/theme/PlasmaColors.ts
+++ b/packages/mantine/src/theme/PlasmaColors.ts
@@ -4,6 +4,23 @@ import {Tuple} from '@mantine/core';
 const toMantineColor = (plasmaColor: Record<string, string>): Tuple<string, 10> =>
     Object.values(plasmaColor) as Tuple<string, 10>;
 
+const navy = toMantineColor(color.primary.navy);
+const red = toMantineColor(color.accent.red);
+const yellow = toMantineColor(color.accent.yellow);
+const teal = toMantineColor(color.accent.teal);
+const lime = [
+    color.secondary.lime[0],
+    color.secondary.lime[0],
+    color.secondary.lime[0],
+    color.secondary.lime[0],
+    color.secondary.lime[6],
+    color.secondary.lime[6],
+    color.secondary.lime[6],
+    color.secondary.lime[9],
+    color.secondary.lime[9],
+    color.secondary.lime[9],
+] as Tuple<string, 10>;
+
 export const PlasmaColors = {
     // Primary
     gray: toMantineColor(color.primary.gray),
@@ -19,26 +36,20 @@ export const PlasmaColors = {
         color.primary.action[8],
         color.primary.action[9],
     ] as Tuple<string, 10>,
-    navy: toMantineColor(color.primary.navy),
+    navy,
+    info: navy,
     // Accent
     blue: toMantineColor(color.accent.blue),
-    red: toMantineColor(color.accent.red),
-    teal: toMantineColor(color.accent.teal),
-    yellow: toMantineColor(color.accent.yellow),
+    red,
+    critical: red,
+    teal,
+    new: teal,
+    yellow,
+    warning: yellow,
     // Secondary
     green: toMantineColor(color.secondary.green),
     indigo: toMantineColor(color.secondary.indigo),
-    lime: [
-        color.secondary.lime[0],
-        color.secondary.lime[0],
-        color.secondary.lime[0],
-        color.secondary.lime[0],
-        color.secondary.lime[6],
-        color.secondary.lime[6],
-        color.secondary.lime[6],
-        color.secondary.lime[9],
-        color.secondary.lime[9],
-        color.secondary.lime[9],
-    ] as Tuple<string, 10>,
+    lime,
+    success: lime,
     purple: toMantineColor(color.secondary.purple),
 };

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -157,5 +157,14 @@ export const plasmaTheme: MantineThemeOverride = {
                 withArrow: true,
             },
         },
+        Badge: {
+            styles: {
+                root: {
+                    textTransform: 'none',
+                    padding: '4px 8px',
+                    fontWeight: 500,
+                },
+            },
+        },
     },
 };


### PR DESCRIPTION
### Proposed Changes

- Add aliases (or synonyms) for some colors that are more semantic (the name describes a purpose instead of the visual look itself)
- Also corrected the default look of the badge in the theme

| before | after |
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/35579930/203151919-2e5befc1-0587-440a-90dc-a5fc34fe8168.png) | ![image](https://user-images.githubusercontent.com/35579930/203152064-627921a7-07fe-4b83-9a9f-b494ab422fea.png) |

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
