### PR TITLE
fix(CodeEditor, Mantine):  local monaco should not load via cdn

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -17,7 +17,7 @@ import {
     useComponentDefaultProps,
 } from '@mantine/core';
 import {useUncontrolled} from '@mantine/hooks';
-import Editor, {loader, useMonaco} from '@monaco-editor/react';
+import Editor, {loader, Monaco} from '@monaco-editor/react';
 import {FunctionComponent, useEffect, useState} from 'react';
 
 import {useParentHeight} from '../../hooks';
@@ -104,8 +104,6 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         ...others
     } = useComponentDefaultProps('CodeEditor', defaultProps, props);
     const [loaded, setLoaded] = useState(false);
-    const [registered, setRegistered] = useState(false);
-    const monaco = useMonaco();
     const {classes, theme} = useStyles();
     const [_value, handleChange] = useUncontrolled<string>({
         value,
@@ -121,6 +119,12 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         setLoaded(true);
     };
 
+    const registerLanguages = (monaco: Monaco) => {
+        if (monaco && language === 'xml') {
+            XML.register(monaco);
+        }
+    };
+
     useEffect(() => {
         if (monacoLoader === 'local') {
             loadLocalMonaco();
@@ -128,13 +132,6 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
             setLoaded(true);
         }
     }, []);
-
-    useEffect(() => {
-        if (monaco && language === 'xml' && !registered) {
-            XML.register(monaco);
-            setRegistered(true);
-        }
-    }, [monaco, language]);
 
     const _label = label ? (
         <Input.Label required={required} {...labelProps}>
@@ -195,7 +192,8 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                 }}
                 value={_value}
                 onChange={handleChange}
-                onMount={(editor) => {
+                onMount={(editor, monaco) => {
+                    registerLanguages(monaco);
                     editor.onDidFocusEditorText(onFocus);
                     editor.onDidBlurEditorText(async () => {
                         await editor.getAction('editor.action.formatDocument').run();

--- a/packages/mantine/src/components/code-editor/__mocks__/@monaco-editor/react.tsx
+++ b/packages/mantine/src/components/code-editor/__mocks__/@monaco-editor/react.tsx
@@ -1,7 +1,19 @@
 import {EditorProps} from '@monaco-editor/react';
-import {FunctionComponent} from 'react';
+import {FunctionComponent, useEffect} from 'react';
 
-const MockedEditor: FunctionComponent<EditorProps> = (props) => <div data-testid="monaco-editor" />;
+const editor: any = {
+    onDidFocusEditorText: jest.fn(),
+    onDidBlurEditorText: jest.fn(),
+};
+
+const monaco: any = jest.fn();
+
+const MockedEditor: FunctionComponent<EditorProps> = (props) => {
+    useEffect(() => {
+        props.onMount(editor, monaco);
+    }, []);
+    return <div data-testid="monaco-editor" />;
+};
 
 export default MockedEditor;
 

--- a/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
+++ b/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
@@ -55,7 +55,7 @@ describe('CodeEditor', () => {
         expect(screen.getByTestId('monaco-editor')).toBeInTheDocument();
     });
 
-    it('loads the xml language in the monaco instance if the editor language is xml', () => {
+    it('loads the xml language in the monaco instance if the editor language is xml', async () => {
         const xmlLanguageSpy = jest.spyOn(XML, 'register').mockImplementation();
         render(<CodeEditor label="label" description="description" monacoLoader="cdn" language="xml" />);
         expect(xmlLanguageSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-1056

The useMonaco hook was using the CDN event when using the local version so I removed it.

### Potential Breaking Changes

None
### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
