### PR TITLE
fix(react): make plasma react usable from code sandbox

### DIFF
--- a/packages/react/jest/setup.ts
+++ b/packages/react/jest/setup.ts
@@ -15,3 +15,5 @@ document.createRange = () => {
 
     return range;
 };
+
+global.URL.createObjectURL = jest.fn();

--- a/packages/react/src/components/browserPreview/BrowserPreviewError.tsx
+++ b/packages/react/src/components/browserPreview/BrowserPreviewError.tsx
@@ -1,4 +1,4 @@
-import previewError from '@coveord/plasma-style/resources/icons/svg/preview-error.svg';
+import {svg as Icons} from '@coveord/plasma-style';
 import classNames from 'classnames';
 import {FunctionComponent} from 'react';
 
@@ -22,7 +22,7 @@ export const BrowserPreviewError: FunctionComponent<BrowserPreviewErrorProps> = 
             'cursor-pointer': onClick,
         })}
     >
-        <img src={previewError} />
+        <img src={URL.createObjectURL(new Blob([Icons.previewError.svgString], {type: 'image/svg+xml'}))} />
         <p className="medium-title-text mt2 center bolder">{description ?? 'Unable to show preview'}</p>
         {errorMessage ? <p className="center mt1 browser-preview__state--error">{errorMessage}</p> : null}
     </div>

--- a/packages/style/gulpfile.js
+++ b/packages/style/gulpfile.js
@@ -18,8 +18,6 @@ const concat = require('gulp-concat');
 const rename = require('gulp-rename');
 const uglify = require('gulp-uglify');
 const merge = require('merge-stream');
-const svgmin = require('gulp-svgmin');
-const cheerio = require('gulp-cheerio');
 const filesToJson = require('gulp-files-to-json');
 const parseArgs = require('minimist');
 const _ = require('underscore');
@@ -31,6 +29,7 @@ const config = {
     },
 };
 
+// eslint-disable-next-line id-blacklist
 const argv = parseArgs(process.argv.slice(2), {boolean: ['min', 'gzip', 'all']});
 const useMinifiedSources = argv.min;
 const useGzippedSources = argv.gzip;
@@ -38,11 +37,11 @@ const cleanAll = argv.all;
 
 gulp.task('lib', () => {
     const dependencies = ['./lib/js/*'];
-    dependencies.forEach((path) => {
-        fs.exists(path, (exists) => {
+    dependencies.forEach((dependencyPath) => {
+        fs.exists(dependencyPath, (exists) => {
             if (!exists) {
-                if (path.indexOf('*') === -1) {
-                    log(colors.red('File not found: ', path));
+                if (dependencyPath.indexOf('*') === -1) {
+                    log(colors.red('File not found: ', dependencyPath));
                     process.exit(1);
                 }
             }
@@ -144,46 +143,7 @@ gulp.task('svg:concat', () => {
         gulp.src('./resources/icons/svg/coveo-search-ui-filetypes/*.svg').pipe(rename({prefix: 'ft-'}))
     );
 
-    return src
-        .pipe(
-            svgmin((file) => {
-                const prefix = path.basename(file.relative, path.extname(file.relative));
-                return {
-                    plugins: [
-                        {
-                            removeUselessDefs: true,
-                        },
-                        {
-                            removeComments: true,
-                        },
-                        {
-                            cleanupIDs: {
-                                prefix: prefix + '-',
-                                minify: true,
-                            },
-                        },
-                    ],
-                };
-            })
-        )
-        .pipe(
-            cheerio(($) => {
-                // tslint:disable-next-line
-                $('svg').each(function () {
-                    const svg = $(this);
-                    if (svg) {
-                        const attrs = svg[0].attribs;
-                        for (const attrName in attrs) {
-                            if (attrName.match(/xmlns:.+/)) {
-                                svg.removeAttr(attrName);
-                            }
-                        }
-                    }
-                });
-            })
-        )
-        .pipe(filesToJson('CoveoStyleGuideSvg.json'))
-        .pipe(gulp.dest('dist/svg'));
+    return src.pipe(filesToJson('CoveoStyleGuideSvg.json')).pipe(gulp.dest('dist/svg'));
 });
 
 gulp.task(

--- a/packages/style/gulpfile.js
+++ b/packages/style/gulpfile.js
@@ -151,11 +151,6 @@ gulp.task('svg:concat', () => {
                 return {
                     plugins: [
                         {
-                            removeAttrs: {
-                                attrs: ['xmlns:*', 'xmlns'],
-                            },
-                        },
-                        {
                             removeUselessDefs: true,
                         },
                         {


### PR DESCRIPTION
### Proposed Changes

Right now, plasma-react cannot be used from within a code sandbox: [example](https://codesandbox.io/s/82y3hv?module=/src/Demo.tsx&file=/src/index.tsx)

The "previewError" svg from plasma-style is preventing plasma-react from being able to load in CodeSandbox, because of this bug https://github.com/facebook/create-react-app/issues/11770. CodeSandbox uses create-react-app which expects svgs to have attributes in camel case instead of standard xml markup. For example `xmlns:xlink="http://www.w3.org/1999/xlink"`  would need to be `xmlnsXlink="http://www.w3.org/1999/xlink"`. 

By not importing the svg file directly and using the svgString from the js object instead, it won't happen. But doing so requires the `xmlns` attributes to be set on the svg string.

### How to test

1. Go in the BrowserPreview demo page
2. This svg should still be able to load 
![image](https://user-images.githubusercontent.com/35579930/204649857-d25722da-1e39-4a3b-a9b3-0aa9782fc57f.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
