### PR TITLE
fix(dropdown): add a grey background on arrow selection options

### DIFF
--- a/packages/style/scss/controls/dropdown.scss
+++ b/packages/style/scss/controls/dropdown.scss
@@ -198,6 +198,7 @@
             &.selected-value {
                 color: var(--grey-40);
                 font-weight: var(--main-font-bold);
+                background-color: var(--navy-blue-80);
             }
 
             &.disabled {
@@ -213,7 +214,12 @@
 
         &.active {
             color: var(--grey-40);
-            background-color: var(--navy-blue-80);
+            > a,
+            > span {
+                &.enabled:not(.selected-value) {
+                    background: var(--grey-20);
+                }
+            }
         }
 
         &.divider {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5612,8 +5612,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
### Proposed Changes

just changed the .scss. file of _dropdown.scss_ so we can make that quick fix for old dropdown (eventually this will be refactored using mantine and newer plasma components)


https://user-images.githubusercontent.com/52010042/214135377-0fade24a-c67e-4b64-b19f-d6cdac57f8cc.mov


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
