### PR TITLE
fix(mantine): standardize input wrapper styles

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -143,9 +143,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     ) : null;
 
     const _description = description ? (
-        <Input.Description mt="xs" {...descriptionProps}>
-            {description}
-        </Input.Description>
+        <Input.Description {...descriptionProps}>{description}</Input.Description>
     ) : null;
 
     const _error = error ? (

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -165,10 +165,10 @@ export const Collection = <T,>(props: CollectionProps<T>) => {
     const _error = error ? <Input.Error {...errorProps}>{error}</Input.Error> : null;
     const _header =
         _label || _description ? (
-            <Stack spacing="xs">
+            <Box mb="sm">
                 {_label}
                 {_description}
-            </Stack>
+            </Box>
         ) : null;
 
     const items = values.map((item, index) => (
@@ -216,14 +216,12 @@ export const Collection = <T,>(props: CollectionProps<T>) => {
                         className={cx(classes.root, className)}
                         {...others}
                     >
-                        <Stack>
-                            {_header}
-                            <Stack spacing={spacing}>
-                                {items}
-                                {provided.placeholder}
-                                {_addButton}
-                                {_error}
-                            </Stack>
+                        {_header}
+                        <Stack spacing={spacing}>
+                            {items}
+                            {provided.placeholder}
+                            {_addButton}
+                            {_error}
                         </Stack>
                     </Box>
                 )}

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -5,6 +5,7 @@ import {ButtonStylesParams, MantineThemeOverride, ModalStylesParams} from '@mant
 import {PlasmaColors} from './PlasmaColors';
 
 export const plasmaTheme: MantineThemeOverride = {
+    // These are overrides over https://github.com/mantinedev/mantine/blob/master/src/mantine-styles/src/theme/default-theme.ts
     colorScheme: 'light',
     fontFamily: 'canada-type-gibson, sans-serif',
     black: color.primary.gray[9],
@@ -59,7 +60,7 @@ export const plasmaTheme: MantineThemeOverride = {
         Button: {
             styles: (theme, params: ButtonStylesParams) => ({
                 root: {
-                    '&': {fontWeight: 400},
+                    fontWeight: 400,
                     backgroundColor: params.variant === 'outline' ? 'white' : undefined,
                 },
             }),
@@ -81,17 +82,23 @@ export const plasmaTheme: MantineThemeOverride = {
             defaultProps: {
                 withAsterisk: false,
             },
+            styles: (theme) => ({
+                label: {
+                    marginBottom: theme.spacing.xs,
+                    lineHeight: '20px',
+                },
+                description: {
+                    lineHeight: '20px',
+                    fontSize: theme.fontSizes.sm,
+                    color: theme.colors.gray[7],
+                    marginBottom: theme.spacing.xs,
+                },
+            }),
         },
         TextInput: {
             defaultProps: {
                 radius: 8,
             },
-            styles: (theme) => ({
-                description: {
-                    fontSize: 'inherit',
-                    paddingBottom: theme.spacing.xs,
-                },
-            }),
         },
         Tooltip: {
             defaultProps: {


### PR DESCRIPTION
### Proposed Changes

Standardize input wrapper (label, description) styles.

Before
<img width="1597" alt="image" src="https://user-images.githubusercontent.com/35579930/207980741-c6640f8b-cb08-43bb-9a3f-58449461a3ba.png">


After
<img width="1598" alt="image" src="https://user-images.githubusercontent.com/35579930/207980412-4ddb29b1-31da-4b7f-901f-a0c3d796c952.png">



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
