### PR TITLE
ci(codeowners): remove ui-tooling team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,8 +4,4 @@
 # review when someone opens a pull request.
 # see https://help.github.com/articles/about-codeowners/ for more details
 
-* @coveo/admin-console @coveo/ui-tooling
-
-# Prevent PRs that only modify package versions from notifying everyone
-package.json
-pnpm-lock.yaml
+* @coveo/admin-console


### PR DESCRIPTION
### Proposed Changes

We are deleting this github team, all of its members are in the admin-console team anyway

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
