### PR TITLE
fix(RangePickerInlineCalendar, Mantine):  allow single day range

### DIFF
--- a/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
+++ b/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
@@ -55,6 +55,9 @@ export const DateRangePickerInlineCalendar = ({
     const calendarInputProps = form.getInputProps('dates');
 
     const onCalendarApply = () => {
+        if (!form.values.dates[1]) {
+            form.values.dates[1] = form.values.dates[0]; // when date range is the same day
+        }
         onApply(form.values.dates);
     };
 

--- a/packages/mantine/src/components/date-range-picker/__tests__/DateRangePickerInlineCalendar.spec.tsx
+++ b/packages/mantine/src/components/date-range-picker/__tests__/DateRangePickerInlineCalendar.spec.tsx
@@ -73,6 +73,20 @@ describe('DateRangePickerInlineCalendar', () => {
         jest.useRealTimers();
     });
 
+    it('set end date same as start date if only one date is selected when clicking in the calendar', async () => {
+        const user = userEvent.setup({delay: null});
+        jest.useFakeTimers().setSystemTime(new Date(2022, 0, 31));
+        const onApply = jest.fn();
+        render(<DateRangePickerInlineCalendar initialRange={[null, null]} onApply={onApply} onCancel={jest.fn()} />);
+
+        await user.click(screen.getAllByRole('button', {name: '8'})[0]);
+        await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+        expect(onApply).toHaveBeenCalledWith([new Date(2022, 0, 8), new Date(2022, 0, 8)]);
+
+        jest.useRealTimers();
+    });
+
     it('calls onApply with the selected dates when typing in the inputs', async () => {
         const user = userEvent.setup({delay: null});
         const onApply = jest.fn();


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-1055

Before:

https://user-images.githubusercontent.com/63734941/208169332-2c61bc63-76ad-4e1b-96a3-f79511f94393.mp4

After:

https://user-images.githubusercontent.com/63734941/208169426-aa49cb43-86a5-4bd1-ad82-59ccad157938.mp4


### Potential Breaking Changes

None

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
