### PR TITLE
Improve on demand sandbox & cleanup naming

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -117,6 +117,7 @@ const components: Component[] = [
     {
         name: 'CodeEditor',
         packageName: '@coveord/plasma-react',
+        suffix: 'Legacy',
     },
     {
         name: 'ColorPicker',
@@ -279,7 +280,6 @@ const components: Component[] = [
     {
         name: 'Header',
         packageName: '@coveord/plasma-mantine',
-        suffix: 'Mantine',
     },
     {
         name: 'Collection',
@@ -288,12 +288,10 @@ const components: Component[] = [
     {
         name: 'CodeEditor',
         packageName: '@coveord/plasma-mantine',
-        suffix: 'Mantine',
     },
     {
         name: 'Table',
         packageName: '@coveord/plasma-mantine',
-        suffix: 'Mantine',
     },
 ];
 

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -11,6 +11,7 @@ import {
     InputWrapperBaseProps,
     Loader,
     Selectors,
+    Space,
     Stack,
     Tooltip,
     useComponentDefaultProps,
@@ -141,7 +142,9 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         <Input.Error mt="xs" {...errorProps}>
             {error}
         </Input.Error>
-    ) : null;
+    ) : (
+        <Space h="xs" />
+    );
 
     const _header =
         _label || _description ? (

--- a/packages/website/build/demo-loader.js
+++ b/packages/website/build/demo-loader.js
@@ -1,15 +1,19 @@
 const path = require('path');
 
+function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
 module.exports = function (source) {
-    const name = path.basename(this.resourcePath).split('.')[0];
+    const name = capitalizeFirstLetter(path.basename(this.resourcePath).split('.')[0]);
     const content = `
 import Demo from '@demo';
 
 ${source.replace('export default', `const ${name}Preview =`)}
 
 const snippet = \`${source.replace(/\\|`|\$/g, '\\$&')}\`;
-const ${name}Demo = () => (
-    <Demo snippet={snippet}>
+const ${name}Demo = (props: DemoComponentProps) => (
+    <Demo snippet={snippet} {...props}>
         <${name}Preview />
     </Demo>
 );

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -1,4 +1,15 @@
-import {ActionIcon, createStyles, ScrollArea, SimpleGrid, Stack, Tooltip, useClipboard} from '@coveord/plasma-mantine';
+import {
+    ActionIcon,
+    Box,
+    Center,
+    createStyles,
+    Group,
+    ScrollArea,
+    Stack,
+    Title,
+    Tooltip,
+    useClipboard,
+} from '@coveord/plasma-mantine';
 import {CheckSize16Px, CopySize16Px, PlaySize16Px} from '@coveord/plasma-react-icons';
 import {Prism} from '@mantine/prism';
 import vsDark from 'prism-react-renderer/themes/vsDark';
@@ -7,14 +18,20 @@ import {ReactNode} from 'react';
 
 import getCodeSandboxLink from './getCodeSandboxLink';
 
-export interface StaticDemoProps {
+const MAX_HEIGHT = 500;
+const MIN_HEIGHT = 100;
+
+interface DemoProps extends DemoComponentProps {
     snippet?: string;
     children?: ReactNode;
 }
 
-const useStyles = createStyles((theme) => ({
-    root: {
-        position: 'relative',
+const useStyles = createStyles((theme, {center, grow}: DemoComponentProps) => ({
+    root: {},
+    sandbox: {
+        border: `1px solid ${theme.colors.gray[3]}`,
+        borderRadius: theme.radius.md,
+        overflow: 'hidden',
     },
     actions: {
         position: 'absolute',
@@ -25,42 +42,67 @@ const useStyles = createStyles((theme) => ({
             backgroundColor: theme.colors.gray[8],
         },
     },
+    preview: {
+        backgroundColor: 'white',
+        minHeight: 100,
+    },
+    previewWrapper: {
+        padding: center ? undefined : theme.spacing.md,
+        height: grow ? MAX_HEIGHT : '100%',
+    },
+    code: {
+        minHeight: 100,
+        position: 'relative',
+        backgroundColor: '#1E1E1E',
+    },
 }));
 
-const height = 500;
-
-const Demo = ({children, snippet}: StaticDemoProps) => {
-    const {classes} = useStyles();
+const Demo = ({children, snippet, center = false, grow = false, title}: DemoProps) => {
+    const {classes} = useStyles({center, grow});
     const clipboard = useClipboard();
     const sandboxLink = getCodeSandboxLink(snippet);
     return (
-        <SimpleGrid cols={2} className={classes.root}>
-            <ScrollArea style={{height}}>{children}</ScrollArea>
-            <Prism
-                withLineNumbers
-                language="tsx"
-                colorScheme="dark"
-                getPrismTheme={(_theme, colorScheme) => (colorScheme === 'light' ? vsLight : vsDark)}
-                styles={{scrollArea: {height}}}
-                radius="md"
-                noCopy
-            >
-                {snippet}
-            </Prism>
-            <Stack className={classes.actions} spacing="xs">
-                <Tooltip label={clipboard.copied ? 'Copied' : 'Copy'} position="left">
-                    <ActionIcon radius="sm" onClick={() => clipboard.copy(snippet)}>
-                        {clipboard.copied ? <CheckSize16Px height={16} /> : <CopySize16Px height={16} />}
-                    </ActionIcon>
-                </Tooltip>
+        <div className={classes.root}>
+            {title ? (
+                <Title order={6} mb="xs">
+                    {title}
+                </Title>
+            ) : null}
+            <Group grow className={classes.sandbox} align="stretch" spacing={0}>
+                <Box component={center ? Center : 'div'} className={classes.preview}>
+                    <ScrollArea.Autosize maxHeight={MAX_HEIGHT}>
+                        <div className={classes.previewWrapper}>{children}</div>
+                    </ScrollArea.Autosize>
+                </Box>
+                <div className={classes.code}>
+                    <Prism
+                        withLineNumbers
+                        language="tsx"
+                        colorScheme="dark"
+                        getPrismTheme={(_theme, colorScheme) => (colorScheme === 'light' ? vsLight : vsDark)}
+                        radius={0}
+                        noCopy
+                        scrollAreaComponent={ScrollArea.Autosize}
+                        styles={{scrollArea: {maxHeight: MAX_HEIGHT, minHeight: MIN_HEIGHT}}}
+                    >
+                        {snippet}
+                    </Prism>
+                    <Stack className={classes.actions} spacing="xs">
+                        <Tooltip label={clipboard.copied ? 'Copied' : 'Copy'} position="left">
+                            <ActionIcon radius="sm" onClick={() => clipboard.copy(snippet)}>
+                                {clipboard.copied ? <CheckSize16Px height={16} /> : <CopySize16Px height={16} />}
+                            </ActionIcon>
+                        </Tooltip>
 
-                <Tooltip label="Open in CodeSanbox" position="left">
-                    <ActionIcon<'a'> radius="sm" href={sandboxLink} target="_blank" component="a">
-                        <PlaySize16Px height={16} />
-                    </ActionIcon>
-                </Tooltip>
-            </Stack>
-        </SimpleGrid>
+                        <Tooltip label="Open in CodeSanbox" position="left">
+                            <ActionIcon<'a'> radius="sm" href={sandboxLink} target="_blank" component="a">
+                                <PlaySize16Px height={16} />
+                            </ActionIcon>
+                        </Tooltip>
+                    </Stack>
+                </div>
+            </Group>
+        </div>
     );
 };
 

--- a/packages/website/src/building-blocs/PageHeader.tsx
+++ b/packages/website/src/building-blocs/PageHeader.tsx
@@ -7,7 +7,7 @@ export interface PageHeaderProps {
     title: string;
     thumbnail?: TileProps['thumbnail'];
     description?: ReactNode;
-    section: 'Foundations' | 'Layout' | 'Form' | 'Navigation' | 'Feedback' | 'Advanced' | 'Mantine';
+    section: 'Foundations' | 'Layout' | 'Form' | 'Navigation' | 'Feedback' | 'Advanced';
     /**
      * Path to the component's source file from /packages/react/src/components
      *

--- a/packages/website/src/building-blocs/PageLayout.tsx
+++ b/packages/website/src/building-blocs/PageLayout.tsx
@@ -1,6 +1,6 @@
 import {Tabs} from '@coveord/plasma-mantine';
 import dynamic from 'next/dynamic';
-import {FunctionComponent, ReactNode} from 'react';
+import {Fragment, FunctionComponent, ReactNode} from 'react';
 
 import {GuidelinesTab} from './GuidelinesTab';
 import {PageHeader, PageHeaderProps} from './PageHeader';
@@ -17,7 +17,7 @@ const Sandbox = dynamic<SandboxProps>(
 interface PlaygroundProps {
     title: string;
     code?: string;
-    Demo?: () => JSX.Element;
+    demo?: ReactNode;
     layout?: 'horizontal' | 'vertical';
 }
 
@@ -74,7 +74,7 @@ const Content: FunctionComponent<
     Pick<
         PageLayoutProps,
         | 'code'
-        | 'Demo'
+        | 'demo'
         | 'examples'
         | 'id'
         | 'relatedComponents'
@@ -85,7 +85,7 @@ const Content: FunctionComponent<
     >
 > = ({
     code,
-    Demo,
+    demo: mainDemo,
     examples,
     id,
     relatedComponents,
@@ -103,11 +103,7 @@ const Content: FunctionComponent<
             </div>
         )}
 
-        {Demo && (
-            <div className="plasma-page-layout__main-code plasma-page-layout__section">
-                <Demo />
-            </div>
-        )}
+        {mainDemo && <div className="plasma-page-layout__main-code plasma-page-layout__section">{mainDemo}</div>}
 
         {withPropsTable && (
             <div className="plasma-page-layout__section">
@@ -119,12 +115,9 @@ const Content: FunctionComponent<
             <div className="plasma-page-layout__section">
                 <h4 className="h2 mb5">Examples</h4>
                 {Object.entries(examples).map(
-                    ([
-                        exampleId,
-                        {code: exampleCode, Demo: ExampleDemo, title, layout: exampleLayout = 'horizontal'},
-                    ]) =>
-                        Demo ? (
-                            <ExampleDemo key={id + exampleId} />
+                    ([exampleId, {code: exampleCode, demo, title, layout: exampleLayout = 'horizontal'}]) =>
+                        demo ? (
+                            <Fragment key={id + exampleId}>{demo}</Fragment>
                         ) : (
                             <Sandbox
                                 key={id + exampleId}

--- a/packages/website/src/building-blocs/getCodeSandboxLink.tsx
+++ b/packages/website/src/building-blocs/getCodeSandboxLink.tsx
@@ -16,6 +16,7 @@ const packageJson = {
         '@mantine/modals': packageConfig.dependencies['@mantine/modals'],
         '@mantine/carousel': packageConfig.dependencies['@mantine/carousel'],
         'embla-carousel-react': packageConfig.dependencies['embla-carousel-react'],
+        'lorem-ipsum': packageConfig.dependencies['lorem-ipsum'],
     },
     devDependencies: {
         tslib: packageConfig.devDependencies.tslib,

--- a/packages/website/src/pages/form/CodeEditor.tsx
+++ b/packages/website/src/pages/form/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import {CodeEditorMantineMetadata} from '@coveord/plasma-components-props-analyzer';
+import {CodeEditorMetadata} from '@coveord/plasma-components-props-analyzer';
 import MainExample from '@examples/form/code-editor/CodeEditor.demo.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -6,13 +6,13 @@ import {PageLayout} from '../../building-blocs/PageLayout';
 const CodeEditorPage = () => (
     <PageLayout
         id="CodeEditor"
-        section="Mantine"
+        section="Form"
         title="Code Editor"
         sourcePath="/packages/mantine/src/components/code-editor/CodeEditor.tsx"
         description="A code editor is a text area that allows users to edit code. A coding syntax is built in."
         thumbnail="codeEditor"
-        propsMetadata={CodeEditorMantineMetadata}
-        Demo={MainExample}
+        propsMetadata={CodeEditorMetadata}
+        demo={<MainExample grow />}
     />
 );
 

--- a/packages/website/src/pages/form/Collection.tsx
+++ b/packages/website/src/pages/form/Collection.tsx
@@ -5,7 +5,7 @@ import {PageLayout} from '../../building-blocs/PageLayout';
 
 export default () => (
     <PageLayout
-        section="Mantine"
+        section="Form"
         title="Collection"
         sourcePath="/packages/mantine/src/components/collection/Collection.tsx"
         description="A Collection allows users to provide multiple inputs for the same parameter. Each input appears on a different line."

--- a/packages/website/src/pages/layout/Header.tsx
+++ b/packages/website/src/pages/layout/Header.tsx
@@ -1,17 +1,17 @@
-import {HeaderMantineMetadata} from '@coveord/plasma-components-props-analyzer';
+import {HeaderMetadata} from '@coveord/plasma-components-props-analyzer';
 import mainExample from '@examples/layout/Header/Header.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 export default () => (
     <PageLayout
-        section="Mantine"
+        section="Layout"
         title="Header"
         sourcePath="/packages/mantine/src/components/header/Header.tsx"
         description="A page header informs a user of the section of the product they are currently in. It includes a breadcrumb and optional call to actions."
         thumbnail="header"
         id="Header"
-        propsMetadata={HeaderMantineMetadata}
+        propsMetadata={HeaderMetadata}
         code={mainExample}
     />
 );

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -1,16 +1,16 @@
-import {TableMantineMetadata} from '@coveord/plasma-components-props-analyzer';
+import {TableMetadata} from '@coveord/plasma-components-props-analyzer';
 import mainExample from '@examples/layout/Table/main.example.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 export default () => (
     <PageLayout
-        section="Mantine"
+        section="Layout"
         title="Table"
         sourcePath="/packages/mantine/src/components/table/Table.tsx"
         description="A table displays large quantities of items or data in a list format. Filtering features, date picker, collapsible rows and actions may be added."
         id="Table"
-        propsMetadata={TableMantineMetadata}
+        propsMetadata={TableMetadata}
         code={mainExample}
     />
 );

--- a/packages/website/src/pages/legacy/form/CodeEditor.tsx
+++ b/packages/website/src/pages/legacy/form/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import {CodeEditorMetadata} from '@coveord/plasma-components-props-analyzer';
+import {CodeEditorLegacyMetadata} from '@coveord/plasma-components-props-analyzer';
 import CodeEditorExample from '@examples/legacy/form/CodeEditor/CodeEditor.example.tsx';
 import CodeEditorReadonlyExample from '@examples/legacy/form/CodeEditor/CodeEditorReadonly.example.tsx';
 
@@ -13,7 +13,7 @@ export default () => (
         thumbnail="codeEditor"
         code={CodeEditorExample}
         componentSourcePath="/editor/CodeEditor.tsx"
-        propsMetadata={CodeEditorMetadata}
+        propsMetadata={CodeEditorLegacyMetadata}
         examples={{
             readOnly: {code: CodeEditorReadonlyExample, title: 'Read only'},
         }}

--- a/packages/website/types/custom/index.d.ts
+++ b/packages/website/types/custom/index.d.ts
@@ -16,8 +16,14 @@ declare module '*.example.tsx' {
     export default content;
 }
 
+interface DemoComponentProps {
+    center?: boolean;
+    grow?: boolean;
+    title?: string;
+}
+
 declare module '*.demo.tsx' {
-    const DemoComponent: () => JSX.Element;
+    const DemoComponent: (props: DemoComponentProps) => JSX.Element;
     export default DemoComponent;
 }
 


### PR DESCRIPTION
### Proposed Changes

Improved the look n feel of the new on-demand sandbox. Added some feature that will be necessary when converting all the pages to this new sandbox

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/35579930/204399646-77a7fa56-c79a-4ecc-ba74-7855f85d2df6.png) | ![image](https://user-images.githubusercontent.com/35579930/204399617-e266ffa0-e963-401f-92ae-8b1c83d09bc0.png) |


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
