### PR TITLE
feat(mantine): implement row multi selection on table component

### DIFF
--- a/packages/mantine/src/components/table/TableActions.tsx
+++ b/packages/mantine/src/components/table/TableActions.tsx
@@ -3,9 +3,9 @@ import {useTable} from './useTable';
 
 interface TableActionsProps<T> {
     /**
-     * Function that return components for the selected row
+     * Function that return components for the selected row or selected rows when multi row selection is enabled
      *
-     * @param datum the data of the selected row
+     * @param datum the data of the selected row(s)
      * @example
      * <Table.Actions<MyType>>
      *     {(datum: MyType) => (
@@ -21,16 +21,16 @@ interface TableActionsProps<T> {
      *     )}
      * </Table.Actions>
      */
-    children: (datum: T) => ReactNode;
+    children: ((datum: T) => ReactNode) | ((data: T[]) => ReactNode);
 }
 
 export const TableActions = <T,>({children}: TableActionsProps<T>): ReactElement => {
-    const {getSelectedRow} = useTable();
-    const selectedRow = getSelectedRow();
+    const {getSelectedRows, multiRowSelectionEnabled} = useTable();
+    const selectedRows = getSelectedRows();
 
-    if (!selectedRow) {
+    if (selectedRows.length <= 0) {
         return null;
     }
 
-    return <>{children(selectedRow)}</>;
+    return <>{children(multiRowSelectionEnabled ? selectedRows : selectedRows[0])}</>;
 };

--- a/packages/mantine/src/components/table/TableCollapsibleColumn.tsx
+++ b/packages/mantine/src/components/table/TableCollapsibleColumn.tsx
@@ -4,12 +4,12 @@ import {ColumnDef} from '@tanstack/table-core';
 import {MouseEvent as ReactMouseEvent} from 'react';
 
 /**
- * Generic column to use when your table need collapsible rows
+ * Generic column to use when your table needs collapsible rows
  */
 export const TableCollapsibleColumn: ColumnDef<unknown> = {
     id: 'collapsible',
-    header: '',
     enableSorting: false,
+    header: '',
     cell: (info) => {
         const handler = info.row.getToggleExpandedHandler();
         const onClick = (e: ReactMouseEvent<HTMLButtonElement>) => {

--- a/packages/mantine/src/components/table/TableContext.tsx
+++ b/packages/mantine/src/components/table/TableContext.tsx
@@ -40,9 +40,13 @@ type TableContextType = {
      */
     clearFilters: () => void;
     /**
-     * Function that returns the selected row if any
+     * Function that returns the selected row if any.
      */
     getSelectedRow: () => any | null;
+    /**
+     * Function that returns an array of the selected rows. Most useful when multi row selection is enabled.
+     */
+    getSelectedRows: () => any[];
     /**
      * Function that clear the selected row
      */
@@ -55,6 +59,7 @@ type TableContextType = {
      * Table container ref
      */
     containerRef: RefObject<HTMLDivElement>;
+    multiRowSelectionEnabled: boolean;
 };
 
 export const TableContext = createContext<TableContextType | null>(null);

--- a/packages/mantine/src/components/table/TableFilter.tsx
+++ b/packages/mantine/src/components/table/TableFilter.tsx
@@ -35,7 +35,13 @@ export const TableFilter: FunctionComponent<TableFilterProps> = ({
 
     const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
         const {value} = event.currentTarget;
-        setState((prevState: TableState) => ({...prevState, globalFilter: value}));
+        setState((prevState: TableState) => ({
+            ...prevState,
+            pagination: prevState.pagination
+                ? {pageIndex: 0, pageSize: prevState.pagination.pageSize}
+                : prevState.pagination,
+            globalFilter: value,
+        }));
     };
 
     return (

--- a/packages/mantine/src/components/table/TableHeader.tsx
+++ b/packages/mantine/src/components/table/TableHeader.tsx
@@ -1,5 +1,8 @@
-import {createStyles, DefaultProps, Group, Selectors} from '@mantine/core';
+import {CrossSize16Px} from '@coveord/plasma-react-icons';
+import {Button, createStyles, DefaultProps, Group, Selectors, Space, Tooltip} from '@mantine/core';
 import {FunctionComponent, ReactNode} from 'react';
+
+import {useTable} from './useTable';
 
 const useStyles = createStyles((theme) => ({
     root: {
@@ -7,7 +10,7 @@ const useStyles = createStyles((theme) => ({
         top: 0,
         zIndex: 13, // skeleton is 11
         backgroundColor: theme.colors.gray[1],
-        borderBottom: `1px solid ${theme.colors.gray[4]}`,
+        borderBottom: `1px solid ${theme.colors.gray[3]}`,
     },
 }));
 
@@ -23,9 +26,26 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
     children,
     ...others
 }) => {
+    const {getSelectedRows, multiRowSelectionEnabled, clearSelection} = useTable();
     const {classes} = useStyles(null, {name: 'TableHeader', classNames, styles, unstyled});
-    return (
-        <Group position="right" spacing="lg" className={classes.root} px="md" py="sm" {...others}>
+    const selectedRows = getSelectedRows();
+    return multiRowSelectionEnabled ? (
+        <Group position="apart" className={classes.root}>
+            {selectedRows.length > 0 ? (
+                <Tooltip label="Unselect all">
+                    <Button onClick={clearSelection} ml="lg" variant="subtle" leftIcon={<CrossSize16Px height={16} />}>
+                        {selectedRows.length} selected
+                    </Button>
+                </Tooltip>
+            ) : (
+                <Space />
+            )}
+            <Group position="right" spacing="lg" px="md" py="sm" {...others}>
+                {children}
+            </Group>
+        </Group>
+    ) : (
+        <Group position="right" spacing="lg" px="md" py="sm" className={classes.root} {...others}>
             {children}
         </Group>
     );

--- a/packages/mantine/src/components/table/TableSelectableColumn.tsx
+++ b/packages/mantine/src/components/table/TableSelectableColumn.tsx
@@ -1,0 +1,33 @@
+import {Checkbox, Tooltip} from '@mantine/core';
+import {ColumnDef} from '@tanstack/table-core';
+
+/**
+ * Generic column to use when your table needs multi selection of rows
+ */
+export const TableSelectableColumn: ColumnDef<unknown> = {
+    id: 'select',
+    enableSorting: false,
+    header: ({table}) => {
+        const label = table.getIsAllRowsSelected() ? 'Unselect all from this page' : 'Select all from this page';
+        return (
+            <Tooltip label={label}>
+                <Checkbox
+                    checked={table.getIsAllPageRowsSelected()}
+                    indeterminate={table.getIsSomePageRowsSelected()}
+                    onChange={table.getToggleAllPageRowsSelectedHandler()}
+                    sx={{display: 'flex'}}
+                    aria-label={label}
+                />
+            </Tooltip>
+        );
+    },
+    cell: ({row}) => (
+        <Checkbox
+            checked={row.getIsSelected()}
+            indeterminate={row.getIsSomeSelected()}
+            onChange={row.getToggleSelectedHandler()}
+            sx={{display: 'flex'}}
+            aria-label="Select row"
+        />
+    ),
+};

--- a/packages/mantine/src/components/table/Th.tsx
+++ b/packages/mantine/src/components/table/Th.tsx
@@ -4,27 +4,16 @@ import {defaultColumnSizing, flexRender, Header} from '@tanstack/react-table';
 
 const useStyles = createStyles((theme) => ({
     th: {
-        padding: '0 !important',
         fontWeight: '400 !important' as any,
+        padding: '0 !important',
         color: theme.black + '!important',
-        button: {
-            padding: '8px 16px',
-            div: {
-                padding: '0px !important',
-            },
-        },
-        div: {
-            padding: '8px 16px',
-        },
-    },
-
-    noSort: {
-        padding: `${theme.spacing.xs}px ${theme.spacing.md}px`,
+        verticalAlign: 'middle',
     },
 
     control: {
         width: '100%',
-        padding: `${theme.spacing.xs}px ${theme.spacing.md}px`,
+        padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+        whiteSpace: 'nowrap',
 
         '&:hover': {
             backgroundColor: theme.colorScheme === 'dark' ? theme.colors.gray[6] : theme.colors.gray[2],
@@ -58,9 +47,7 @@ export const Th = <T,>({header}: ThProps<T>) => {
     if (!header.column.getCanSort()) {
         return (
             <th className={classes.th} style={{width}}>
-                <Text className={classes.noSort} size="xs">
-                    {flexRender(header.column.columnDef.header, header.getContext())}
-                </Text>
+                <Text size="xs">{flexRender(header.column.columnDef.header, header.getContext())}</Text>
             </th>
         );
     }
@@ -72,7 +59,7 @@ export const Th = <T,>({header}: ThProps<T>) => {
     return (
         <th className={classes.th} style={{width}} aria-sort={sortingOrder ? SortingLabels[sortingOrder] : 'none'}>
             <UnstyledButton onClick={onSort} className={classes.control}>
-                <Group position="apart">
+                <Group position="apart" noWrap>
                     <Text size="xs">{flexRender(header.column.columnDef.header, header.getContext())}</Text>
                     <Center sx={(theme) => ({color: sortingOrder ? theme.colors.action[8] : undefined})}>
                         <Icon height={14} />

--- a/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
@@ -34,4 +34,25 @@ describe('Table.Actions', () => {
         expect(screen.queryByRole('button', {name: 'Eat fruit'})).not.toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Eat vegetable'})).toBeVisible();
     });
+
+    describe('when multi row selection is enabled', () => {
+        it('passes down an array of selected rows', async () => {
+            const user = userEvent.setup({delay: null});
+            const renderSpy = jest.fn().mockImplementation(() => <div />);
+            render(
+                <Table<RowData>
+                    data={[{name: 'fruit'}, {name: 'vegetable'}, {name: 'bread'}]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                >
+                    <Table.Header>
+                        <Table.Actions>{renderSpy}</Table.Actions>
+                    </Table.Header>
+                </Table>
+            );
+            await user.click(screen.getByRole('cell', {name: 'fruit'}));
+            await user.click(screen.getByRole('cell', {name: 'vegetable'}));
+            expect(renderSpy).toHaveBeenCalledWith([{name: 'fruit'}, {name: 'vegetable'}]);
+        });
+    });
 });

--- a/packages/mantine/src/components/table/useRowSelection.ts
+++ b/packages/mantine/src/components/table/useRowSelection.ts
@@ -1,0 +1,45 @@
+import {functionalUpdate, Table} from '@tanstack/table-core';
+import {useState} from 'react';
+
+export const useRowSelection = <T>(table: Table<T>) => {
+    const [rowSelection, setRowSelection] = useState<Record<string, T>>({});
+
+    table.setOptions((prev) => ({
+        ...prev,
+        onRowSelectionChange: (rowSelectionUpdater) => {
+            table.setState((old) => {
+                const selectedRowsIds = functionalUpdate(rowSelectionUpdater, old['rowSelection']);
+                setRowSelection((current) => {
+                    const currentRowsById = table.getRowModel().rowsById;
+                    return Object.keys(selectedRowsIds).reduce((memo, rowId) => {
+                        if (current[rowId]) {
+                            memo[rowId] = current[rowId];
+                        } else {
+                            memo[rowId] = currentRowsById[rowId].original;
+                        }
+                        return memo;
+                    }, {} as Record<string, T>);
+                });
+
+                return {
+                    ...old,
+                    rowSelection: selectedRowsIds,
+                };
+            });
+        },
+    }));
+
+    const clearSelection = () => {
+        table.resetRowSelection(true);
+    };
+
+    const getSelectedRows = () => Object.values(rowSelection);
+
+    const getSelectedRow = () => getSelectedRows()[0] ?? null;
+
+    return {
+        clearSelection,
+        getSelectedRow,
+        getSelectedRows,
+    };
+};

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -26,7 +26,7 @@ interface DemoProps extends DemoComponentProps {
     children?: ReactNode;
 }
 
-const useStyles = createStyles((theme, {grow}: DemoComponentProps) => ({
+const useStyles = createStyles((theme, {grow, noPadding}: DemoComponentProps) => ({
     root: {},
     sandbox: {
         border: `1px solid ${theme.colors.gray[3]}`,
@@ -49,7 +49,7 @@ const useStyles = createStyles((theme, {grow}: DemoComponentProps) => ({
         minHeight: 100,
     },
     previewWrapper: {
-        padding: theme.spacing.md,
+        padding: noPadding ? 0 : theme.spacing.md,
         height: grow ? MAX_HEIGHT : '100%',
     },
     code: {
@@ -59,8 +59,8 @@ const useStyles = createStyles((theme, {grow}: DemoComponentProps) => ({
     },
 }));
 
-const Demo = ({children, snippet, center = false, grow = false, title, layout}: DemoProps) => {
-    const {classes} = useStyles({center, grow});
+const Demo = ({children, snippet, center = false, grow = false, title, layout, noPadding}: DemoProps) => {
+    const {classes} = useStyles({center, grow, noPadding});
     const clipboard = useClipboard();
     const sandboxLink = getCodeSandboxLink(snippet);
     return (

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -9,6 +9,7 @@ import {
     Title,
     useTable,
 } from '@coveord/plasma-mantine';
+import {EditSize16Px} from '@coveord/plasma-react-icons';
 import {FunctionComponent, useState} from 'react';
 
 interface IExampleRowData {
@@ -66,6 +67,7 @@ export default () => {
     return (
         <Table
             data={data}
+            getRowId={({id}) => id.toString()}
             columns={columns}
             noDataChildren={<NoData />}
             onMount={(state) => {
@@ -121,8 +123,16 @@ const DatePickerPresets: Record<string, DateRangePickerPreset> = {
 
 const TableActions: FunctionComponent<{datum: IExampleRowData}> = ({datum}) => {
     const actionCondition = datum.id % 2 === 0 ? true : false;
-    const pressedAction = () => alert('Some action is triggered!');
-    return <>{actionCondition ? <Button onClick={pressedAction}>Action!</Button> : null}</>;
+    const pressedAction = () => alert('Edit action is triggered!');
+    return (
+        <>
+            {actionCondition ? (
+                <Button variant="subtle" onClick={pressedAction} leftIcon={<EditSize16Px height={16} />}>
+                    Edit
+                </Button>
+            ) : null}
+        </>
+    );
 };
 
 const UserPredicate: FunctionComponent = () => (

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -1,0 +1,116 @@
+import {BlankSlate, Button, ColumnDef, createColumnHelper, Table, Title, useTable} from '@coveord/plasma-mantine';
+import {DeleteSize16Px, EditSize16Px} from '@coveord/plasma-react-icons';
+import {FunctionComponent, useState} from 'react';
+
+interface IExampleRowData {
+    userId: number;
+    id: number;
+    title: string;
+    body: string;
+}
+
+export default () => {
+    const columnHelper = createColumnHelper<IExampleRowData>();
+    const columns: Array<ColumnDef<IExampleRowData>> = [
+        columnHelper.accessor('userId', {
+            header: 'User ID',
+            cell: (info) => info.row.original.userId,
+        }),
+        columnHelper.accessor('title', {
+            header: 'Title',
+            cell: (info) => info.row.original.title,
+        }),
+    ];
+    const [data, setData] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [pages, setPages] = useState(1);
+
+    const fetchData = (state: any) => {
+        setLoading(true);
+        const searchParams = new URLSearchParams({
+            _page: state.pagination.pageIndex + 1,
+            _limit: state.pagination.pageSize,
+            title_like: state.globalFilter,
+        });
+        if (!state.globalFilter) {
+            searchParams.delete('title_like');
+        }
+        fetch(`https://jsonplaceholder.typicode.com/posts?${searchParams.toString()}`)
+            .then((response) => response.json())
+            .then((json) => setData(json))
+            .then(() => setPages(Math.ceil(100 / state.pagination?.pageSize)))
+            .catch((e) => console.log(e));
+        setLoading(false);
+    };
+
+    return (
+        <Table<IExampleRowData>
+            data={data}
+            getRowId={({id}) => id.toString()}
+            columns={columns}
+            noDataChildren={<NoData />}
+            onMount={(state) => {
+                fetchData(state);
+            }}
+            onChange={(state) => {
+                fetchData(state);
+            }}
+            loading={loading}
+            multiRowSelectionEnabled
+        >
+            <Table.Header>
+                <Table.Actions>
+                    {(selectedRows: IExampleRowData[]) => <TableActions data={selectedRows} />}
+                </Table.Actions>
+                <Table.Filter placeholder="Search posts by title" />
+            </Table.Header>
+            <Table.Footer>
+                <Table.PerPage />
+                <Table.Pagination totalPages={pages} />
+            </Table.Footer>
+        </Table>
+    );
+};
+
+const NoData: FunctionComponent = () => {
+    const {state, form, clearFilters} = useTable();
+    const isFiltered = !!state.globalFilter || !!form.values.predicates.user;
+
+    return isFiltered ? (
+        <BlankSlate>
+            <Title order={4}>No data found for those filters</Title>
+            <Button onClick={clearFilters}>Clear filters</Button>
+        </BlankSlate>
+    ) : (
+        <BlankSlate>
+            <Title order={4}>No Data</Title>
+        </BlankSlate>
+    );
+};
+
+const TableActions: FunctionComponent<{data: IExampleRowData[]}> = ({data}) => {
+    if (data.length === 1) {
+        return (
+            <Button
+                variant="subtle"
+                onClick={() => alert(`Action triggered on a single row: ${data[0].id}`)}
+                leftIcon={<EditSize16Px height={16} />}
+            >
+                Single row action
+            </Button>
+        );
+    }
+    if (data.length > 1) {
+        return (
+            <Button
+                variant="subtle"
+                onClick={() => alert(`Bulk action triggered on multiple rows: ${data.map(({id}) => id).join(', ')}`)}
+                leftIcon={<DeleteSize16Px height={16} />}
+            >
+                Bulk action
+            </Button>
+        );
+    }
+
+    return null;
+};

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -1,9 +1,10 @@
 import {TableMetadata} from '@coveord/plasma-components-props-analyzer';
 import TableDemo from '@examples/layout/Table/Table.demo.tsx';
+import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
-export default () => (
+const DemoPage = () => (
     <PageLayout
         section="Layout"
         title="Table"
@@ -11,6 +12,11 @@ export default () => (
         description="A table displays large quantities of items or data in a list format. Filtering features, date picker, collapsible rows and actions may be added."
         id="Table"
         propsMetadata={TableMetadata}
-        demo={<TableDemo layout="vertical" />}
+        demo={<TableDemo noPadding layout="vertical" />}
+        examples={{
+            multiSelect: <TableMultiSelectionDemo noPadding title="Table with bulk selection of rows" />,
+        }}
     />
 );
+
+export default DemoPage;

--- a/packages/website/types/custom/index.d.ts
+++ b/packages/website/types/custom/index.d.ts
@@ -20,6 +20,7 @@ interface DemoComponentProps {
     center?: boolean;
     grow?: boolean;
     title?: string;
+    noPadding?: boolean;
     layout?: 'horizontal' | 'vertical';
 }
 


### PR DESCRIPTION
### Proposed Changes

Implemented multi selection of table rows which enables the user to perform actions in bulk.

The user only needs to set the `multiRowSelectionEnabled` prop on his table component to see this new behaviour activated on his table, and adjust his Table.Actions render function to accept an array of selected rows.

### Potential Breaking Changes

None, existing tables with single selection of row shouldn't be affected by this change.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
