### PR TITLE
feat(react-icons): add forwardRef on react icons

### DIFF
--- a/packages/react-icons/bin/index.js
+++ b/packages/react-icons/bin/index.js
@@ -45,6 +45,7 @@ const convertVariant = async (file) => {
                 template,
                 expandProps: false,
                 svgProps: {
+                    ref: '{ref}',
                     'aria-label': iconName,
                     role: 'img',
                     height: '{height || width || "1em"}',

--- a/packages/react-icons/bin/template.js
+++ b/packages/react-icons/bin/template.js
@@ -41,9 +41,9 @@ const template = (variables, {tpl}) => {
     return tpl`
 ${variables.imports};
 
-import {SVGProps} from 'react';
+import {forwardRef, SVGProps} from 'react';
 
-const ${variables.componentName} = (${props}) => (${variables.jsx});
+const ${variables.componentName} = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>((${props}, ref) => (${variables.jsx}));
 
 ${variables.exports};
 `;

--- a/packages/react-icons/bin/template.js
+++ b/packages/react-icons/bin/template.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const t = require('@babel/types');
 
 const findSvgTag = (variables) => variables.jsx.openingElement;

--- a/packages/react-icons/src/index.ts
+++ b/packages/react-icons/src/index.ts
@@ -1,5 +1,5 @@
-import {ComponentType} from 'react';
+import {ForwardRefExoticComponent, SVGProps} from 'react';
 
 export * from './generated';
 
-export type Icon = ComponentType<React.SVGProps<SVGSVGElement>>;
+export type Icon = ForwardRefExoticComponent<SVGProps<SVGSVGElement>>;

--- a/packages/react/src/components/collapsible/CollapsibleToggle.tsx
+++ b/packages/react/src/components/collapsible/CollapsibleToggle.tsx
@@ -5,9 +5,10 @@ export interface CollapsibleToggleProps {
     expanded: boolean;
 }
 
-export const CollapsibleToggle: FunctionComponent<
-    React.PropsWithChildren<CollapsibleToggleProps & SVGProps<SVGSVGElement>>
-> = ({expanded, ...svgProps}) => {
+export const CollapsibleToggle: FunctionComponent<CollapsibleToggleProps & Omit<SVGProps<SVGSVGElement>, 'ref'>> = ({
+    expanded,
+    ...svgProps
+}) => {
     const Icon = expanded ? ArrowHeadUpSize16Px : ArrowHeadDownSize16Px;
     return <Icon height={16} {...svgProps} />;
 };

--- a/packages/website/src/examples/foundations/Iconography/Iconography.demo.tsx
+++ b/packages/website/src/examples/foundations/Iconography/Iconography.demo.tsx
@@ -1,10 +1,13 @@
 import {DollarsSize64Px} from '@coveord/plasma-react-icons';
+import {Tooltip} from '@mantine/core';
 
 // Control the size using "height" or "width" attributes (defaults to 1em)
 // The icon takes the same color as the text around it
 
 export default () => (
     <div style={{color: 'green'}}>
-        <DollarsSize64Px height={64} />
+        <Tooltip label="Dollar" position="left">
+            <DollarsSize64Px height={64} />
+        </Tooltip>
     </div>
 );


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

Changed the script that generates the icons to add the forwardRef. It's now possible to use multiple Mantine components like the Tooltip with the react-icons

<img width="179" alt="image" src="https://user-images.githubusercontent.com/260007/213246346-70a40d3e-854c-45ce-8484-591e47944c5f.png">

### Potential Breaking Changes

The inferred interface of the icon changed but I don't think we need a breaking change for that
