### PR TITLE
fix(icons): expose mock folder

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -23,7 +23,8 @@
     "module": "dist/esm/index.js",
     "types": "./dist/definitions/index.d.ts",
     "files": [
-        "dist"
+        "dist",
+        "mock"
     ],
     "scripts": {
         "build": "pnpm generate && node ../../scripts/build",


### PR DESCRIPTION
### Proposed Changes

The mock folder isn't exposed by the package.json, which makes it impossible to use it from dependent packages external to this monorepo. (related to https://github.com/coveo/plasma/pull/3005)

![image](https://user-images.githubusercontent.com/35579930/213755983-d02a59af-dfc2-43f1-8bed-e5e50364b79b.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
