### PR TITLE
fix(plasma-mantine): fix ModalWizard breaks when mantine version > 5.6.2

### DIFF
--- a/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
+++ b/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
@@ -143,7 +143,7 @@ export const ModalWizard: ModalWizardType = ({
         >
             {currentStep.props.showProgressBar && <Progress color="teal" size="lg" value={getProgressMemo} />}
             {currentStep}
-            <StickyFooter borderTop py={null} px={null} pt="md">
+            <StickyFooter py={0} px={0} pt="sm" borderTop>
                 <Button
                     name={isFirstStep ? cancelButtonLabel : previousButtonLabel}
                     disabled={false}


### PR DESCRIPTION
### Proposed Changes

fix ModalWizard breaks when mantine version > 5.6.2

### Potential Breaking Changes

No breaking changes introduced

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
