### PR TITLE
feat(website): add CodeEditor examples for XML and python

### DIFF
--- a/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
@@ -1,0 +1,19 @@
+import {CodeEditor, useForm} from '@coveord/plasma-mantine';
+
+export default () => {
+    const form = useForm({
+        initialValues: {
+            code: 'def my_extension():\n\tprint("Not implemented yet.")\n\nmy_extension()',
+        },
+    });
+
+    return (
+        <CodeEditor
+            language="python"
+            label="Extension"
+            description="Define an extension using Python"
+            monacoLoader="cdn"
+            {...form.getInputProps('code')}
+        />
+    );
+};

--- a/packages/website/src/examples/form/code-editor/CodeEditorXML.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorXML.demo.tsx
@@ -3,17 +3,17 @@ import {CodeEditor, useForm} from '@coveord/plasma-mantine';
 export default () => {
     const form = useForm({
         initialValues: {
-            config: '<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em"><circle cx="8" cy="8" r="6.5" stroke="currentColor"/><path d="M5 8H11M8 5L8 11" stroke="currentColor" stroke-linecap="round"/></svg>',
+            markup: '<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em"><circle cx="8" cy="8" r="6.5" stroke="currentColor"/><path d="M5 8H11M8 5L8 11" stroke="currentColor" stroke-linecap="round"/></svg>',
         },
     });
 
     return (
         <CodeEditor
             language="xml"
-            label="Add icon svg"
+            label="Some XML structure"
             description="XML markup of the add icon svg"
             monacoLoader="cdn"
-            {...form.getInputProps('config')}
+            {...form.getInputProps('markup')}
         />
     );
 };

--- a/packages/website/src/pages/form/CodeEditor.tsx
+++ b/packages/website/src/pages/form/CodeEditor.tsx
@@ -1,5 +1,7 @@
 import {CodeEditorMetadata} from '@coveord/plasma-components-props-analyzer';
 import CodeEditorDemo from '@examples/form/code-editor/CodeEditor.demo.tsx';
+import CodeEditorPythonDemo from '@examples/form/code-editor/CodeEditorPython.demo.tsx';
+import CodeEditorXMLDemo from '@examples/form/code-editor/CodeEditorXML.demo.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -13,6 +15,10 @@ const CodeEditorPage = () => (
         thumbnail="codeEditor"
         propsMetadata={CodeEditorMetadata}
         demo={<CodeEditorDemo grow />}
+        examples={{
+            python: <CodeEditorPythonDemo grow title="Python language" />,
+            xml: <CodeEditorXMLDemo grow title="XML language" />,
+        }}
     />
 );
 


### PR DESCRIPTION
### Proposed Changes

Add examples for the CodeEditor component with XML and Python languages

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
