### PR TITLE
fix(mantine): add type keyword to header props export

### DIFF
--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -10,7 +10,7 @@ export * from '@mantine/hooks';
 export {createColumnHelper, type ColumnDef} from '@tanstack/table-core';
 export * from './components';
 // explicitly overriding mantine components
-export {Header, Table, HeaderProps, Modal} from './components';
+export {Header, Table, type HeaderProps, Modal} from './components';
 export * from './theme';
 
 declare module '@mantine/core' {


### PR DESCRIPTION
### Proposed Changes

Explicitly exported interfaces and types need to be accompanied with the `type` keyword. Otherwise users of the package will get the following error 

![image](https://user-images.githubusercontent.com/35579930/206031060-1b856be8-cf2c-407d-9a63-4ebdf78e32d7.png)

cc: @paulgerold 

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
