### PR TITLE
feat(Modal): +ReactNode as title prop type

### DIFF
--- a/packages/mantine/src/components/modal/Modal.tsx
+++ b/packages/mantine/src/components/modal/Modal.tsx
@@ -1,5 +1,5 @@
 import {Modal as MantineModal, ModalProps} from '@mantine/core';
-import {FunctionComponent} from 'react';
+import {FunctionComponent, ReactNode} from 'react';
 import {Header, HeaderProps} from '../header';
 
 export interface CustomModalProps extends Omit<ModalProps, 'title'> {
@@ -10,7 +10,7 @@ export interface CustomModalProps extends Omit<ModalProps, 'title'> {
     /**
      * The title text displayed on top of the modal
      */
-    title: string;
+    title: ReactNode;
     /**
      * The description text displayed inside the header underneath the title
      */

--- a/packages/mantine/src/components/modal/__tests__/Modal.spec.tsx
+++ b/packages/mantine/src/components/modal/__tests__/Modal.spec.tsx
@@ -1,5 +1,6 @@
+import {QuestionSize32Px} from '@coveord/plasma-react-icons';
 import {Container} from '@mantine/core';
-import {render, screen, fireEvent} from '@test-utils';
+import {fireEvent, render, screen} from '@test-utils';
 import {Modal} from '../Modal';
 
 describe('Modal', () => {
@@ -15,6 +16,25 @@ describe('Modal', () => {
         expect(screen.getByText(/Children/i)).toBeInTheDocument();
         expect(screen.getByRole('dialog')).toBeInTheDocument();
         expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('allows ReactNode as title', async () => {
+        render(
+            <Modal
+                opened
+                onClose={jest.fn()}
+                title={
+                    <div>
+                        <QuestionSize32Px />
+                        ReactNode title
+                    </div>
+                }
+            >
+                <Container>Children</Container>
+            </Modal>
+        );
+        expect(await screen.findByRole('img', {name: /question/i})).toBeInTheDocument();
+        expect(screen.getByText(/reactnode title/i)).toBeInTheDocument();
     });
 
     it('trigger onClose function when click on the close button', () => {


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-1067
Added ReactNode as a type for modal title so it has more flexibility

e.g. from figma file 
<img width="615" alt="image" src="https://user-images.githubusercontent.com/52010042/211862013-60008c3c-d2ad-458f-8f83-9e4d666b60f5.png">

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
