### PR TITLE
fix(mantine): simplify disabled tooltip

### DIFF
--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -1,4 +1,4 @@
-import {Button as MantineButton, ButtonProps as MantineButtonProps, useMantineTheme} from '@mantine/core';
+import {Button as MantineButton, ButtonProps as MantineButtonProps} from '@mantine/core';
 import {forwardRef} from 'react';
 
 import {createPolymorphicComponent} from '../../utils';
@@ -6,22 +6,16 @@ import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from './Butto
 
 export interface ButtonProps extends MantineButtonProps, ButtonWithDisabledTooltipProps {}
 
-const _Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-    const theme = useMantineTheme();
-    return (
+const _Button = forwardRef<HTMLButtonElement, ButtonProps>(
+    ({disabledTooltip, disabled, disabledTooltipProps, ...others}, ref) => (
         <ButtonWithDisabledTooltip
-            component={MantineButton}
-            ref={ref}
-            disabledHoverColor={theme.colors.gray[2]}
-            {...props}
-        />
-    );
-});
+            disabled={disabled}
+            disabledTooltip={disabledTooltip}
+            disabledTooltipProps={disabledTooltipProps}
+        >
+            <MantineButton ref={ref} disabled={disabled} {...others} />
+        </ButtonWithDisabledTooltip>
+    )
+);
 
-export const Button = createPolymorphicComponent<
-    'button',
-    ButtonProps,
-    {Group: typeof MantineButton.Group; DisabledTooltip: typeof ButtonWithDisabledTooltip}
->(_Button);
-
-Button.DisabledTooltip = ButtonWithDisabledTooltip;
+export const Button = createPolymorphicComponent<'button', ButtonProps, {Group: typeof MantineButton.Group}>(_Button);

--- a/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
+++ b/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
@@ -1,58 +1,37 @@
-import {Box, Tooltip} from '@mantine/core';
-import {Property} from 'csstype';
-import {forwardRef, MouseEventHandler} from 'react';
+import {Box, Tooltip, TooltipProps} from '@mantine/core';
+import {forwardRef, ReactNode} from 'react';
 
 import {createPolymorphicComponent} from '../../utils';
 
 export interface ButtonWithDisabledTooltipProps {
-    disabled?: boolean;
-    onClick?: MouseEventHandler<HTMLButtonElement>;
     /**
      * The tooltip message to display when disabled
      */
     disabledTooltip?: string;
     /**
-     * The background color when disabled
-     *
-     * @default 'unset'
+     * Whether the button underneath the tooltip is disabled
      */
-    disabledHoverColor?: Property.BackgroundColor;
+    disabled?: boolean;
+    children?: ReactNode;
+    /**
+     * Additional tooltip props to set on the disabled button tooltip
+     */
+    disabledTooltipProps?: Omit<TooltipProps, 'disabled' | 'label' | 'children'>;
 }
 
-const _ButtonWithDisabledTooltip = forwardRef<HTMLButtonElement, ButtonWithDisabledTooltipProps>(
-    ({disabledTooltip, disabled, onClick, disabledHoverColor: hoverColor = 'unset', ...others}, ref) =>
+const _ButtonWithDisabledTooltip = forwardRef<HTMLDivElement, ButtonWithDisabledTooltipProps>(
+    ({disabledTooltip, disabled, children, disabledTooltipProps, ...others}, ref) =>
         disabledTooltip ? (
-            <Tooltip label={disabledTooltip} disabled={!disabled}>
-                <Box
-                    component="button"
-                    ref={ref}
-                    {...(disabled ? {'data-disabled': true} : {})}
-                    sx={(theme) => ({
-                        '&[data-disabled]': {
-                            pointerEvents: 'all',
-                            color: theme.colors.gray[5],
-                        },
-                        '&[data-disabled]:hover': {
-                            backgroundColor: hoverColor,
-                            cursor: 'not-allowed',
-                        },
-                    })}
-                    onClick={(event) => {
-                        if (disabled) {
-                            event.preventDefault();
-                            event.stopPropagation();
-                        } else {
-                            onClick?.(event);
-                        }
-                    }}
-                    {...others}
-                />
+            <Tooltip label={disabledTooltip} disabled={!disabled} {...disabledTooltipProps}>
+                <Box ref={ref} sx={{'&:hover': {cursor: 'not-allowed'}}} {...others}>
+                    {children}
+                </Box>
             </Tooltip>
         ) : (
-            <Box component="button" ref={ref} disabled={disabled} onClick={onClick} {...others} />
+            <>{children}</>
         )
 );
 
-export const ButtonWithDisabledTooltip = createPolymorphicComponent<'button', ButtonWithDisabledTooltipProps>(
+export const ButtonWithDisabledTooltip = createPolymorphicComponent<'div', ButtonWithDisabledTooltipProps>(
     _ButtonWithDisabledTooltip
 );

--- a/packages/mantine/src/components/button/__tests__/ButtonWithDisabledTooltip.spec.tsx
+++ b/packages/mantine/src/components/button/__tests__/ButtonWithDisabledTooltip.spec.tsx
@@ -2,40 +2,15 @@ import {render, screen, userEvent} from '@test-utils';
 import {ButtonWithDisabledTooltip} from '../ButtonWithDisabledTooltip';
 
 describe('ButtonWithDisabledTooltip', () => {
-    it('disables the button when disabled prop is true', async () => {
-        const user = userEvent.setup();
-        const onClickSpy = jest.fn();
-        render(
-            <ButtonWithDisabledTooltip disabled onClick={onClickSpy}>
-                save
-            </ButtonWithDisabledTooltip>
-        );
-
-        const button = screen.getByRole('button', {name: /save/i});
-        await user.click(button);
-        expect(button).toBeDisabled();
-        expect(onClickSpy).not.toHaveBeenCalled();
-    });
-
-    it('does not disable the button when disabled prop is false', async () => {
-        const user = userEvent.setup();
-        const onClickSpy = jest.fn();
-        render(<ButtonWithDisabledTooltip onClick={onClickSpy}>save</ButtonWithDisabledTooltip>);
-
-        const button = screen.getByRole('button', {name: /save/i});
-        await user.click(button);
-        expect(button).toBeEnabled();
-        expect(onClickSpy).toHaveBeenCalledTimes(1);
-    });
-
     it('shows a tooltip when hovering over the disabled button', async () => {
         const user = userEvent.setup();
         render(
             <ButtonWithDisabledTooltip disabled disabledTooltip="tooltip message">
-                save
+                <button disabled>save</button>
             </ButtonWithDisabledTooltip>
         );
         const button = screen.getByRole('button', {name: /save/i});
+        expect(button).toBeDisabled();
         expect(screen.queryByRole('tooltip', {name: /tooltip message/i})).not.toBeInTheDocument();
         await user.hover(button);
         expect(screen.getByRole('tooltip', {name: /tooltip message/i})).toBeInTheDocument();
@@ -43,10 +18,29 @@ describe('ButtonWithDisabledTooltip', () => {
 
     it('does not show the tooltip when hovering over the button if it is not disabled', async () => {
         const user = userEvent.setup();
-        render(<ButtonWithDisabledTooltip disabledTooltip="tooltip message">save</ButtonWithDisabledTooltip>);
+        render(
+            <ButtonWithDisabledTooltip disabledTooltip="tooltip message">
+                <button>save</button>
+            </ButtonWithDisabledTooltip>
+        );
         const button = screen.getByRole('button', {name: /save/i});
         expect(screen.queryByRole('tooltip', {name: /tooltip message/i})).not.toBeInTheDocument();
         await user.hover(button);
         expect(screen.queryByRole('tooltip', {name: /tooltip message/i})).not.toBeInTheDocument();
+    });
+
+    it('does not render the tooltip if there is no disabled tooltip message', () => {
+        const {container} = render(
+            <ButtonWithDisabledTooltip>
+                <button>save</button>
+            </ButtonWithDisabledTooltip>
+        );
+        expect(container).toMatchInlineSnapshot(`
+            <div>
+              <button>
+                save
+              </button>
+            </div>
+        `);
     });
 });

--- a/packages/mantine/src/components/inline-confirm/InlineConfirm.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirm.tsx
@@ -2,11 +2,13 @@ import {Children, FunctionComponent, PropsWithChildren, ReactElement, useState} 
 
 import {InlineConfirmButton} from './InlineConfirmButton';
 import {InlineConfirmContext} from './InlineConfirmContext';
+import {InlineConfirmMenuItem} from './InlineConfirmMenuItem';
 import {InlineConfirmPrompt} from './InlineConfirmPrompt';
 
 type InlineConfirmType = FunctionComponent<PropsWithChildren> & {
     Prompt: typeof InlineConfirmPrompt;
     Button: typeof InlineConfirmButton;
+    MenuItem: typeof InlineConfirmMenuItem;
 };
 
 export const InlineConfirm: InlineConfirmType = ({children}) => {
@@ -27,3 +29,4 @@ export const InlineConfirm: InlineConfirmType = ({children}) => {
 
 InlineConfirm.Prompt = InlineConfirmPrompt;
 InlineConfirm.Button = InlineConfirmButton;
+InlineConfirm.MenuItem = InlineConfirmMenuItem;

--- a/packages/mantine/src/components/inline-confirm/InlineConfirmMenuItem.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirmMenuItem.tsx
@@ -1,15 +1,14 @@
-import {Button} from '@mantine/core';
 import {forwardRef, MouseEventHandler} from 'react';
 
-import {ButtonProps} from '../button';
+import {Menu, MenuItemProps} from '../menu';
 import {useInlineConfirm} from './useInlineConfirm';
 
-export interface InlineConfirmButtonProps extends ButtonProps {
+export interface InlineConfirmMenuItemProps extends MenuItemProps {
     id: string;
     onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-export const InlineConfirmButton = forwardRef<HTMLButtonElement, InlineConfirmButtonProps>(
+export const InlineConfirmMenuItem = forwardRef<HTMLButtonElement, InlineConfirmMenuItemProps>(
     ({onClick, id, ...others}, ref) => {
         const {setConfirmingId} = useInlineConfirm();
         const handleOnClick: MouseEventHandler<HTMLButtonElement> = (e) => {
@@ -17,6 +16,6 @@ export const InlineConfirmButton = forwardRef<HTMLButtonElement, InlineConfirmBu
             onClick?.(e);
         };
 
-        return <Button ref={ref} onClick={handleOnClick} {...others} />;
+        return <Menu.Item ref={ref} onClick={handleOnClick} {...others} />;
     }
 );

--- a/packages/mantine/src/components/inline-confirm/__tests__/InlineConfirm.spec.tsx
+++ b/packages/mantine/src/components/inline-confirm/__tests__/InlineConfirm.spec.tsx
@@ -1,3 +1,4 @@
+import {Menu} from '@mantine/core';
 import {render, screen, userEvent} from '@test-utils';
 
 import {InlineConfirm} from '../InlineConfirm';
@@ -21,6 +22,30 @@ describe('InlineConfirm', () => {
         );
 
         await user.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls the onClick prop when clicking on the menu item', async () => {
+        const user = userEvent.setup({delay: null});
+        const onClickSpy = jest.fn();
+        render(
+            <InlineConfirm>
+                <Menu>
+                    <Menu.Target>
+                        <button>open menu</button>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <InlineConfirm.MenuItem id="delete" onClick={onClickSpy}>
+                            Delete
+                        </InlineConfirm.MenuItem>
+                    </Menu.Dropdown>
+                </Menu>
+            </InlineConfirm>
+        );
+
+        await user.click(screen.getByRole('button', {name: /open menu/i}));
+        await user.click(screen.getByRole('menuitem', {name: /delete/i}));
 
         expect(onClickSpy).toHaveBeenCalledTimes(1);
     });

--- a/packages/mantine/src/components/menu/Menu.tsx
+++ b/packages/mantine/src/components/menu/Menu.tsx
@@ -2,13 +2,22 @@ import {Menu as MantineMenu, MenuItemProps as MantineMenuItemProps} from '@manti
 import {forwardRef} from 'react';
 
 import {createPolymorphicComponent, overrideComponent} from '../../utils';
-import {Button, ButtonWithDisabledTooltipProps} from '../button';
+import {ButtonWithDisabledTooltipProps} from '../button';
+import {ButtonWithDisabledTooltip} from '../button/ButtonWithDisabledTooltip';
 
 export interface MenuItemProps extends MantineMenuItemProps, ButtonWithDisabledTooltipProps {}
 
-const _MenuItem = forwardRef<HTMLButtonElement, MenuItemProps>((props, ref) => (
-    <Button.DisabledTooltip component={MantineMenu.Item} ref={ref} {...props} />
-));
+const _MenuItem = forwardRef<HTMLButtonElement, MenuItemProps>(
+    ({disabledTooltip, disabled, disabledTooltipProps, ...others}, ref) => (
+        <ButtonWithDisabledTooltip
+            disabled={disabled}
+            disabledTooltip={disabledTooltip}
+            disabledTooltipProps={disabledTooltipProps}
+        >
+            <MantineMenu.Item ref={ref} disabled={disabled} {...others} />
+        </ButtonWithDisabledTooltip>
+    )
+);
 
 const MenuItem = createPolymorphicComponent<'button', MenuItemProps>(_MenuItem);
 

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -112,6 +112,7 @@ export const plasmaTheme: MantineThemeOverride = {
                 color: 'navy',
                 withArrow: true,
                 withinPortal: true,
+                multiline: true,
             },
         },
         Breadcrumbs: {
@@ -183,6 +184,12 @@ export const plasmaTheme: MantineThemeOverride = {
         ColorSwatch: {
             defaultProps: {
                 size: 8,
+                withShadow: false,
+            },
+        },
+        MenuItem: {
+            defaultProps: {
+                fw: 300,
             },
         },
     },


### PR DESCRIPTION
### Proposed Changes

I had an issue with the way the disabled tooltip mechanism was implemented when using it in conjunction with a menu item + the inline confirm button.

For example
```tsx
<Menu.Item
    component={InlineConfirm.Button}
    id={InlineConfirmId}
    disabled={tooManyRules}
    disabledTooltip={Locales.format('table.header.action.delete.disabled')}
>
    {Locales.format('table.header.action.delete')}
</Menu.Item>
```

The `component={InlineConfirm.Button}` prop would overwrite the `component={MantineMenu.Item}` from the Menu.Item component which would render something like a button instead of a menu item.

I switched the ButtonWithDisabledTooltip implementation to just wrap the button with a div instead of adding all those data attributes. 

Anyways, long story short now it works and displays well.

![image](https://user-images.githubusercontent.com/35579930/215619275-8e93c76e-a019-40b3-ac6d-9d58473be541.png)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
