### PR TITLE
fix(mantine): adjust modal sizes in the theme

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -70,7 +70,7 @@ export const plasmaTheme: MantineThemeOverride = {
                 modal: {
                     width: fullScreen
                         ? undefined
-                        : theme.fn.size({size, sizes: {xs: 320, sm: 440, md: '45%', lg: 1334, xl: '85%'}}),
+                        : theme.fn.size({size, sizes: {xs: 440, sm: 550, md: 800, lg: 1334, xl: '85%'}}),
                 },
             }),
             defaultProps: {


### PR DESCRIPTION
### Proposed Changes

Adjusting the modal sizes a bit. XS was so small it wasn't usable. MD was still in pourcentages, meaning on bigger screens it was possible to have an MD that is bigger than LG.

Here is what is looks like with the new sizes.

https://user-images.githubusercontent.com/35579930/209159052-0734ba36-5c54-4400-bca8-6f971e7c98e8.mov

### Potential Breaking Changes

Existing modals might change size a bit, but the new sizes should not cause any major problems

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
