### PR TITLE
feat(mantine): add xml language support to the CodeEditor

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -17,10 +17,11 @@ import {
     useComponentDefaultProps,
 } from '@mantine/core';
 import {useUncontrolled} from '@mantine/hooks';
-import Editor, {loader} from '@monaco-editor/react';
+import Editor, {loader, useMonaco} from '@monaco-editor/react';
 import {FunctionComponent, useEffect, useState} from 'react';
 
 import {useParentHeight} from '../../hooks';
+import {XML} from './languages/xml';
 
 const useStyles = createStyles((theme) => ({
     root: {},
@@ -40,7 +41,7 @@ interface CodeEditorProps
      *
      * @default 'plaintext'
      */
-    language?: 'plaintext' | 'json' | 'markdown' | 'python';
+    language?: 'plaintext' | 'json' | 'markdown' | 'python' | 'xml';
     /** Default value for uncontrolled input */
     defaultValue?: string;
     /** Value for controlled input */
@@ -103,6 +104,8 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         ...others
     } = useComponentDefaultProps('CodeEditor', defaultProps, props);
     const [loaded, setLoaded] = useState(false);
+    const [registered, setRegistered] = useState(false);
+    const monaco = useMonaco();
     const {classes, theme} = useStyles();
     const [_value, handleChange] = useUncontrolled<string>({
         value,
@@ -113,8 +116,8 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     const [parentHeight, ref] = useParentHeight();
 
     const loadLocalMonaco = async () => {
-        const monaco = await import('monaco-editor');
-        loader.config({monaco});
+        const monacoInstance = await import('monaco-editor');
+        loader.config({monaco: monacoInstance});
         setLoaded(true);
     };
 
@@ -125,6 +128,13 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
             setLoaded(true);
         }
     }, []);
+
+    useEffect(() => {
+        if (monaco && language === 'xml' && !registered) {
+            XML.register(monaco);
+            setRegistered(true);
+        }
+    }, [monaco, language]);
 
     const _label = label ? (
         <Input.Label required={required} {...labelProps}>

--- a/packages/mantine/src/components/code-editor/__mocks__/@monaco-editor/react.tsx
+++ b/packages/mantine/src/components/code-editor/__mocks__/@monaco-editor/react.tsx
@@ -1,4 +1,4 @@
-import {type EditorProps} from '@monaco-editor/react';
+import {EditorProps} from '@monaco-editor/react';
 import {FunctionComponent} from 'react';
 
 const MockedEditor: FunctionComponent<EditorProps> = (props) => <div data-testid="monaco-editor" />;
@@ -8,3 +8,5 @@ export default MockedEditor;
 export const loader = {
     config: jest.fn(),
 };
+
+export const useMonaco = () => jest.fn();

--- a/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
+++ b/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
@@ -3,6 +3,7 @@ import {loader} from '@monaco-editor/react';
 import {render, screen, waitForElementToBeRemoved, within} from '@test-utils';
 
 import {CodeEditor} from '../CodeEditor';
+import {XML} from '../languages/xml';
 
 describe('CodeEditor', () => {
     beforeEach(() => {
@@ -52,5 +53,11 @@ describe('CodeEditor', () => {
         render(<CodeEditor label="label" description="description" monacoLoader="cdn" />);
         expect(loader.config).not.toHaveBeenCalled();
         expect(screen.getByTestId('monaco-editor')).toBeInTheDocument();
+    });
+
+    it('loads the xml language in the monaco instance if the editor language is xml', () => {
+        const xmlLanguageSpy = jest.spyOn(XML, 'register').mockImplementation();
+        render(<CodeEditor label="label" description="description" monacoLoader="cdn" language="xml" />);
+        expect(xmlLanguageSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/mantine/src/components/code-editor/languages/xml.ts
+++ b/packages/mantine/src/components/code-editor/languages/xml.ts
@@ -1,0 +1,43 @@
+import {Monaco} from '@monaco-editor/react';
+
+const format = (xml: string): string => {
+    // https://stackoverflow.com/questions/57039218/doesnt-monaco-editor-support-xml-language-by-default
+    const PADDING = ' '.repeat(2);
+    const reg = /(>)(<)(\/*)/g;
+    let pad = 0;
+
+    xml = xml.replace(reg, '$1\r\n$2$3');
+
+    return xml
+        .split('\r\n')
+        .map((node) => {
+            let indent = 0;
+            if (node.match(/.+<\/\w[^>]*>$/)) {
+                indent = 0;
+            } else if (node.match(/^<\/\w/) && pad > 0) {
+                pad -= 1;
+            } else if (node.match(/^<\w[^>]*[^/]>.*$/)) {
+                indent = 1;
+            } else {
+                indent = 0;
+            }
+
+            pad += indent;
+
+            return PADDING.repeat(pad - indent) + node;
+        })
+        .join('\r\n');
+};
+
+const register = (monaco: Monaco): void => {
+    monaco.languages.registerDocumentFormattingEditProvider('xml', {
+        provideDocumentFormattingEdits: async (model) => [
+            {
+                range: model.getFullModelRange(),
+                text: format(model.getValue()),
+            },
+        ],
+    });
+};
+
+export const XML = {register};

--- a/packages/website/src/examples/form/code-editor/CodeEditorXML.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorXML.demo.tsx
@@ -1,0 +1,19 @@
+import {CodeEditor, useForm} from '@coveord/plasma-mantine';
+
+export default () => {
+    const form = useForm({
+        initialValues: {
+            config: '<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em"><circle cx="8" cy="8" r="6.5" stroke="currentColor"/><path d="M5 8H11M8 5L8 11" stroke="currentColor" stroke-linecap="round"/></svg>',
+        },
+    });
+
+    return (
+        <CodeEditor
+            language="xml"
+            label="Add icon svg"
+            description="XML markup of the add icon svg"
+            monacoLoader="cdn"
+            {...form.getInputProps('config')}
+        />
+    );
+};


### PR DESCRIPTION
### Proposed Changes

Adding syntax highlighting and formatter for the xml language.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
