### PR TITLE
fix(mantine): expose Button.Group

### DIFF
--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -19,3 +19,4 @@ const _Button = forwardRef<HTMLButtonElement, ButtonProps>(
 );
 
 export const Button = createPolymorphicComponent<'button', ButtonProps, {Group: typeof MantineButton.Group}>(_Button);
+Button.Group = MantineButton.Group;

--- a/packages/mantine/src/components/button/__tests__/Button.spec.tsx
+++ b/packages/mantine/src/components/button/__tests__/Button.spec.tsx
@@ -1,0 +1,12 @@
+import {render} from '@test-utils';
+
+import {Button} from '../Button';
+
+describe('Button', () => {
+    it('exposes a Button Group component', () => {
+        expect(Button.Group).toBeDefined();
+        expect(() => {
+            render(<Button.Group></Button.Group>);
+        }).not.toThrow();
+    });
+});


### PR DESCRIPTION
### Proposed Changes

When wrapping the Button component I forgot to expose the Button.Group component

### Potential Breaking Changes

None, it breaks currently when trying to render a Button.Group

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
