### PR TITLE
refactor(website): use path aliases for all examples imports

### DIFF
--- a/packages/website/src/pages/advanced/InfoToken.tsx
+++ b/packages/website/src/pages/advanced/InfoToken.tsx
@@ -1,13 +1,13 @@
 import {InfoTokenMetadata} from '@coveord/plasma-components-props-analyzer';
+import criticalExample from '@examples/InfoToken/critical.example.tsx';
+import infoExample from '@examples/InfoToken/info.example.tsx';
 import code from '@examples/InfoToken/main.example.tsx';
+import questionExample from '@examples/InfoToken/question.example.tsx';
+import successExample from '@examples/InfoToken/success.example.tsx';
+import tipExample from '@examples/InfoToken/tip.example.tsx';
+import warningExample from '@examples/InfoToken/warning.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import criticalExample from '../../examples/InfoToken/critical.example.tsx';
-import infoExample from '../../examples/InfoToken/info.example.tsx';
-import questionExample from '../../examples/InfoToken/question.example.tsx';
-import successExample from '../../examples/InfoToken/success.example.tsx';
-import tipExample from '../../examples/InfoToken/tip.example.tsx';
-import warningExample from '../../examples/InfoToken/warning.example.tsx';
 
 export default () => (
     <PageLayout

--- a/packages/website/src/pages/advanced/ListBox.tsx
+++ b/packages/website/src/pages/advanced/ListBox.tsx
@@ -4,7 +4,7 @@ import code from '@examples/ListBox/main.example.tsx';
 import withFooterExample from '@examples/ListBox/withFooter.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import loadingExample from '../../examples/ListBox/loading.example.tsx';
+import loadingExample from '@examples/ListBox/loading.example.tsx';
 
 export default () => (
     <PageLayout

--- a/packages/website/src/pages/advanced/ListBox.tsx
+++ b/packages/website/src/pages/advanced/ListBox.tsx
@@ -1,10 +1,10 @@
 import {ListBoxMetadata} from '@coveord/plasma-components-props-analyzer';
 import emptyExample from '@examples/ListBox/empty.example.tsx';
+import loadingExample from '@examples/ListBox/loading.example.tsx';
 import code from '@examples/ListBox/main.example.tsx';
 import withFooterExample from '@examples/ListBox/withFooter.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import loadingExample from '@examples/ListBox/loading.example.tsx';
 
 export default () => (
     <PageLayout

--- a/packages/website/src/pages/feedback/Badge.tsx
+++ b/packages/website/src/pages/feedback/Badge.tsx
@@ -1,9 +1,9 @@
 import {BadgeMetadata} from '@coveord/plasma-components-props-analyzer';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import BadgeExample from '../../examples/Badge/Badge.example.tsx';
-import BadgeSmallExample from '../../examples/Badge/BadgeSmall.example.tsx';
-import BadgeWithIconsExample from '../../examples/Badge/BadgeWithIcons.example.tsx';
+import BadgeExample from '@examples/Badge/Badge.example.tsx';
+import BadgeSmallExample from '@examples/Badge/BadgeSmall.example.tsx';
+import BadgeWithIconsExample from '@examples/Badge/BadgeWithIcons.example.tsx';
 
 export const BadgeExamples = () => (
     <PageLayout

--- a/packages/website/src/pages/feedback/Badge.tsx
+++ b/packages/website/src/pages/feedback/Badge.tsx
@@ -1,9 +1,9 @@
 import {BadgeMetadata} from '@coveord/plasma-components-props-analyzer';
-
-import {PageLayout} from '../../building-blocs/PageLayout';
 import BadgeExample from '@examples/Badge/Badge.example.tsx';
 import BadgeSmallExample from '@examples/Badge/BadgeSmall.example.tsx';
 import BadgeWithIconsExample from '@examples/Badge/BadgeWithIcons.example.tsx';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
 
 export const BadgeExamples = () => (
     <PageLayout

--- a/packages/website/src/pages/mantine/CodeEditor.tsx
+++ b/packages/website/src/pages/mantine/CodeEditor.tsx
@@ -1,7 +1,7 @@
 import {CodeEditorMantineMetadata} from '@coveord/plasma-components-props-analyzer';
+import MainExample from '@examples/code-editor/CodeEditor.demo.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import MainExample from '@examples/code-editor/CodeEditor.demo.tsx';
 
 const CodeEditorPage = () => (
     <PageLayout

--- a/packages/website/src/pages/mantine/CodeEditor.tsx
+++ b/packages/website/src/pages/mantine/CodeEditor.tsx
@@ -1,7 +1,7 @@
 import {CodeEditorMantineMetadata} from '@coveord/plasma-components-props-analyzer';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import MainExample from '../../examples/code-editor/CodeEditor.demo.tsx';
+import MainExample from '@examples/code-editor/CodeEditor.demo.tsx';
 
 const CodeEditorPage = () => (
     <PageLayout

--- a/packages/website/src/pages/mantine/Collection.tsx
+++ b/packages/website/src/pages/mantine/Collection.tsx
@@ -1,7 +1,7 @@
 import {CollectionMetadata} from '@coveord/plasma-components-props-analyzer';
+import mainExample from '@examples/collection/Collection.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import mainExample from '@examples/collection/Collection.example.tsx';
 
 export default () => (
     <PageLayout

--- a/packages/website/src/pages/mantine/Collection.tsx
+++ b/packages/website/src/pages/mantine/Collection.tsx
@@ -1,7 +1,7 @@
 import {CollectionMetadata} from '@coveord/plasma-components-props-analyzer';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import mainExample from '../../examples/collection/Collection.example.tsx';
+import mainExample from '@examples/collection/Collection.example.tsx';
 
 export default () => (
     <PageLayout

--- a/packages/website/src/pages/mantine/Header.tsx
+++ b/packages/website/src/pages/mantine/Header.tsx
@@ -1,7 +1,7 @@
 import {HeaderMantineMetadata} from '@coveord/plasma-components-props-analyzer';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import mainExample from '../../examples/Header/Header.mantine.example.tsx';
+import mainExample from '@examples/Header/Header.mantine.example.tsx';
 
 export default () => (
     <PageLayout

--- a/packages/website/src/pages/mantine/Header.tsx
+++ b/packages/website/src/pages/mantine/Header.tsx
@@ -1,7 +1,7 @@
 import {HeaderMantineMetadata} from '@coveord/plasma-components-props-analyzer';
+import mainExample from '@examples/Header/Header.mantine.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import mainExample from '@examples/Header/Header.mantine.example.tsx';
 
 export default () => (
     <PageLayout

--- a/packages/website/src/pages/navigation/Breadcrumbs.tsx
+++ b/packages/website/src/pages/navigation/Breadcrumbs.tsx
@@ -1,8 +1,8 @@
 import {BreadcrumbHeaderMetadata} from '@coveord/plasma-components-props-analyzer';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import complex from '../../examples/Breadcrumbs/complex.example.tsx';
-import code from '../../examples/Breadcrumbs/main.example.tsx';
+import complex from '@examples/Breadcrumbs/complex.example.tsx';
+import code from '@examples/Breadcrumbs/main.example.tsx';
 
 const BreadcrumbsExamples = () => (
     <PageLayout

--- a/packages/website/src/pages/navigation/Breadcrumbs.tsx
+++ b/packages/website/src/pages/navigation/Breadcrumbs.tsx
@@ -1,8 +1,8 @@
 import {BreadcrumbHeaderMetadata} from '@coveord/plasma-components-props-analyzer';
-
-import {PageLayout} from '../../building-blocs/PageLayout';
 import complex from '@examples/Breadcrumbs/complex.example.tsx';
 import code from '@examples/Breadcrumbs/main.example.tsx';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
 
 const BreadcrumbsExamples = () => (
     <PageLayout

--- a/packages/website/src/pages/navigation/SideNavigation.tsx
+++ b/packages/website/src/pages/navigation/SideNavigation.tsx
@@ -1,9 +1,9 @@
 import {SideNavigationMetadata} from '@coveord/plasma-components-props-analyzer';
-
-import {PageLayout} from '../../building-blocs/PageLayout';
 import collapsible from '@examples/SideNavigation/collapsible.example.tsx';
 import loading from '@examples/SideNavigation/loading.example.tsx';
 import code from '@examples/SideNavigation/main.example.tsx';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
 
 export const SideNavigationExamples = () => (
     <PageLayout

--- a/packages/website/src/pages/navigation/SideNavigation.tsx
+++ b/packages/website/src/pages/navigation/SideNavigation.tsx
@@ -1,9 +1,9 @@
 import {SideNavigationMetadata} from '@coveord/plasma-components-props-analyzer';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
-import collapsible from '../../examples/SideNavigation/collapsible.example.tsx';
-import loading from '../../examples/SideNavigation/loading.example.tsx';
-import code from '../../examples/SideNavigation/main.example.tsx';
+import collapsible from '@examples/SideNavigation/collapsible.example.tsx';
+import loading from '@examples/SideNavigation/loading.example.tsx';
+import code from '@examples/SideNavigation/main.example.tsx';
 
 export const SideNavigationExamples = () => (
     <PageLayout


### PR DESCRIPTION
### Proposed Changes

Removing relative imports of example files by using the existing path alias. Doing so will facilitate what comes next: moving pages around.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
