### PR TITLE
fix(mantine): give unsortable columns header some padding

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -44,6 +44,9 @@ const useStyles = createStyles<string, TableStylesParams>((theme, {hasHeader, mu
             '& td:first-of-type, th:first-of-type > *': {
                 paddingLeft: theme.spacing.xl,
             },
+            '& tbody td': {
+                verticalAlign: 'top',
+            },
         },
 
         header: {
@@ -67,12 +70,9 @@ const useStyles = createStyles<string, TableStylesParams>((theme, {hasHeader, mu
             backgroundColor: multiRowSelectionEnabled ? undefined : rowBackgroundColor,
         },
 
-        rowSelectionCheckboxCell: {
-            verticalAlign: 'middle',
-        },
-
         rowCollapsibleButtonCell: {
             textAlign: 'right',
+            padding: `${theme.spacing.xs / 2}px ${theme.spacing.sm}px !important`,
         },
 
         row: {
@@ -261,7 +261,6 @@ export const Table: TableType = <T,>({
                                 key={cell.id}
                                 style={{width}}
                                 className={cx({
-                                    [classes.rowSelectionCheckboxCell]: cell.column.id === TableSelectableColumn.id,
                                     [classes.rowCollapsibleButtonCell]: cell.column.id === TableCollapsibleColumn.id,
                                 })}
                             >
@@ -276,7 +275,11 @@ export const Table: TableType = <T,>({
                     <tr>
                         <td
                             colSpan={columns.length + 1}
-                            style={{padding: 0, borderTop: row.getIsExpanded() ? undefined : 'none'}}
+                            style={{
+                                padding: 0,
+                                borderTop: row.getIsExpanded() ? undefined : 'none',
+                                borderBottom: row.getIsExpanded() ? undefined : 'none',
+                            }}
                         >
                             <Collapse in={row.getIsExpanded()}>
                                 <Box px="sm" py="xs">

--- a/packages/mantine/src/components/table/TableActions.tsx
+++ b/packages/mantine/src/components/table/TableActions.tsx
@@ -1,3 +1,4 @@
+import {Group} from '@mantine/core';
 import {ReactElement, ReactNode} from 'react';
 import {useTable} from './useTable';
 
@@ -32,5 +33,5 @@ export const TableActions = <T,>({children}: TableActionsProps<T>): ReactElement
         return null;
     }
 
-    return <>{children(multiRowSelectionEnabled ? selectedRows : selectedRows[0])}</>;
+    return <Group spacing="xs">{children(multiRowSelectionEnabled ? selectedRows : selectedRows[0])}</Group>;
 };

--- a/packages/mantine/src/components/table/TableCollapsibleColumn.tsx
+++ b/packages/mantine/src/components/table/TableCollapsibleColumn.tsx
@@ -1,5 +1,5 @@
 import {ArrowHeadDownSize24Px, ArrowHeadUpSize24Px} from '@coveord/plasma-react-icons';
-import {Button} from '@mantine/core';
+import {ActionIcon} from '@mantine/core';
 import {ColumnDef} from '@tanstack/table-core';
 import {MouseEvent as ReactMouseEvent} from 'react';
 
@@ -10,6 +10,7 @@ export const TableCollapsibleColumn: ColumnDef<unknown> = {
     id: 'collapsible',
     enableSorting: false,
     header: '',
+    size: 62,
     cell: (info) => {
         const handler = info.row.getToggleExpandedHandler();
         const onClick = (e: ReactMouseEvent<HTMLButtonElement>) => {
@@ -18,9 +19,9 @@ export const TableCollapsibleColumn: ColumnDef<unknown> = {
         };
 
         return info.row.getCanExpand() ? (
-            <Button onClick={onClick} variant="subtle" size="xs">
+            <ActionIcon onClick={onClick} variant="subtle" radius="sm">
                 {info.row.getIsExpanded() ? <ArrowHeadUpSize24Px /> : <ArrowHeadDownSize24Px />}
-            </Button>
+            </ActionIcon>
         ) : null;
     },
 };

--- a/packages/mantine/src/components/table/Th.tsx
+++ b/packages/mantine/src/components/table/Th.tsx
@@ -47,7 +47,9 @@ export const Th = <T,>({header}: ThProps<T>) => {
     if (!header.column.getCanSort()) {
         return (
             <th className={classes.th} style={{width}}>
-                <Text size="xs">{flexRender(header.column.columnDef.header, header.getContext())}</Text>
+                <Text size="xs" py="xs" px="sm">
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                </Text>
             </th>
         );
     }


### PR DESCRIPTION
### Proposed Changes

Make sure columns that are not sortable have the proper padding.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/35579930/208538978-9d132771-4d04-44a4-b895-53a1394641c2.png) | ![image](https://user-images.githubusercontent.com/35579930/208539032-ea80aa08-2068-4b81-ae0d-a32a65756479.png) |

Bonus: I converted the Collapsible toggle button to an ActionIcon, instead of a standard button, which reduces the minimum height of rows a bit allowing to have more rows displayed at the same time.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/35579930/208539409-dcc4082d-7b5f-4f36-9b3c-a90d7516731d.png) | ![image](https://user-images.githubusercontent.com/35579930/208539329-be931ab8-655f-44fa-a76e-967f91a61d3e.png) |

Bonus #2: Reduce spacing between table actions

| Before | After |
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/35579930/208541956-e22132a8-0338-4f61-8259-4414cd44a2eb.png) | ![image](https://user-images.githubusercontent.com/35579930/208541858-3b0ec6be-e9b0-40fc-93ff-e50e373ba5ce.png) |


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
