### PR TITLE
refactor(website): standardize source code links

### DIFF
--- a/packages/website/src/building-blocs/PageHeader.tsx
+++ b/packages/website/src/building-blocs/PageHeader.tsx
@@ -9,12 +9,6 @@ export interface PageHeaderProps {
     description?: ReactNode;
     section: 'Foundations' | 'Layout' | 'Form' | 'Navigation' | 'Feedback' | 'Advanced';
     /**
-     * Path to the component's source file from /packages/react/src/components
-     *
-     * @example '/button/Button.tsx'
-     */
-    componentSourcePath?: string;
-    /**
      * Path to a relevant source file in the repo
      *
      * @example 'packages/style/scss/typekit.scss'
@@ -27,28 +21,24 @@ export const PageHeader: FunctionComponent<PageHeaderProps> = ({
     description,
     thumbnail,
     section,
-    componentSourcePath,
     sourcePath,
-}) => {
-    const githubPath = componentSourcePath ? `packages/react/src/components${componentSourcePath}` : sourcePath;
-    return (
-        <div className="plasma-page-header">
-            <h2 className="h5-subdued normal-white-space">{section}</h2>
-            <h1 className="h1-light normal-white-space" data-coveo-field="title">
-                {title}
-            </h1>
-            <h3 className="h4-book-subdued" data-coveo-field="description">
-                {description}
-            </h3>
-            {githubPath && (
-                <GithubButton
-                    ariaLabel="View source code on GitHub"
-                    href={`https://github.com/coveo/plasma/blob/master/${githubPath}`}
-                >
-                    View source
-                </GithubButton>
-            )}
-            <Tile thumbnail={thumbnail} />
-        </div>
-    );
-};
+}) => (
+    <div className="plasma-page-header">
+        <h2 className="h5-subdued normal-white-space">{section}</h2>
+        <h1 className="h1-light normal-white-space" data-coveo-field="title">
+            {title}
+        </h1>
+        <h3 className="h4-book-subdued" data-coveo-field="description">
+            {description}
+        </h3>
+        {sourcePath && (
+            <GithubButton
+                ariaLabel="View source code on GitHub"
+                href={`https://github.com/coveo/plasma/blob/master${sourcePath}`}
+            >
+                View source
+            </GithubButton>
+        )}
+        <Tile thumbnail={thumbnail} />
+    </div>
+);

--- a/packages/website/src/building-blocs/PageLayout.tsx
+++ b/packages/website/src/building-blocs/PageLayout.tsx
@@ -41,13 +41,11 @@ export const PageLayout = ({
     thumbnail,
     section,
     children,
-    componentSourcePath,
     sourcePath,
     ...contentProps
 }: PageLayoutProps) => (
     <div id={id} className="plasma-page-layout">
         <PageHeader
-            componentSourcePath={componentSourcePath}
             sourcePath={sourcePath}
             section={section}
             thumbnail={thumbnail}

--- a/packages/website/src/pages/foundations/Colors.tsx
+++ b/packages/website/src/pages/foundations/Colors.tsx
@@ -93,7 +93,7 @@ export const ColorsExamples = () => (
         title="Colors"
         thumbnail="colors"
         description="The colors that give Plasma its identity"
-        sourcePath="packages/tokens#readme"
+        sourcePath="/packages/tokens#readme"
         withPropsTable={false}
     >
         <div className="plasma-page-layout__section pl5">

--- a/packages/website/src/pages/legacy/advanced/InfoToken.tsx
+++ b/packages/website/src/pages/legacy/advanced/InfoToken.tsx
@@ -15,8 +15,8 @@ const DemoPage = () => (
         title="Info Token"
         section="Advanced"
         description="An InfoToken is a visual representation of the status of something."
-        componentSourcePath="/info-token/InfoToken.tsx"
         demo={<InfoTokenDemo center />}
+        sourcePath="/packages/react/src/components/info-token/InfoToken.tsx"
         propsMetadata={InfoTokenMetadata}
         examples={{
             info: <InfoTokenInfoDemo center title="Information" />,

--- a/packages/website/src/pages/legacy/advanced/LinkSvg.tsx
+++ b/packages/website/src/pages/legacy/advanced/LinkSvg.tsx
@@ -9,8 +9,8 @@ const DemoPage = () => (
         title="Link SVG"
         section="Advanced"
         description="A SVG that acts as a link."
-        componentSourcePath="/svg/LinkSvg.tsx"
         demo={<LinkSvgDemo center />}
+        sourcePath="/packages/react/src/components/svg/LinkSvg.tsx"
         propsMetadata={LinkSvgMetadata}
     />
 );

--- a/packages/website/src/pages/legacy/advanced/ListBox.tsx
+++ b/packages/website/src/pages/legacy/advanced/ListBox.tsx
@@ -12,8 +12,8 @@ const DemoPage = () => (
         title="List Box"
         section="Advanced"
         description="A list of items from which to choose from."
-        componentSourcePath="/listBox/ListBox.tsx"
         demo={<ListBoxDemo center />}
+        sourcePath="/packages/react/src/components/listBox/ListBox.tsx"
         propsMetadata={ListBoxMetadata}
         examples={{
             loading: <ListBoxLoadingDemo center title="Loading" />,

--- a/packages/website/src/pages/legacy/advanced/OptionsCycle.tsx
+++ b/packages/website/src/pages/legacy/advanced/OptionsCycle.tsx
@@ -10,8 +10,8 @@ const DemoPage = () => (
         title="Options Cycle"
         section="Advanced"
         description="Allows to cycle through an ordered list of options using right-left arrow buttons."
-        componentSourcePath="/optionsCycle/OptionsCycle.tsx"
         demo={<OptionsCycleDemo center />}
+        sourcePath="/packages/react/src/components/optionsCycle/OptionsCycle.tsx"
         propsMetadata={OptionsCycleConnectedMetadata}
         examples={{
             buttonStyle: <OptionsCycleButtonDemo center title="Styles like the Button" />,

--- a/packages/website/src/pages/legacy/advanced/PartialStringMatch.tsx
+++ b/packages/website/src/pages/legacy/advanced/PartialStringMatch.tsx
@@ -10,8 +10,8 @@ const DemoPage = () => (
         section="Advanced"
         propsMetadata={PartialStringMatchMetadata}
         description="Highlights a string searched for in any DOM tree."
-        componentSourcePath="/partial-string-match/PartialStringMatch.tsx"
         demo={<PartialStringMatchDemo />}
+        sourcePath="/packages/react/src/components/partial-string-match/PartialStringMatch.tsx"
     />
 );
 

--- a/packages/website/src/pages/legacy/advanced/SlideY.tsx
+++ b/packages/website/src/pages/legacy/advanced/SlideY.tsx
@@ -9,8 +9,8 @@ const DemoPage = () => (
         title="Slide Y"
         section="Advanced"
         description="Allows to hide and show content using a vertical expand animation."
-        sourcePath="packages/react/src/animations/SlideY.tsx"
         demo={<SlideYDemo />}
+        sourcePath="/packages/react/src/animations/SlideY.tsx"
         propsMetadata={SlideYMetadata}
     />
 );

--- a/packages/website/src/pages/legacy/feedback/Badge.tsx
+++ b/packages/website/src/pages/legacy/feedback/Badge.tsx
@@ -8,7 +8,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const BadgeDemos = () => (
     <PageLayout
         id="Badge"
-        componentSourcePath="/badge/Badge.tsx"
+        sourcePath="/packages/react/src/components/badge/Badge.tsx"
         title="Badge"
         section="Feedback"
         description="A badge is a small label that displays a short yet important piece of information."

--- a/packages/website/src/pages/legacy/feedback/ColorBar.tsx
+++ b/packages/website/src/pages/legacy/feedback/ColorBar.tsx
@@ -11,8 +11,8 @@ const DemoPage = () => (
         title="Color Bar"
         section="Feedback"
         description="A color bar is used to indicate the ratio between things."
-        componentSourcePath="/colorBar/ColorBar.tsx"
         demo={<ColorBarDemo />}
+        sourcePath="/packages/react/src/components/colorBar/ColorBar.tsx"
         propsMetadata={ColorBarMetadata}
         examples={{
             partial: <ColorBarPartialDemo title="Partially filled" />,

--- a/packages/website/src/pages/legacy/feedback/ColorDot.tsx
+++ b/packages/website/src/pages/legacy/feedback/ColorDot.tsx
@@ -7,7 +7,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const ColorDotsDemos = () => (
     <PageLayout
         id="ColorDot"
-        sourcePath="packages/style/scss/elements/color-dot.scss"
+        sourcePath="/packages/style/scss/elements/color-dot.scss"
         title="Color dot"
         section="Feedback"
         withPropsTable={false}

--- a/packages/website/src/pages/legacy/feedback/IconBadge.tsx
+++ b/packages/website/src/pages/legacy/feedback/IconBadge.tsx
@@ -6,7 +6,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const IconBadgeDemos = () => (
     <PageLayout
         id="IconBadge"
-        componentSourcePath="/iconBadge/IconBadge.tsx"
+        sourcePath="/packages/react/src/components/iconBadge/IconBadge.tsx"
         title="IconBadge"
         section="Feedback"
         thumbnail="placeholder"

--- a/packages/website/src/pages/legacy/feedback/LastUpdated.tsx
+++ b/packages/website/src/pages/legacy/feedback/LastUpdated.tsx
@@ -10,8 +10,8 @@ const DemoPage = () => (
         title="Last Updated"
         section="Feedback"
         description="A “last updated” string displays the time a set of data has been last updated by a system."
-        componentSourcePath="/lastUpdated/LastUpdated.tsx"
         demo={<LastUpdatedDemo />}
+        sourcePath="/packages/react/src/components/lastUpdated/LastUpdated.tsx"
         propsMetadata={LastUpdatedMetadata}
         examples={{specificTime: <LastUpdatedSpecificTimeDemo title="Specific date" />}}
     />

--- a/packages/website/src/pages/legacy/feedback/Loading.tsx
+++ b/packages/website/src/pages/legacy/feedback/Loading.tsx
@@ -2,8 +2,8 @@ import {LoadingMetadata} from '@coveord/plasma-components-props-analyzer';
 
 import {PageLayout} from '../../../building-blocs/PageLayout';
 import LoadingDemo from '../../../examples/legacy/feedback/Loading/Loading.demo.tsx';
-import LoadingFullcontent from '../../../examples/legacy/feedback/Loading/LoadingFullcontent.demo.tsx';
-import LoadingSpinner from '../../../examples/legacy/feedback/Loading/LoadingSpinner.demo.tsx';
+import LoadingFullContentDemo from '../../../examples/legacy/feedback/Loading/LoadingFullcontent.demo.tsx';
+import LoadingSpinnerDemo from '../../../examples/legacy/feedback/Loading/LoadingSpinner.demo.tsx';
 
 const DemoPage = () => (
     <PageLayout
@@ -11,12 +11,12 @@ const DemoPage = () => (
         title="Loading Spinner"
         section="Feedback"
         description="A loading spinner indicates that content or data is actively being loaded."
-        componentSourcePath="/loading/Loading.tsx"
         demo={<LoadingDemo center />}
+        sourcePath="/packages/react/src/components/loading/Loading.tsx"
         propsMetadata={LoadingMetadata}
         examples={{
-            fullContent: <LoadingFullcontent center title="Vertically centered" />,
-            loadingSpinner: <LoadingSpinner center title="Loading spinner that can be used in other components" />,
+            fullContent: <LoadingFullContentDemo center title="Vertically centered" />,
+            loadingSpinner: <LoadingSpinnerDemo center title="Loading spinner that can be used in other components" />,
         }}
     />
 );

--- a/packages/website/src/pages/legacy/feedback/StepProgressBar.tsx
+++ b/packages/website/src/pages/legacy/feedback/StepProgressBar.tsx
@@ -9,8 +9,8 @@ const DemoPage = () => (
         title="Step Progress Bar"
         section="Feedback"
         description="A step progress bar visualizes a user’s progress as they complete a task by representing the number of steps left to complete the task."
-        componentSourcePath="/stepProgressBar/StepProgressBar.tsx"
         demo={<StepProgressBarDemo />}
+        sourcePath="/packages/react/src/components/stepProgressBar/StepProgressBar.tsx"
         propsMetadata={StepProgressBarMetadata}
     />
 );

--- a/packages/website/src/pages/legacy/feedback/SyncFeedback.tsx
+++ b/packages/website/src/pages/legacy/feedback/SyncFeedback.tsx
@@ -10,8 +10,8 @@ const DemoPage = () => (
         title="Sync Feedback"
         section="Feedback"
         description="A sync feedback indicates the status of an operation to the user."
-        componentSourcePath="/numericInput/NumericInputConnected.tsx"
         demo={<SyncFeedbackDemo center />}
+        sourcePath="/packages/react/src/components/numericInput/NumericInputConnected.tsx"
         propsMetadata={SyncFeedbackMetadata}
         examples={{label: <SyncFeedbackLabelDemo center title="Custom Labels" />}}
     />

--- a/packages/website/src/pages/legacy/feedback/Toast.tsx
+++ b/packages/website/src/pages/legacy/feedback/Toast.tsx
@@ -8,7 +8,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const ToastDemos = () => (
     <PageLayout
         id="Toast"
-        componentSourcePath="/toast/Toast.tsx"
+        sourcePath="/packages/react/src/components/toast/Toast.tsx"
         title="Toast"
         thumbnail="toast"
         section="Feedback"

--- a/packages/website/src/pages/legacy/feedback/Tooltip.tsx
+++ b/packages/website/src/pages/legacy/feedback/Tooltip.tsx
@@ -6,7 +6,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const TooltipDemos = () => (
     <PageLayout
         id="Tooltip"
-        componentSourcePath="/tooltip/Tooltip.tsx"
+        sourcePath="/packages/react/src/components/tooltip/Tooltip.tsx"
         title="Tooltip"
         section="Feedback"
         description="A tooltip is a floating label that provides brief additional information about an interface component."

--- a/packages/website/src/pages/legacy/form/ActionableItem.tsx
+++ b/packages/website/src/pages/legacy/form/ActionableItem.tsx
@@ -12,7 +12,7 @@ const ActionableItemDemos: FunctionComponent = () => (
         description="An actionable item is a dropdown menu listing actions associated with an element."
         demo={<ActionableItemDemo center />}
         propsMetadata={ActionableItemMetadata}
-        componentSourcePath="/actionable-item/ActionableItem.tsx"
+        sourcePath="/packages/react/src/components/actionable-item/ActionableItem.tsx"
     />
 );
 

--- a/packages/website/src/pages/legacy/form/Button.tsx
+++ b/packages/website/src/pages/legacy/form/Button.tsx
@@ -27,7 +27,7 @@ const ButtonPage = () => (
             iconAndLink: <ButtonWithIconAndLinkDemo center title="Icon only with an hyperlink" />,
             withTooltip: <ButtonWithTooltipDemo center title="With tooltip" />,
         }}
-        componentSourcePath="/button/Button.tsx"
+        sourcePath="/packages/react/src/components/button/Button.tsx"
         propsMetadata={ButtonMetadata}
     />
 );

--- a/packages/website/src/pages/legacy/form/Checkbox.tsx
+++ b/packages/website/src/pages/legacy/form/Checkbox.tsx
@@ -12,7 +12,7 @@ const CheckboxDemos = () => (
         title="Checkbox"
         section="Form"
         description="A set of checkboxes allow users to select multiple options from a list. A single checkbox can be used to enable/disable an option."
-        componentSourcePath="/checkbox/Checkbox.tsx"
+        sourcePath="/packages/react/src/components/checkbox/Checkbox.tsx"
         demo={<CheckboxDemo center />}
         examples={{
             connected: <CheckboxConnectedDemo center title="Connected to the PlasmaState" />,

--- a/packages/website/src/pages/legacy/form/CodeEditor.tsx
+++ b/packages/website/src/pages/legacy/form/CodeEditor.tsx
@@ -12,7 +12,7 @@ const CodeEditorLegacyPage = () => (
         description="A code editor is a text area that allows users to edit code. A coding syntax is built in."
         thumbnail="codeEditor"
         demo={<CodeEditorDemo />}
-        componentSourcePath="/editor/CodeEditor.tsx"
+        sourcePath="/packages/react/src/components/editor/CodeEditor.tsx"
         propsMetadata={CodeEditorLegacyMetadata}
         examples={{
             readOnly: <CodeEditorReadonlyDemo title="Read only" />,

--- a/packages/website/src/pages/legacy/form/ColorPicker.tsx
+++ b/packages/website/src/pages/legacy/form/ColorPicker.tsx
@@ -16,7 +16,7 @@ const ColorPickerDemos = () => (
                 <a href="https://github.com/casesandberg/react-color/">React Color</a>
             </>
         }
-        componentSourcePath="/color-picker/ColorPicker.tsx"
+        sourcePath="/packages/react/src/components/color-picker/ColorPicker.tsx"
         demo={<ColorPickerDemo center />}
         propsMetadata={ColorPickerMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/Countdown.tsx
+++ b/packages/website/src/pages/legacy/form/Countdown.tsx
@@ -8,7 +8,7 @@ const Page = () => (
         id="Countdown"
         section="Form"
         title="Countdown"
-        componentSourcePath="/calendar/Countdown.tsx"
+        sourcePath="/packages/react/src/components/calendar/Countdown.tsx"
         description="A Countdown illustrates how much time there is left until an end date is reached."
         demo={<CountdownDemo center />}
         propsMetadata={CountdownMetadata}

--- a/packages/website/src/pages/legacy/form/DatePicker.tsx
+++ b/packages/website/src/pages/legacy/form/DatePicker.tsx
@@ -11,7 +11,7 @@ const Page = () => (
         title="Date Picker"
         section="Form"
         description="A date picker is a calendar interface that allows users to select a single date or a date range."
-        componentSourcePath="/datePicker/DatePickerDropdown.tsx"
+        sourcePath="/packages/react/src/components/datePicker/DatePickerDropdown.tsx"
         demo={<DatePickerDemo />}
         propsMetadata={DatePickerDropdownConnectedMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/DiffViewer.tsx
+++ b/packages/website/src/pages/legacy/form/DiffViewer.tsx
@@ -12,7 +12,7 @@ const Page = () => (
         title="Diff Viewer"
         section="Form"
         description="A diff viewer allows users to compare code files by showing them side by side and highlighting differences between them."
-        componentSourcePath="/diffViewer/DiffViewer.tsx"
+        sourcePath="/packages/react/src/components/diffViewer/DiffViewer.tsx"
         demo={<DiffViewerDemo />}
         propsMetadata={DiffViewerMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/Facet.tsx
+++ b/packages/website/src/pages/legacy/form/Facet.tsx
@@ -11,7 +11,7 @@ const FacetsDemoPage = () => (
         title="Facet"
         section="Form"
         description="A facet is a set of options used to filter a list of content items."
-        componentSourcePath="/facets/FacetConnected.tsx"
+        sourcePath="/packages/react/src/components/facets/FacetConnected.tsx"
         demo={<FacetDemo center />}
         propsMetadata={FacetMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/Filepicker.tsx
+++ b/packages/website/src/pages/legacy/form/Filepicker.tsx
@@ -9,7 +9,7 @@ const Page = () => (
         title="File Picker"
         section="Form"
         description="A file picker is a dialog that allows users to upload a file."
-        componentSourcePath="/filepicker/FilePicker.tsx"
+        sourcePath="/packages/react/src/components/filepicker/FilePicker.tsx"
         demo={<FilepickerDemo center />}
         propsMetadata={FilepickerMetadata}
     />

--- a/packages/website/src/pages/legacy/form/FilterBox.tsx
+++ b/packages/website/src/pages/legacy/form/FilterBox.tsx
@@ -11,7 +11,7 @@ const Page = () => (
         title="Filter Box"
         section="Form"
         description="A filter box allows users to enter text to filter data. It is frequently used with tables and dropdown menus."
-        componentSourcePath="/filterBox/FilterBoxConnected.tsx"
+        sourcePath="/packages/react/src/components/filterBox/FilterBoxConnected.tsx"
         demo={<FilterBoxDemo center />}
         propsMetadata={FilterBoxConnectedMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/FlatSelect.tsx
+++ b/packages/website/src/pages/legacy/form/FlatSelect.tsx
@@ -14,7 +14,7 @@ const FlatSelectDemoPage = () => (
         title="Flat Select"
         section="Form"
         description="A flat select is a group of mutually exclusive buttons aligned horizontally. It is used to allow users to switch between interface displays or binary options."
-        componentSourcePath="/flatSelect/FlatSelect.tsx"
+        sourcePath="/packages/react/src/components/flatSelect/FlatSelect.tsx"
         demo={<FlatSelectDemo center />}
         propsMetadata={FlatSelectConnectedMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/JSONEditor.tsx
+++ b/packages/website/src/pages/legacy/form/JSONEditor.tsx
@@ -12,7 +12,7 @@ const Page = () => (
         title="JSON Editor"
         section="Form"
         description="A JSON editor is a text area where users can enter and edit data in JSON format."
-        componentSourcePath="/editor/JSONEditor.tsx"
+        sourcePath="/packages/react/src/components/editor/JSONEditor.tsx"
         demo={<JSONEditorDemo />}
         propsMetadata={JSONEditorConnectedMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/MultiSelect.tsx
+++ b/packages/website/src/pages/legacy/form/MultiSelect.tsx
@@ -11,7 +11,7 @@ const Page = () => (
         title="Multi Select"
         section="Form"
         description="A multi select allows users to select multiple options from a list. It is typically used when there are a large number of options."
-        componentSourcePath="/select/MultiSelectConnected.tsx"
+        sourcePath="/packages/react/src/components/select/MultiSelectConnected.tsx"
         demo={<MultiSelectDemo center />}
         propsMetadata={MultiSelectConnectedMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/NumericInput.tsx
+++ b/packages/website/src/pages/legacy/form/NumericInput.tsx
@@ -10,7 +10,7 @@ const NumericInputDemos = () => (
         title="Numeric Input"
         section="Form"
         description="A numeric input allows users to enter and edit numerical values, either manually or using an input stepper."
-        componentSourcePath="/numericInput/NumericInputConnected.tsx"
+        sourcePath="/packages/react/src/components/numericInput/NumericInputConnected.tsx"
         propsMetadata={NumericInputConnectedMetadata}
         demo={<NumericInputDemo center />}
         examples={{disabled: <NumericInputDisabledDemo center title="Disabled" />}}

--- a/packages/website/src/pages/legacy/form/RadioButton.tsx
+++ b/packages/website/src/pages/legacy/form/RadioButton.tsx
@@ -10,7 +10,7 @@ const Page = () => (
         title="Radio Buttons"
         section="Form"
         description="A radio button allows users to select exactly one option from a list of mutually exclusive options."
-        componentSourcePath="/radio/RadioSelectConnected.tsx"
+        sourcePath="/packages/react/src/components/radio/RadioSelectConnected.tsx"
         demo={<RadioButtonDemo center />}
         propsMetadata={RadioSelectConnectedMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/SearchBar.tsx
+++ b/packages/website/src/pages/legacy/form/SearchBar.tsx
@@ -8,7 +8,7 @@ const Page = () => (
         id="SearchBar"
         title="Search Bar"
         section="Form"
-        componentSourcePath="/searchBar/SearchBar.tsx"
+        sourcePath="/packages/react/src/components/searchBar/SearchBar.tsx"
         propsMetadata={SearchBarMetadata}
         description="A search bar allows users to search a large set of data by entering keywords. A list of matching items is then returned."
         demo={<SearchBarDemo center />}

--- a/packages/website/src/pages/legacy/form/SingleSelect.tsx
+++ b/packages/website/src/pages/legacy/form/SingleSelect.tsx
@@ -12,7 +12,7 @@ const Page = () => (
         title="Single Select"
         section="Form"
         description="A single select allows users to select only one option from a list. It is typically used when there are a large number of options."
-        componentSourcePath="/select/SingleSelectConnected.tsx"
+        sourcePath="/packages/react/src/components/select/SingleSelectConnected.tsx"
         demo={<SingleSelectDemo center />}
         propsMetadata={SingleSelectConnectedMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/Slider.tsx
+++ b/packages/website/src/pages/legacy/form/Slider.tsx
@@ -12,7 +12,7 @@ const Page = () => (
         title="Slider"
         section="Form"
         description="A slider offers a quick and visual way for users to select a value within a given range."
-        componentSourcePath="/slider/Slider.tsx"
+        sourcePath="/packages/react/src/components/slider/Slider.tsx"
         demo={<SliderDemo />}
         propsMetadata={SliderMetadata}
         examples={{

--- a/packages/website/src/pages/legacy/form/TextArea.tsx
+++ b/packages/website/src/pages/legacy/form/TextArea.tsx
@@ -9,7 +9,7 @@ const Page = () => (
         title="Text Area"
         section="Form"
         description="A text area allows users to enter and edit longer text, often on multiple lines or in a paragraph."
-        componentSourcePath="/textarea/TextArea.tsx"
+        sourcePath="/packages/react/src/components/textarea/TextArea.tsx"
         demo={<TextAreaDemo />}
         propsMetadata={TextAreaMetadata}
     />

--- a/packages/website/src/pages/legacy/form/TextInput.tsx
+++ b/packages/website/src/pages/legacy/form/TextInput.tsx
@@ -12,7 +12,7 @@ export const TextInputDemos: FunctionComponent = () => (
         section="Form"
         thumbnail="textInput"
         description="A text input allows users to enter and edit short texts, such as names, emails, and passwords."
-        componentSourcePath="/textInput/TextInput.tsx"
+        sourcePath="/packages/react/src/components/textInput/TextInput.tsx"
         demo={<TextInputDemo center />}
         examples={{hookUsage: <UseTextInputDemo title="useTextInput hook usage" />}}
         propsMetadata={TextInputMetadata}

--- a/packages/website/src/pages/legacy/foundations/Links.tsx
+++ b/packages/website/src/pages/legacy/foundations/Links.tsx
@@ -13,7 +13,7 @@ export const Links = () => (
         thumbnail="links"
         withPropsTable={false}
         description="A link is a navigational element that guides users to external resources or other sections of the product."
-        sourcePath="packages/style/scss/elements/links.scss"
+        sourcePath="/packages/style/scss/elements/links.scss"
         examples={{
             disabledLink: <LinkDisabledDemo center title="Disabled" />,
             buttonLink: <ButtonLinkDemo center title="A button disguised as a link" />,

--- a/packages/website/src/pages/legacy/foundations/Spacing.tsx
+++ b/packages/website/src/pages/legacy/foundations/Spacing.tsx
@@ -10,7 +10,7 @@ export const Spacing = () => (
         title="Spacing"
         description="Spacing is the standard padding and margin size that one can adjust to customize the layout of an interface."
         withPropsTable={false}
-        sourcePath="packages/style/scss/utility/white-space.scss"
+        sourcePath="/packages/style/scss/utility/white-space.scss"
     >
         <div className="plasma-page-layout__section">
             <h4 className="h2 mb1">The spacing mechanism</h4>

--- a/packages/website/src/pages/legacy/foundations/Typekit.tsx
+++ b/packages/website/src/pages/legacy/foundations/Typekit.tsx
@@ -245,8 +245,8 @@ export const Typekit = () => (
         title="Typekit"
         thumbnail="typekit"
         description="The Typekit covers all typography styles designed specifically to work with the Plasma ecosystem."
-        sourcePath="packages/style/scss/typekit.scss"
         demo={<TypekitDemo center />}
+        sourcePath="/packages/style/scss/typekit.scss"
         withPropsTable={false}
     >
         <div className="plasma-page-layout__section full-content flex-column">

--- a/packages/website/src/pages/legacy/layout/Banner.tsx
+++ b/packages/website/src/pages/legacy/layout/Banner.tsx
@@ -5,7 +5,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const BannerDemos = () => (
     <PageLayout
         id="BannerContainer"
-        componentSourcePath="/banner/BannerContainer.tsx"
+        sourcePath="/packages/react/src/components/banner/BannerContainer.tsx"
         title="Banner"
         withPropsTable={false}
         section="Layout"

--- a/packages/website/src/pages/legacy/layout/BlankSlate.tsx
+++ b/packages/website/src/pages/legacy/layout/BlankSlate.tsx
@@ -9,7 +9,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const BlankSlateDemo = () => (
     <PageLayout
         id="BlankSlate"
-        componentSourcePath="/blankSlate/BlankSlate.tsx"
+        sourcePath="/packages/react/src/components/blankSlate/BlankSlate.tsx"
         title="Blank Slate"
         section="Layout"
         description="A blank slate informs users that a section doesn’t contain any data and provides a way to address it."

--- a/packages/website/src/pages/legacy/layout/BorderedLine.tsx
+++ b/packages/website/src/pages/legacy/layout/BorderedLine.tsx
@@ -5,7 +5,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 const BorderedLineDemos = () => (
     <PageLayout
         id="BorderedLine"
-        componentSourcePath="/borderedLine/BorderedLine.tsx"
+        sourcePath="/packages/react/src/components/borderedLine/BorderedLine.tsx"
         title="Bordered Line"
         section="Layout"
         thumbnail="placeholder"

--- a/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
@@ -18,7 +18,7 @@ export const BrowserPreviewDemos = () => (
         section="Layout"
         thumbnail="placeholder"
         description="A browser preview shows the result of configuration changes in a simplified representation of a browser interface."
-        componentSourcePath="/browserPreview/BrowserPreview.tsx"
+        sourcePath="/packages/react/src/components/browserPreview/BrowserPreview.tsx"
         propsMetadata={BrowserPreviewMetadata}
         demo={<BrowserPreviewDemo />}
         examples={{

--- a/packages/website/src/pages/legacy/layout/Chart.tsx
+++ b/packages/website/src/pages/legacy/layout/Chart.tsx
@@ -11,7 +11,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const ChartDemos = () => (
     <PageLayout
         id="ChartContainer"
-        componentSourcePath="/chart/ChartContainer.tsx"
+        sourcePath="/packages/react/src/components/chart/ChartContainer.tsx"
         title="Charts"
         section="Layout"
         description="A chart compares sets of complex data to provide insights on their relationship and status."

--- a/packages/website/src/pages/legacy/layout/ChildForm.tsx
+++ b/packages/website/src/pages/legacy/layout/ChildForm.tsx
@@ -9,7 +9,7 @@ const ChildFormDemos = () => (
         title="Child Form"
         section="Layout"
         description="A child form associates a subset of options or content to its parent option."
-        componentSourcePath="/childForm/ChildForm.tsx"
+        sourcePath="/packages/react/src/components/childForm/ChildForm.tsx"
         demo={<ChildFormDemo />}
         examples={{
             vertical: <ChildFormVerticalDemo title="Vertical" />,

--- a/packages/website/src/pages/legacy/layout/Collapsible.tsx
+++ b/packages/website/src/pages/legacy/layout/Collapsible.tsx
@@ -9,7 +9,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 const CollapsibleDemos = () => (
     <PageLayout
         id="CollapsibleConnected"
-        componentSourcePath="/collapsible/CollapsibleConnected.tsx"
+        sourcePath="/packages/react/src/components/collapsible/CollapsibleConnected.tsx"
         title="Collapsible"
         section="Layout"
         description="A collapsible allows users to hide or display a section of content."

--- a/packages/website/src/pages/legacy/layout/IconCard.tsx
+++ b/packages/website/src/pages/legacy/layout/IconCard.tsx
@@ -13,7 +13,7 @@ export const IconCardDemos = () => (
         title="Icon Card"
         section="Layout"
         description="An icon card is an element that regroups related pieces of information together. It can be either static or interactive."
-        componentSourcePath="/iconCard/IconCard.tsx"
+        sourcePath="/packages/react/src/components/iconCard/IconCard.tsx"
         propsMetadata={IconCardMetadata}
         demo={<IconCardDemo center />}
         examples={{

--- a/packages/website/src/pages/legacy/layout/InfoBox.tsx
+++ b/packages/website/src/pages/legacy/layout/InfoBox.tsx
@@ -11,7 +11,7 @@ export const InfoBoxDemos: FunctionComponent = () => (
         title="Info Box"
         section="Layout"
         description="An info box displays contextual information."
-        componentSourcePath="/infoBox/InfoBox.tsx"
+        sourcePath="/packages/react/src/components/infoBox/InfoBox.tsx"
         demo={<InfoBoxDemo />}
         examples={{
             warning: <InfoBoxWarningDemo title="Warning InfoBox" />,

--- a/packages/website/src/pages/legacy/layout/LabeledValue.tsx
+++ b/packages/website/src/pages/legacy/layout/LabeledValue.tsx
@@ -8,7 +8,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 const LabeledValueDemos = () => (
     <PageLayout
         id="LabeledValue"
-        componentSourcePath="/labeledValue/LabeledValue.tsx"
+        sourcePath="/packages/react/src/components/labeledValue/LabeledValue.tsx"
         title="Labeled value"
         section="Layout"
         thumbnail="placeholder"

--- a/packages/website/src/pages/legacy/layout/Limit.tsx
+++ b/packages/website/src/pages/legacy/layout/Limit.tsx
@@ -10,7 +10,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 const LimitDemos = () => (
     <PageLayout
         id="Limit"
-        componentSourcePath="/limit/Limit.tsx"
+        sourcePath="/packages/react/src/components/limit/Limit.tsx"
         title="Limit card"
         section="Layout"
         description="A limit card displays the limit and usage of a resource. It includes a bar illustrating the usage against the limit."

--- a/packages/website/src/pages/legacy/layout/ModalWindow.tsx
+++ b/packages/website/src/pages/legacy/layout/ModalWindow.tsx
@@ -13,7 +13,7 @@ const ModalWindowDemos = () => (
         title="Modal Window"
         section="Layout"
         description="A modal appears over the current context to have users focus on a particular task or information."
-        componentSourcePath="/modal/ModalComposite.tsx"
+        sourcePath="/packages/react/src/components/modal/ModalComposite.tsx"
         propsMetadata={ModalCompositeConnectedMetadata}
         demo={<ModalWindowDemo />}
         examples={{

--- a/packages/website/src/pages/legacy/layout/ModalWizard.tsx
+++ b/packages/website/src/pages/legacy/layout/ModalWizard.tsx
@@ -10,7 +10,7 @@ export const ModalWizardDemos = () => (
         title="Modal Wizard"
         section="Layout"
         description="A modal wizard guides users through a task by presenting a succession of actions to complete."
-        componentSourcePath="/modalWizard/ModalWizard.tsx"
+        sourcePath="/packages/react/src/components/modalWizard/ModalWizard.tsx"
         demo={<ModalWizardDemo />}
         propsMetadata={ModalWizardMetadata}
         examples={{withValidationIds: <ModalWizardWithValidationIdsDemo title="Using validation ids" />}}

--- a/packages/website/src/pages/legacy/layout/PageHeader.tsx
+++ b/packages/website/src/pages/legacy/layout/PageHeader.tsx
@@ -7,7 +7,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const PageHeaderDemos = () => (
     <PageLayout
         id="BasicHeader"
-        componentSourcePath="/headers/BasicHeader.tsx"
+        sourcePath="/packages/react/src/components/headers/BasicHeader.tsx"
         title="Page header"
         section="Layout"
         description="A page header informs a user of the section of the product they are currently in. It includes a breadcrumb and optional tabs."

--- a/packages/website/src/pages/legacy/layout/Section.tsx
+++ b/packages/website/src/pages/legacy/layout/Section.tsx
@@ -8,7 +8,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 const SectionDemos = () => (
     <PageLayout
         id="Section"
-        componentSourcePath="/section/Section.tsx"
+        sourcePath="/packages/react/src/components/section/Section.tsx"
         title="Section"
         section="Layout"
         thumbnail="placeholder"

--- a/packages/website/src/pages/legacy/layout/SplitLayout.tsx
+++ b/packages/website/src/pages/legacy/layout/SplitLayout.tsx
@@ -10,7 +10,7 @@ const SplitLayoutDemos = () => (
         title="Split Layout"
         section="Layout"
         description="A split layout organizes information in two vertical columns."
-        componentSourcePath="/splitlayout/SplitLayout.tsx"
+        sourcePath="/packages/react/src/components/splitlayout/SplitLayout.tsx"
         demo={<SplitLayoutDemo />}
         layout="vertical"
         propsMetadata={SplitLayoutMetadata}

--- a/packages/website/src/pages/legacy/layout/StickyFooter.tsx
+++ b/packages/website/src/pages/legacy/layout/StickyFooter.tsx
@@ -9,7 +9,7 @@ const Demo = () => (
         title="Sticky Footer"
         section="Layout"
         description="A page footer that sticks to the bottom of the screen"
-        componentSourcePath="/stickyFooter/StickyFooter.tsx"
+        sourcePath="/packages/react/src/components/stickyFooter/StickyFooter.tsx"
         propsMetadata={StickyFooterLegacyMetadata}
         demo={<StickyFooterDemo />}
     />

--- a/packages/website/src/pages/legacy/layout/Table.tsx
+++ b/packages/website/src/pages/legacy/layout/Table.tsx
@@ -15,7 +15,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 const TableDemos = () => (
     <PageLayout
         id="TableHOC"
-        componentSourcePath="/table-hoc/TableHOC.tsx"
+        sourcePath="/packages/react/src/components/table-hoc/TableHOC.tsx"
         title="Table"
         section="Layout"
         description="A table displays large quantities of items or data in a list format. Filtering features and actions may be added."

--- a/packages/website/src/pages/legacy/navigation/Breadcrumbs.tsx
+++ b/packages/website/src/pages/legacy/navigation/Breadcrumbs.tsx
@@ -7,7 +7,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 const BreadcrumbsDemos = () => (
     <PageLayout
         id="BreadcrumbHeader"
-        componentSourcePath="/breadcrumbs/BreadcrumbHeader.tsx"
+        sourcePath="/packages/react/src/components/breadcrumbs/BreadcrumbHeader.tsx"
         title="Breadcrumbs"
         section="Navigation"
         description="A breadcrumb is a secondary navigation that helps users to understand the hierarchy of interfaces and navigate through them."

--- a/packages/website/src/pages/legacy/navigation/SideNavigation.tsx
+++ b/packages/website/src/pages/legacy/navigation/SideNavigation.tsx
@@ -8,7 +8,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const SideNavigationDemos = () => (
     <PageLayout
         id="SideNavigation"
-        componentSourcePath="/sideNavigation/SideNavigation.tsx"
+        sourcePath="/packages/react/src/components/sideNavigation/SideNavigation.tsx"
         title="SideNavigation"
         section="Navigation"
         description="A sidebar navigation is a primary navigation element that displays the architecture of the product’s features."

--- a/packages/website/src/pages/legacy/navigation/SubNavigation.tsx
+++ b/packages/website/src/pages/legacy/navigation/SubNavigation.tsx
@@ -9,7 +9,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const SubNavigationDemos = () => (
     <PageLayout
         id="SubNavigation"
-        componentSourcePath="/subNavigation/SubNavigation.tsx"
+        sourcePath="/packages/react/src/components/subNavigation/SubNavigation.tsx"
         title="SubNavigation"
         section="Navigation"
         description="A subnavigation is a secondary vertical navigation component that allows users to navigate between sections of the same interface."

--- a/packages/website/src/pages/legacy/navigation/Tabs.tsx
+++ b/packages/website/src/pages/legacy/navigation/Tabs.tsx
@@ -8,7 +8,7 @@ import {PageLayout} from '../../../building-blocs/PageLayout';
 export const TabsDemos: FunctionComponent = () => (
     <PageLayout
         id="Tab"
-        componentSourcePath="/tab/Tab.tsx"
+        sourcePath="/packages/react/src/components/tab/Tab.tsx"
         title="Tab"
         section="Navigation"
         description="A set of tabs allows users to navigate between sections of the same interface."


### PR DESCRIPTION
### Proposed Changes

Now that we have demo pages for components coming from more than one single package, it makes more sense to always specify the full path for the "View source code" github button

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
