### PR TITLE
fix(mantine): adjust color swatch default size

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -180,5 +180,10 @@ export const plasmaTheme: MantineThemeOverride = {
                 },
             },
         },
+        ColorSwatch: {
+            defaultProps: {
+                size: 8,
+            },
+        },
     },
 };


### PR DESCRIPTION
### Proposed Changes

Adjusting the default size of the `ColorSwatch` to 8px

![image](https://user-images.githubusercontent.com/35579930/215204269-e2f90725-dc64-4655-bffa-adfcdc3f1823.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
