### PR TITLE
fix(mantine): adjust header doc link icon alignment

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -48,7 +48,7 @@ export const Header: FunctionComponent<HeaderProps> = ({
                         <Breadcrumbs>{children}</Breadcrumbs>
                         {docLink ? (
                             <Tooltip label={docLinkTooltipLabel} position="bottom">
-                                <Anchor href={docLink} target="_blank" ml="xs">
+                                <Anchor inline href={docLink} target="_blank" ml="xs">
                                     <QuestionSize24Px height={24} />
                                 </Anchor>
                             </Tooltip>


### PR DESCRIPTION
### Proposed Changes

Setting the inline prop on the anchor makes the vertical alignment look better

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
