### PR TITLE
fix(table, Mantine):  adjust the first column padding to align with Header

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -29,8 +29,8 @@ import {Th} from './Th';
 const useStyles = createStyles<string, {hasHeader: boolean}>((theme, {hasHeader}, getRef) => ({
     table: {
         width: '100%',
-        '& td:first-child': {
-            paddingLeft: theme.spacing.md,
+        '& td:first-of-type': {
+            paddingLeft: theme.spacing.xl,
         },
     },
 
@@ -40,8 +40,11 @@ const useStyles = createStyles<string, {hasHeader: boolean}>((theme, {hasHeader}
         backgroundColor: theme.colorScheme === 'dark' ? theme.black : theme.white,
         transition: 'box-shadow 150ms ease',
         zIndex: 12, // skeleton is 11
-        '& tr th:first-child div': {
-            paddingLeft: theme.spacing.md,
+        '& tr th:first-of-type button': {
+            paddingLeft: theme.spacing.xl,
+        },
+        '& tr th:first-of-type div': {
+            paddingLeft: theme.spacing.xl,
         },
 
         '&::after': {


### PR DESCRIPTION
### Proposed Changes

UITOOL-1013

I did a first fix in https://github.com/coveo/plasma/pull/2913 but turns out that now I need 40px instead of 24 :derp:

After:

<img width="721" alt="image" src="https://user-images.githubusercontent.com/63734941/205716754-d74c847a-0b38-49b9-acf9-31a3c712caf7.png">

Demo code (emulate a standard page layout):

![image](https://user-images.githubusercontent.com/63734941/205716809-8d901868-933d-414e-989c-ff9152f8da7c.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
