### PR TITLE
fix(style): changed mantine textinput error colors and added styles t…

### DIFF
--- a/packages/mantine/src/components/collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/collection/CollectionItem.tsx
@@ -43,8 +43,11 @@ const StaticCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSh
     );
 };
 
-const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({children}) => {
-    const {classes, cx} = useStyles();
+const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
+    children,
+    styles,
+}) => {
+    const {classes, cx} = useStyles(null, {name: 'Collection', styles});
     return <Group className={cx(classes.item)}>{children}</Group>;
 };
 

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -106,12 +106,6 @@ export const plasmaTheme: MantineThemeOverride = {
             defaultProps: {
                 radius: 8,
             },
-            styles: (theme) => ({
-                description: {
-                    fontSize: 'inherit',
-                    paddingBottom: theme.spacing.xs,
-                },
-            }),
         },
         Tooltip: {
             defaultProps: {

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -99,6 +99,19 @@ export const plasmaTheme: MantineThemeOverride = {
             defaultProps: {
                 radius: 8,
             },
+            styles: (theme) => ({
+                description: {
+                    fontSize: 'inherit',
+                    paddingBottom: theme.spacing.xs,
+                },
+                invalid: {
+                    color: theme.colors.red[9],
+                    borderColor: theme.colors.red[6],
+                },
+                error: {
+                    color: theme.colors.red[9],
+                },
+            }),
         },
         Tooltip: {
             defaultProps: {

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -93,6 +93,13 @@ export const plasmaTheme: MantineThemeOverride = {
                     color: theme.colors.gray[7],
                     marginBottom: theme.spacing.xs,
                 },
+                invalid: {
+                    color: theme.colors.red[9],
+                    borderColor: theme.colors.red[6],
+                },
+                error: {
+                    color: theme.colors.red[9],
+                },
             }),
         },
         TextInput: {
@@ -103,13 +110,6 @@ export const plasmaTheme: MantineThemeOverride = {
                 description: {
                     fontSize: 'inherit',
                     paddingBottom: theme.spacing.xs,
-                },
-                invalid: {
-                    color: theme.colors.red[9],
-                    borderColor: theme.colors.red[6],
-                },
-                error: {
-                    color: theme.colors.red[9],
                 },
             }),
         },
@@ -185,17 +185,6 @@ export const plasmaTheme: MantineThemeOverride = {
                     fontWeight: 500,
                 },
             },
-        },
-        Select: {
-            styles: (theme) => ({
-                invalid: {
-                    color: theme.colors.red[9],
-                    borderColor: theme.colors.red[6],
-                },
-                error: {
-                    color: theme.colors.red[9],
-                },
-            }),
         },
     },
 };

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -186,5 +186,16 @@ export const plasmaTheme: MantineThemeOverride = {
                 },
             },
         },
+        Select: {
+            styles: (theme) => ({
+                invalid: {
+                    color: theme.colors.red[9],
+                    borderColor: theme.colors.red[6],
+                },
+                error: {
+                    color: theme.colors.red[9],
+                },
+            }),
+        },
     },
 };

--- a/packages/style/scss/controls/text-input.scss
+++ b/packages/style/scss/controls/text-input.scss
@@ -60,11 +60,6 @@
         --status-text-color: var(--critical-100);
     }
 
-    &.valid {
-        --status-color: var(--success-60);
-        --status-text-color: var(--success-100);
-    }
-
     &.warning {
         --status-color: var(--warning-70);
         --status-text-color: var(--warning-90);


### PR DESCRIPTION
…o collection disabled items

### Proposed Changes

`DisabledCollectionItem` now uses the useStyles and takes the `styles` object to add custom style to it (in my case, a background color)

I have also changed the error colours on the TextInput component from mantine so it reflects our colour 

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
