### PR TITLE
fix(mantine form): override getinputprops and use in collection

### DIFF
--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -18,7 +18,8 @@
         "clean": "rimraf dist",
         "start": "node ../../scripts/start",
         "test": "jest --maxWorkers=65%",
-        "test:watch": "jest --watchAll"
+        "test:watch": "jest --watchAll",
+        "test:debug": "node --inspect-brk node_modules/jest/bin/jest --runInBand --watchAll --detectOpenHandles --forceExit"
     },
     "dependencies": {
         "@coveord/plasma-react-icons": "workspace:*",

--- a/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
+++ b/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
@@ -1,7 +1,7 @@
-import {useForm} from '@mantine/form';
 import {render, screen, userEvent, within} from '@test-utils';
 import {useState} from 'react';
 
+import {useForm} from '../../../form';
 import {Collection} from '../Collection';
 
 describe('Collection', () => {

--- a/packages/mantine/src/form/FormProvider.tsx
+++ b/packages/mantine/src/form/FormProvider.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable prefer-arrow/prefer-arrow-functions */
+import {_TransformValues, UseForm, UseFormReturnType} from '@mantine/form/lib/types';
+import React, {createContext, useContext} from 'react';
+
+import {useForm} from './useForm';
+
+export interface FormProviderProps<Form> {
+    form: Form;
+    children: React.ReactNode;
+}
+
+export function createFormContext<
+    Values,
+    TransformValues extends _TransformValues<Values> = (values: Values) => Values
+>() {
+    type Form = UseFormReturnType<Values, TransformValues>;
+
+    const FormContext = createContext<Form>(null);
+
+    function FormProvider({form, children}: FormProviderProps<Form>) {
+        return <FormContext.Provider value={form}>{children}</FormContext.Provider>;
+    }
+
+    function useFormContext() {
+        const ctx = useContext(FormContext);
+        if (!ctx) {
+            throw new Error('useFormContext was called outside of FormProvider context');
+        }
+
+        return ctx;
+    }
+
+    return [FormProvider, useFormContext, useForm] as [
+        React.FC<FormProviderProps<Form>>,
+        () => Form,
+        UseForm<Values, TransformValues>
+    ];
+}

--- a/packages/mantine/src/form/index.ts
+++ b/packages/mantine/src/form/index.ts
@@ -1,0 +1,2 @@
+export * from './useForm';
+export * from './FormProvider';

--- a/packages/mantine/src/form/useForm.ts
+++ b/packages/mantine/src/form/useForm.ts
@@ -1,0 +1,26 @@
+import {useForm as useMantineForm} from '@mantine/form';
+import {GetInputProps} from '@mantine/form/lib/types';
+
+export const useForm: typeof useMantineForm = (options) => {
+    const form = useMantineForm(options);
+
+    const getInputProps: GetInputProps<Record<string, unknown>> = (
+        path,
+        {type = 'input', withError = type === 'input', withFocus = true} = {}
+    ) => {
+        const originalPayload = form.getInputProps(path, {type, withError, withFocus});
+        if (Array.isArray(originalPayload.value)) {
+            return {
+                ...originalPayload,
+                onReorderItem: (payload: Record<'from' | 'to', number>) => form.reorderListItem(path, payload),
+                onRemoveItem: (index: number) => form.removeListItem(path, index),
+                onInsertItem: (valueToInsert: unknown, index: number) =>
+                    form.insertListItem(path, valueToInsert, index),
+            };
+        }
+
+        return originalPayload;
+    };
+
+    return {...form, getInputProps};
+};

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -4,13 +4,15 @@ import {PlasmaColors} from './theme/PlasmaColors';
 
 export * from '@mantine/carousel';
 export * from '@mantine/core';
-export * from '@mantine/form';
 export type {FormValidateInput} from '@mantine/form/lib/types';
 export * from '@mantine/hooks';
 export {createColumnHelper, type ColumnDef} from '@tanstack/table-core';
 export * from './components';
+export * from '@mantine/form';
 // explicitly overriding mantine components
 export {Header, Table, type HeaderProps, Modal} from './components';
+export {useForm, createFormContext} from './form';
+
 export * from './theme';
 
 declare module '@mantine/core' {


### PR DESCRIPTION
## [UITOOL-1030](https://coveord.atlassian.net/browse/UITOOL-1030)

### Description

Override of UseForm to front a `getInputProps` addapted to arrays

### Potential Breaking Changes

The controlled Collection component will not leverage the onChange prop anymore. Thus Collection components controlled manually with the `onChange` prop will break

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[UITOOL-1030]: https://coveord.atlassian.net/browse/UITOOL-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ