### PR TITLE
feat(mantine): disabled button with tooltip

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -111,6 +111,7 @@ const components: Component[] = [
     {
         name: 'Button',
         packageName: '@coveord/plasma-react',
+        suffix: 'Legacy',
     },
     {
         name: 'Checkbox',
@@ -306,6 +307,11 @@ const components: Component[] = [
     {
         name: 'StickyFooter',
         packageName: '@coveord/plasma-mantine',
+    },
+    {
+        name: 'Button',
+        packageName: '@coveord/plasma-mantine',
+        propsType: 'ButtonProps',
     },
 ];
 

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "@coveord/plasma-react-icons": "workspace:*",
         "@coveord/plasma-tokens": "workspace:*",
+        "@mantine/utils": "5.10.1",
         "@monaco-editor/react": "4.4.5",
         "@swc/helpers": "0.4.12",
         "@tanstack/react-table": "8.5.11",
@@ -54,6 +55,7 @@
         "@types/react-beautiful-dnd": "13.1.2",
         "@types/react-dom": "18.0.6",
         "@types/testing-library__jest-dom": "5.14.5",
+        "csstype": "3.1.1",
         "embla-carousel-react": "7.0.4",
         "eslint-plugin-jest": "27.1.1",
         "eslint-plugin-testing-library": "5.7.2",
@@ -70,13 +72,13 @@
     },
     "peerDependencies": {
         "@emotion/react": "^11.10.0",
-        "@mantine/carousel": "5.8.3",
+        "@mantine/carousel": "^5.8.3",
         "@mantine/core": "^5.6.2",
         "@mantine/dates": "^5.6.2",
         "@mantine/form": "^5.6.2",
         "@mantine/hooks": "^5.6.2",
         "@mantine/modals": "^5.6.2",
-        "embla-carousel-react": "7.0.4",
+        "embla-carousel-react": "^7.0.4",
         "react": ">= 18.0.0",
         "react-dom": ">= 18.0.0"
     }

--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -1,0 +1,27 @@
+import {Button as MantineButton, ButtonProps as MantineButtonProps, useMantineTheme} from '@mantine/core';
+import {forwardRef} from 'react';
+
+import {createPolymorphicComponent} from '../../utils';
+import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from './ButtonWithDisabledTooltip';
+
+export interface ButtonProps extends MantineButtonProps, ButtonWithDisabledTooltipProps {}
+
+const _Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+    const theme = useMantineTheme();
+    return (
+        <ButtonWithDisabledTooltip
+            component={MantineButton}
+            ref={ref}
+            disabledHoverColor={theme.colors.gray[2]}
+            {...props}
+        />
+    );
+});
+
+export const Button = createPolymorphicComponent<
+    'button',
+    ButtonProps,
+    {Group: typeof MantineButton.Group; DisabledTooltip: typeof ButtonWithDisabledTooltip}
+>(_Button);
+
+Button.DisabledTooltip = ButtonWithDisabledTooltip;

--- a/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
+++ b/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
@@ -1,0 +1,58 @@
+import {Box, Tooltip} from '@mantine/core';
+import {Property} from 'csstype';
+import {forwardRef, MouseEventHandler} from 'react';
+
+import {createPolymorphicComponent} from '../../utils';
+
+export interface ButtonWithDisabledTooltipProps {
+    disabled?: boolean;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    /**
+     * The tooltip message to display when disabled
+     */
+    disabledTooltip?: string;
+    /**
+     * The background color when disabled
+     *
+     * @default 'unset'
+     */
+    disabledHoverColor?: Property.BackgroundColor;
+}
+
+const _ButtonWithDisabledTooltip = forwardRef<HTMLButtonElement, ButtonWithDisabledTooltipProps>(
+    ({disabledTooltip, disabled, onClick, disabledHoverColor: hoverColor = 'unset', ...others}, ref) =>
+        disabledTooltip ? (
+            <Tooltip label={disabledTooltip} disabled={!disabled}>
+                <Box
+                    component="button"
+                    ref={ref}
+                    {...(disabled ? {'data-disabled': true} : {})}
+                    sx={(theme) => ({
+                        '&[data-disabled]': {
+                            pointerEvents: 'all',
+                            color: theme.colors.gray[5],
+                        },
+                        '&[data-disabled]:hover': {
+                            backgroundColor: hoverColor,
+                            cursor: 'not-allowed',
+                        },
+                    })}
+                    onClick={(event) => {
+                        if (disabled) {
+                            event.preventDefault();
+                            event.stopPropagation();
+                        } else {
+                            onClick?.(event);
+                        }
+                    }}
+                    {...others}
+                />
+            </Tooltip>
+        ) : (
+            <Box component="button" ref={ref} disabled={disabled} onClick={onClick} {...others} />
+        )
+);
+
+export const ButtonWithDisabledTooltip = createPolymorphicComponent<'button', ButtonWithDisabledTooltipProps>(
+    _ButtonWithDisabledTooltip
+);

--- a/packages/mantine/src/components/button/__tests__/ButtonWithDisabledTooltip.spec.tsx
+++ b/packages/mantine/src/components/button/__tests__/ButtonWithDisabledTooltip.spec.tsx
@@ -1,0 +1,52 @@
+import {render, screen, userEvent} from '@test-utils';
+import {ButtonWithDisabledTooltip} from '../ButtonWithDisabledTooltip';
+
+describe('ButtonWithDisabledTooltip', () => {
+    it('disables the button when disabled prop is true', async () => {
+        const user = userEvent.setup();
+        const onClickSpy = jest.fn();
+        render(
+            <ButtonWithDisabledTooltip disabled onClick={onClickSpy}>
+                save
+            </ButtonWithDisabledTooltip>
+        );
+
+        const button = screen.getByRole('button', {name: /save/i});
+        await user.click(button);
+        expect(button).toBeDisabled();
+        expect(onClickSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not disable the button when disabled prop is false', async () => {
+        const user = userEvent.setup();
+        const onClickSpy = jest.fn();
+        render(<ButtonWithDisabledTooltip onClick={onClickSpy}>save</ButtonWithDisabledTooltip>);
+
+        const button = screen.getByRole('button', {name: /save/i});
+        await user.click(button);
+        expect(button).toBeEnabled();
+        expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a tooltip when hovering over the disabled button', async () => {
+        const user = userEvent.setup();
+        render(
+            <ButtonWithDisabledTooltip disabled disabledTooltip="tooltip message">
+                save
+            </ButtonWithDisabledTooltip>
+        );
+        const button = screen.getByRole('button', {name: /save/i});
+        expect(screen.queryByRole('tooltip', {name: /tooltip message/i})).not.toBeInTheDocument();
+        await user.hover(button);
+        expect(screen.getByRole('tooltip', {name: /tooltip message/i})).toBeInTheDocument();
+    });
+
+    it('does not show the tooltip when hovering over the button if it is not disabled', async () => {
+        const user = userEvent.setup();
+        render(<ButtonWithDisabledTooltip disabledTooltip="tooltip message">save</ButtonWithDisabledTooltip>);
+        const button = screen.getByRole('button', {name: /save/i});
+        expect(screen.queryByRole('tooltip', {name: /tooltip message/i})).not.toBeInTheDocument();
+        await user.hover(button);
+        expect(screen.queryByRole('tooltip', {name: /tooltip message/i})).not.toBeInTheDocument();
+    });
+});

--- a/packages/mantine/src/components/button/index.ts
+++ b/packages/mantine/src/components/button/index.ts
@@ -1,0 +1,2 @@
+export * from './Button';
+export {type ButtonWithDisabledTooltipProps} from './ButtonWithDisabledTooltip';

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -1,7 +1,6 @@
 import {AddSize16Px} from '@coveord/plasma-react-icons';
 import {
     Box,
-    Button,
     DefaultProps,
     Group,
     Input,
@@ -17,6 +16,7 @@ import {useDidUpdate, useId} from '@mantine/hooks';
 import {ReactNode} from 'react';
 import {DragDropContext, Droppable} from 'react-beautiful-dnd';
 
+import {Button} from '../button';
 import useStyles from './Collection.styles';
 import {CollectionItem} from './CollectionItem';
 

--- a/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
+++ b/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
@@ -1,7 +1,8 @@
-import {Button, Center, Group, Space} from '@mantine/core';
+import {Center, Group, Space} from '@mantine/core';
 import {DateRangePickerValue, RangeCalendar, RangeCalendarProps} from '@mantine/dates';
 import {useForm} from '@mantine/form';
 
+import {Button} from '../button';
 import {DateRangePickerPreset, DateRangePickerPresetSelect} from './DateRangePickerPresetSelect';
 import {EditableDateRangePicker, EditableDateRangePickerProps} from './EditableDateRangePicker';
 

--- a/packages/mantine/src/components/index.ts
+++ b/packages/mantine/src/components/index.ts
@@ -9,3 +9,5 @@ export * from './table';
 export * from './prompt';
 export * from './modal';
 export * from './modal-wizard';
+export * from './button';
+export * from './menu';

--- a/packages/mantine/src/components/inline-confirm/InlineConfirmButton.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirmButton.tsx
@@ -1,5 +1,6 @@
-import {Button, ButtonProps} from '@mantine/core';
 import {HTMLAttributes, MouseEventHandler} from 'react';
+
+import {Button, ButtonProps} from '../button';
 import {useInlineConfirm} from './useInlineConfirm';
 
 interface InlineConfirmButtonProps extends ButtonProps, Omit<HTMLAttributes<HTMLButtonElement>, 'color'> {

--- a/packages/mantine/src/components/inline-confirm/InlineConfirmPrompt.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirmPrompt.tsx
@@ -1,6 +1,7 @@
-import {Button, Group} from '@mantine/core';
+import {Group} from '@mantine/core';
 import {FunctionComponent, ReactNode, useEffect} from 'react';
 
+import {Button} from '../button';
 import {useInlineConfirm} from './useInlineConfirm';
 
 interface InlineConfirmPromptProps {

--- a/packages/mantine/src/components/menu/Menu.tsx
+++ b/packages/mantine/src/components/menu/Menu.tsx
@@ -1,0 +1,18 @@
+import {Menu as MantineMenu, MenuItemProps as MantineMenuItemProps} from '@mantine/core';
+import {forwardRef} from 'react';
+
+import {createPolymorphicComponent, overrideComponent} from '../../utils';
+import {Button, ButtonWithDisabledTooltipProps} from '../button';
+
+export interface MenuItemProps extends MantineMenuItemProps, ButtonWithDisabledTooltipProps {}
+
+const _MenuItem = forwardRef<HTMLButtonElement, MenuItemProps>((props, ref) => (
+    <Button.DisabledTooltip component={MantineMenu.Item} ref={ref} {...props} />
+));
+
+const MenuItem = createPolymorphicComponent<'button', MenuItemProps>(_MenuItem);
+
+export const Menu = overrideComponent(MantineMenu, {
+    displayName: '@coveord/plasma-mantine/Menu',
+    Item: MenuItem,
+});

--- a/packages/mantine/src/components/menu/index.ts
+++ b/packages/mantine/src/components/menu/index.ts
@@ -1,0 +1,1 @@
+export * from './Menu';

--- a/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
+++ b/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
@@ -1,8 +1,10 @@
-import {Box, Button, createStyles, DefaultProps, Modal, ModalProps, Progress, Selectors} from '@mantine/core';
+import {Box, createStyles, DefaultProps, Modal, ModalProps, Progress, Selectors} from '@mantine/core';
 import {Children, ReactElement, useMemo, useState} from 'react';
+
+import {Button} from '../button';
+import {Header} from '../header';
 import {StickyFooter} from '../sticky-footer';
 import {ModalWizardStep} from './ModalWizardStep';
-import {Header} from '../header';
 
 const useStyles = createStyles(() => ({
     modal: {

--- a/packages/mantine/src/components/table/TableDateRangePicker.tsx
+++ b/packages/mantine/src/components/table/TableDateRangePicker.tsx
@@ -1,8 +1,10 @@
 import {CalendarSize24Px} from '@coveord/plasma-react-icons';
-import {Popover, Button} from '@mantine/core';
+import {Popover} from '@mantine/core';
 import {DateRangePickerValue} from '@mantine/dates';
 import dayjs from 'dayjs';
 import {FunctionComponent, useState} from 'react';
+
+import {Button} from '../button';
 import {DateRangePickerInlineCalendar, DateRangePickerInlineCalendarProps} from '../date-range-picker';
 import {DateRangePickerPreset} from '../date-range-picker/DateRangePickerPresetSelect';
 import {useTable} from './useTable';

--- a/packages/mantine/src/components/table/TableHeader.tsx
+++ b/packages/mantine/src/components/table/TableHeader.tsx
@@ -1,7 +1,8 @@
 import {CrossSize16Px} from '@coveord/plasma-react-icons';
-import {Button, createStyles, DefaultProps, Group, Selectors, Space, Tooltip} from '@mantine/core';
+import {createStyles, DefaultProps, Group, Selectors, Space, Tooltip} from '@mantine/core';
 import {FunctionComponent, ReactNode} from 'react';
 
+import {Button} from '../button';
 import {useTable} from './useTable';
 
 const useStyles = createStyles((theme) => ({

--- a/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
@@ -1,7 +1,7 @@
-import {Button} from '@mantine/core';
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
 import {render, screen, userEvent} from '@test-utils';
 
+import {Button} from '../../button';
 import {Table} from '../Table';
 
 type RowData = {name: string};

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -10,7 +10,7 @@ export {createColumnHelper, type ColumnDef} from '@tanstack/table-core';
 export * from './components';
 export * from '@mantine/form';
 // explicitly overriding mantine components
-export {Header, Table, type HeaderProps, Modal} from './components';
+export {Header, Table, type HeaderProps, Modal, Button, type ButtonProps, Menu, type MenuItemProps} from './components';
 export {useForm, createFormContext} from './form';
 
 export * from './theme';

--- a/packages/mantine/src/utils/__tests__/overrideComponent.spec.tsx
+++ b/packages/mantine/src/utils/__tests__/overrideComponent.spec.tsx
@@ -1,0 +1,74 @@
+import {render} from '@test-utils';
+import {ReactNode} from 'react';
+
+import {overrideComponent} from '../overrideComponent';
+
+describe('overrideComponent', () => {
+    it('overrides the specified properties on the component and copies over the rest', () => {
+        const Component = () => <div>hello world</div>;
+        Component.displayName = 'hello world';
+        Component.One = () => <span>one</span>;
+        Component.Two = () => <span>two</span>;
+
+        const NewComponent = overrideComponent(Component, {
+            displayName: 'hello new world',
+            One: (props: {children: ReactNode}) => <span>{props.children}</span>,
+        });
+
+        expect(NewComponent.displayName).toBe('hello new world');
+
+        const {container, rerender} = render(<Component />);
+        expect(container).toMatchInlineSnapshot(`
+            <div>
+              <div>
+                hello world
+              </div>
+            </div>
+        `);
+
+        rerender(<NewComponent />);
+        expect(container).toMatchInlineSnapshot(`
+            <div>
+              <div>
+                hello world
+              </div>
+            </div>
+        `);
+
+        rerender(<Component.One />);
+        expect(container).toMatchInlineSnapshot(`
+            <div>
+              <span>
+                one
+              </span>
+            </div>
+        `);
+
+        rerender(<NewComponent.One>1</NewComponent.One>);
+        expect(container).toMatchInlineSnapshot(`
+            <div>
+              <span>
+                1
+              </span>
+            </div>
+        `);
+
+        rerender(<Component.Two />);
+        expect(container).toMatchInlineSnapshot(`
+            <div>
+              <span>
+                two
+              </span>
+            </div>
+        `);
+
+        rerender(<NewComponent.Two />);
+        expect(container).toMatchInlineSnapshot(`
+            <div>
+              <span>
+                two
+              </span>
+            </div>
+        `);
+    });
+});

--- a/packages/mantine/src/utils/createPolymorphicComponent.ts
+++ b/packages/mantine/src/utils/createPolymorphicComponent.ts
@@ -1,0 +1,8 @@
+import {createPolymorphicComponent as mantineCreatePolymorphicComponent} from '@mantine/utils';
+
+/*
+ * createPolymorphicComponent is already exported from @mantine/core, but there is an issue when using pnpm + typescript
+ * that forces us to use it directly from @mantine/utils (see https://github.com/microsoft/TypeScript/issues/47663)
+ * We are simply rexporting it here to avoid having to deal with this issue everywhere
+ */
+export const createPolymorphicComponent = mantineCreatePolymorphicComponent;

--- a/packages/mantine/src/utils/index.ts
+++ b/packages/mantine/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './createPolymorphicComponent';
+export * from './overrideComponent';

--- a/packages/mantine/src/utils/overrideComponent.ts
+++ b/packages/mantine/src/utils/overrideComponent.ts
@@ -1,0 +1,18 @@
+/**
+ * Allows to override static properties from a component function
+ *
+ * @param component The component which holds the static properties
+ * @param properties The new static properties to assign on the component
+ * @returns A new component with the specified properties. It doesn't change the original component
+ * @example const Menu = overrideComponent(MantineMenu, {Item: MyMenuItem}); // Menu.Item will equal MyMenuItem
+ */
+export const overrideComponent = <
+    Component extends (...args: Parameters<Component>) => ReturnType<Component>,
+    StaticProperties = Record<keyof Component, never>
+>(
+    component: Component,
+    properties: StaticProperties
+): ((...args: Parameters<Component>) => ReturnType<Component>) & Component & StaticProperties => {
+    const componentClone = (...args: Parameters<Component>) => component(...args);
+    return Object.assign(componentClone, component, properties);
+};

--- a/packages/website/src/SideNavigation.tsx
+++ b/packages/website/src/SideNavigation.tsx
@@ -95,6 +95,7 @@ const CurrentNavigation = () => {
                 <NavLink href="/layout/StickyFooter" label="Sticky footer" />
             </CollapsibleSideSection>
             <CollapsibleSideSection title="Form">
+                <NavLink href="/form/Button" label="Button" />
                 <NavLink href="/form/CodeEditor" label="Code editor" />
                 <NavLink href="/form/Collection" label="Collection" />
             </CollapsibleSideSection>

--- a/packages/website/src/examples/form/button/Button.demo.tsx
+++ b/packages/website/src/examples/form/button/Button.demo.tsx
@@ -1,0 +1,3 @@
+import {Button} from '@coveord/plasma-mantine';
+
+export default () => <Button onClick={() => alert('button clicked')}>Default button</Button>;

--- a/packages/website/src/examples/form/button/ButtonDisabled.demo.tsx
+++ b/packages/website/src/examples/form/button/ButtonDisabled.demo.tsx
@@ -1,0 +1,7 @@
+import {Button} from '@coveord/plasma-mantine';
+
+export default () => (
+    <Button disabled disabledTooltip="This button is disabled" onClick={() => alert('button clicked')}>
+        Disabled button
+    </Button>
+);

--- a/packages/website/src/examples/form/button/ButtonSecondary.demo.tsx
+++ b/packages/website/src/examples/form/button/ButtonSecondary.demo.tsx
@@ -1,0 +1,7 @@
+import {Button} from '@coveord/plasma-mantine';
+
+export default () => (
+    <Button variant="outline" onClick={() => alert('button clicked')}>
+        Secondary button
+    </Button>
+);

--- a/packages/website/src/pages/form/Button.tsx
+++ b/packages/website/src/pages/form/Button.tsx
@@ -1,0 +1,25 @@
+import {ButtonMetadata} from '@coveord/plasma-components-props-analyzer';
+import ButtonDemo from '@examples/form/button/Button.demo.tsx';
+import ButtonDisabledDemo from '@examples/form/button/ButtonDisabled.demo.tsx';
+import ButtonSecondaryDemo from '@examples/form/button/ButtonSecondary.demo.tsx';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
+
+const ButtonPage = () => (
+    <PageLayout
+        id="Button"
+        title="Button"
+        section="Form"
+        thumbnail="actionButton"
+        description="A button draws attention to an important action and initializes this action when clicked."
+        demo={<ButtonDemo center />}
+        examples={{
+            secondary: <ButtonSecondaryDemo center title="Secondary" />,
+            disabled: <ButtonDisabledDemo center title="Disabled" />,
+        }}
+        sourcePath="/packages/mantine/src/components/button/Button.tsx"
+        propsMetadata={ButtonMetadata}
+    />
+);
+
+export default ButtonPage;

--- a/packages/website/src/pages/legacy/form/Button.tsx
+++ b/packages/website/src/pages/legacy/form/Button.tsx
@@ -1,4 +1,4 @@
-import {ButtonMetadata} from '@coveord/plasma-components-props-analyzer';
+import {ButtonLegacyMetadata} from '@coveord/plasma-components-props-analyzer';
 import ButtonDemo from '@examples/legacy/form/button/Button.demo.tsx';
 import ButtonDisabledDemo from '@examples/legacy/form/button/Disabled.demo.tsx';
 import ButtonWithIconAndLinkDemo from '@examples/legacy/form/button/IconAndLink.demo.tsx';
@@ -28,7 +28,7 @@ const ButtonPage = () => (
             withTooltip: <ButtonWithTooltipDemo center title="With tooltip" />,
         }}
         sourcePath="/packages/react/src/components/button/Button.tsx"
-        propsMetadata={ButtonMetadata}
+        propsMetadata={ButtonLegacyMetadata}
     />
 );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,7 @@ importers:
       '@mantine/form': 5.9.2
       '@mantine/hooks': 5.9.2
       '@mantine/modals': 5.9.2
+      '@mantine/utils': 5.10.1
       '@monaco-editor/react': 4.4.5
       '@swc/cli': 0.1.57
       '@swc/core': 1.3.22
@@ -126,6 +127,7 @@ importers:
       '@types/react-beautiful-dnd': 13.1.2
       '@types/react-dom': ^18.0
       '@types/testing-library__jest-dom': 5.14.5
+      csstype: 3.1.1
       dayjs: 1.11.3
       embla-carousel-react: 7.0.4
       eslint-plugin-jest: 27.1.1
@@ -146,6 +148,7 @@ importers:
     dependencies:
       '@coveord/plasma-react-icons': link:../react-icons
       '@coveord/plasma-tokens': link:../tokens
+      '@mantine/utils': 5.10.1_react@18.2.0
       '@monaco-editor/react': 4.4.5_7payg3yaajmz2lehtpasnhysrm
       '@swc/helpers': 0.4.12
       '@tanstack/react-table': 8.5.11_biqbaboplfbrettd7655fr4n2y
@@ -175,6 +178,7 @@ importers:
       '@types/react-beautiful-dnd': 13.1.2
       '@types/react-dom': 18.0.9
       '@types/testing-library__jest-dom': 5.14.5
+      csstype: 3.1.1
       embla-carousel-react: 7.0.4_react@18.2.0
       eslint-plugin-jest: 27.1.1_uo52wfafpsvhxs5nuzgmkssvwi
       eslint-plugin-testing-library: 5.7.2_typescript@4.9.3
@@ -2031,6 +2035,14 @@ packages:
       csstype: 3.0.9
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+
+  /@mantine/utils/5.10.1_react@18.2.0:
+    resolution: {integrity: sha512-PfzSpbipAwF5g5zoyC2Htxf2b9TFFwP6c9dK1jlrBzqtkeQK1axZ72Vbc1jKjGWYutVBbOWuk40GKUwYoDFVTw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /@mantine/utils/5.9.2_react@18.2.0:
     resolution: {integrity: sha512-dvqqbdrK/nw4stFCXRCn38Ru12RqdWv8uzbywP5dQVCyTw8pW/Cq+T7YCWpbkFcKFea9UhOrPhBygJcjc13FgA==}


### PR DESCRIPTION
### Proposed Changes

Implemented an easy way to add tooltips over disabled buttons. I basically took [this doc](https://mantine.dev/core/button/#disabled-button-with-tooltip) and generalized it into a [custom polymorphic component](https://mantine.dev/guides/polymorphic/#create-your-own-polymorphic-components). This way, we can just add the `disabledTooltip` prop to any button of the mantine ecosystem.

Examples

https://user-images.githubusercontent.com/35579930/215129583-b8f0bb1d-b18d-442c-aca5-e29f84c395eb.mov

https://user-images.githubusercontent.com/35579930/215128348-1c9ce008-cdc8-4c01-a85d-122080301b85.mov

I added a demo page for the Button component where you can test it out

#### New `overrideComponent` util

As you can see in the diff, I created a new util that facilitates overriding components. Its pretty useful when you need to override just one of the static components (for example `Menu.Item`), but keep the original component implementation (`Menu`).

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
