### PR TITLE
feat(table): added support for doubleclick on a row

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -124,6 +124,10 @@ interface TableProps<T> {
      * Initial state of the table
      */
     initialState?: InitialTableState & Partial<TableFormType>;
+    /**
+     * Action passed when user doubleClicks on a row
+     */
+    doubleClickAction?: (datum: T) => void;
 }
 
 interface TableType {
@@ -149,6 +153,7 @@ export const Table: TableType = <T,>({
     onChange,
     children,
     loading = false,
+    doubleClickAction,
 }: TableProps<T>) => {
     const convertedChildren = Children.toArray(children) as ReactElement[];
     const header = convertedChildren.find((child) => child.type === TableHeader);
@@ -224,6 +229,7 @@ export const Table: TableType = <T,>({
             <Fragment key={row.id}>
                 <tr
                     onClick={() => toggleRowSelection(row)}
+                    onDoubleClick={() => doubleClickAction(row.original)}
                     className={cx(classes.row, {[classes.rowSelected]: row.getIsSelected()})}
                 >
                     {row.getVisibleCells().map((cell) => {

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -125,7 +125,7 @@ interface TableProps<T> {
      */
     initialState?: InitialTableState & Partial<TableFormType>;
     /**
-     * Action passed when user doubleClicks on a row
+     * Action passed when user double clicks on a row
      */
     doubleClickAction?: (datum: T) => void;
 }
@@ -229,7 +229,7 @@ export const Table: TableType = <T,>({
             <Fragment key={row.id}>
                 <tr
                     onClick={() => toggleRowSelection(row)}
-                    onDoubleClick={() => doubleClickAction(row.original)}
+                    onDoubleClick={() => doubleClickAction?.(row.original)}
                     className={cx(classes.row, {[classes.rowSelected]: row.getIsSelected()})}
                 >
                     {row.getVisibleCells().map((cell) => {

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -4,7 +4,7 @@ import {FunctionComponent} from 'react';
 
 import {Table} from '../Table';
 
-type RowData = {firstName: string; lastName: string};
+type RowData = {firstName: string; lastName?: string};
 
 const columnHelper = createColumnHelper<RowData>();
 const columns: Array<ColumnDef<RowData>> = [
@@ -125,6 +125,21 @@ describe('Table', () => {
 
         const allRows = screen.getAllByRole('button', {name: 'arrowHeadDown'});
         expect(allRows).toHaveLength(2);
+    });
+
+    it('calls an action when user double clicks on a row', async () => {
+        const user = userEvent.setup();
+        const doubleClickSpy = jest.fn();
+        render(
+            <Table<RowData>
+                data={[{firstName: 'Mario'}, {firstName: 'Luigi'}]}
+                columns={columns}
+                doubleClickAction={doubleClickSpy}
+            ></Table>
+        );
+        await user.dblClick(screen.getByRole('cell', {name: 'Mario'}));
+        expect(doubleClickSpy).toHaveBeenCalledTimes(1);
+        expect(doubleClickSpy).toHaveBeenCalledWith({firstName: 'Mario'});
     });
 
     it('reset row selection when user click outside the table', async () => {


### PR DESCRIPTION
### Proposed Changes

Added prop in Table to support doubleClick action on a Table Row.
We opted to add the prop in the table in case there is something wanted out of doubleclick that is not an action on the table.

### Potential Breaking Changes

None
### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
