### PR TITLE
feat(react-icons): remove loadable

### DIFF
--- a/packages/mantine/jest.config.js
+++ b/packages/mantine/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
     globalSetup: '<rootDir>/src/__tests__/GlobalSetup.ts',
     moduleNameMapper: {
         '^@test-utils$': '<rootDir>/src/__tests__/Utils.tsx',
+        '^@coveord/plasma-react-icons$': '<rootDir>/node_modules/@coveord/plasma-react-icons/mock',
     },
     testEnvironment: 'jsdom',
     transform: {

--- a/packages/react-icons/mock/index.tsx
+++ b/packages/react-icons/mock/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * You can use the following mock in jest to avoid loading the actual icons during tests, it can slow down your tests if you don't.
+ * Just add the following entry to your moduleNameMappter config
+ * '^@coveord/plasma-react-icons$': '<rootDir>/node_modules/@coveord/plasma-react-icons/mock',
+ */
+
+/**
+ * Transforms ArrowUpSize16Px into arrowUp
+ */
+const formatLabel = (name: string) => {
+    const label = name.replace(/(.+)Size\d+Px/, '$1');
+    return label.charAt(0).toLowerCase() + label.slice(1);
+};
+
+const handler = {
+    get: (obj, prop: string) => (props) => <span role="img" aria-label={formatLabel(prop)} {...props}></span>,
+};
+
+module.exports = new Proxy({}, handler);

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -31,7 +31,6 @@
         "generate": "node ./bin/index.js"
     },
     "dependencies": {
-        "@loadable/component": "5.15.2",
         "@swc/helpers": "0.4.12"
     },
     "devDependencies": {
@@ -40,7 +39,6 @@
         "@svgr/core": "6.2.1",
         "@swc/cli": "0.1.57",
         "@swc/core": "1.3.22",
-        "@types/loadable__component": "5.13.4",
         "@types/react": "18.0.21",
         "@types/react-dom": "18.0.6",
         "fs-extra": "10.1.0",

--- a/packages/react-icons/src/index.ts
+++ b/packages/react-icons/src/index.ts
@@ -1,7 +1,5 @@
-import {LoadableComponent} from '@loadable/component';
 import {ComponentType} from 'react';
 
 export * from './generated';
 
-export type Icon = ComponentType<React.SVGProps<SVGSVGElement>> | LoadableComponent<React.SVGProps<SVGSVGElement>>;
-
+export type Icon = ComponentType<React.SVGProps<SVGSVGElement>>;

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
         '^d3-scale$': '<rootDir>/node_modules/d3-scale/dist/d3-scale.min.js',
         '^d3-array$': '<rootDir>/node_modules/d3-array/dist/d3-array.min.js',
         '^d3-shape$': '<rootDir>/node_modules/d3-shape/dist/d3-shape.min.js',
+        '^@coveord/plasma-react-icons$': '<rootDir>/node_modules/@coveord/plasma-react-icons/mock',
     },
     setupFiles: ['<rootDir>/jest/setup.ts'],
     setupFilesAfterEnv: ['<rootDir>/jest/entry.tsx'],

--- a/packages/react/src/components/collapsible/tests/CollapsibleInfoBox.spec.tsx
+++ b/packages/react/src/components/collapsible/tests/CollapsibleInfoBox.spec.tsx
@@ -30,7 +30,7 @@ describe('CollapsibleInfoBox', () => {
         };
         render(<CollapsibleInfoBox {...props} />);
 
-        expect(screen.queryByRole('img', {name: 'arrowHeadDown'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: 'info'})).not.toBeInTheDocument();
     });
 
     it('display the sectionAdditionalContent if there is any and it is a section', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,12 +404,10 @@ importers:
     specifiers:
       '@babel/types': 7.17.10
       '@coveord/plasma-tokens': workspace:*
-      '@loadable/component': 5.15.2
       '@svgr/core': 6.2.1
       '@swc/cli': 0.1.57
       '@swc/core': 1.3.22
       '@swc/helpers': 0.4.12
-      '@types/loadable__component': 5.13.4
       '@types/react': ^18.0
       '@types/react-dom': ^18.0
       fs-extra: 10.1.0
@@ -423,7 +421,6 @@ importers:
       tslib: 2.3.1
       typescript: 4.9.3
     dependencies:
-      '@loadable/component': 5.15.2_react@18.2.0
       '@swc/helpers': 0.4.12
     devDependencies:
       '@babel/types': 7.17.10
@@ -431,7 +428,6 @@ importers:
       '@svgr/core': 6.2.1
       '@swc/cli': 0.1.57_@swc+core@1.3.22
       '@swc/core': 1.3.22
-      '@types/loadable__component': 5.13.4
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
       fs-extra: 10.1.0


### PR DESCRIPTION
### Proposed Changes

All icons are now rendered synchronously instead of async. A new mock is exposed to remove any lag sync icons could cause.

You should add the following moduleNameMapper entry to your jest config

```js
'^@coveord/plasma-react-icons$': '<rootDir>/node_modules/@coveord/plasma-react-icons/mock',
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
