### PR TITLE
feat(mantine, table): allow passing options to the table

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,7 @@
         {
             "groupName": "@tanstack table",
             "description": "Group @tanstack table packages together because they need to be updated at the same time",
-            "matchPackageNames": ["@tanstack/react-table", "@tanstack/table-core"]
+            "matchPackageNames": ["@tanstack/react-table", "@tanstack/table-core", "@tanstack/match-sorter-utils"]
         }
     ],
     "lockFileMaintenance": {

--- a/packages/mantine/src/components/table/TableContext.tsx
+++ b/packages/mantine/src/components/table/TableContext.tsx
@@ -60,6 +60,11 @@ type TableContextType = {
      */
     containerRef: RefObject<HTMLDivElement>;
     multiRowSelectionEnabled: boolean;
+
+    /**
+     * Function that returns the number of pages
+     */
+    getPageCount: () => number;
 };
 
 export const TableContext = createContext<TableContextType | null>(null);

--- a/packages/mantine/src/components/table/TablePagination.tsx
+++ b/packages/mantine/src/components/table/TablePagination.tsx
@@ -5,13 +5,13 @@ import {useTable} from './useTable';
 
 interface TablePaginationProps {
     /**
-     * The total number of page
+     * The total number of page. Use null only if your table is paginated client side
      */
-    totalPages: number;
+    totalPages: number | null;
 }
 
 export const TablePagination: FunctionComponent<TablePaginationProps> = ({totalPages}) => {
-    const {state, setState, containerRef} = useTable();
+    const {state, setState, containerRef, getPageCount} = useTable();
     const updatePage = (newPage: number) => {
         setState((prevState: TableState) => ({
             ...prevState,
@@ -20,11 +20,13 @@ export const TablePagination: FunctionComponent<TablePaginationProps> = ({totalP
         containerRef.current.scrollIntoView({behavior: 'smooth'});
     };
 
+    const total = totalPages === null ? getPageCount() : totalPages;
+
     return (
         <Pagination
             page={state.pagination.pageIndex + 1}
             onChange={updatePage}
-            total={totalPages}
+            total={total}
             boundaries={0}
             size="md"
             getItemAriaLabel={(label) => {

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -6,11 +6,22 @@ export * from '@mantine/carousel';
 export * from '@mantine/core';
 export type {FormValidateInput} from '@mantine/form/lib/types';
 export * from '@mantine/hooks';
-export {createColumnHelper, type ColumnDef} from '@tanstack/table-core';
+export * from '@tanstack/table-core';
 export * from './components';
 export * from '@mantine/form';
+export {Pagination} from '@mantine/core';
 // explicitly overriding mantine components
-export {Header, Table, type HeaderProps, Modal, Button, type ButtonProps, Menu, type MenuItemProps} from './components';
+export {
+    Header,
+    Table,
+    type TableProps,
+    type HeaderProps,
+    Modal,
+    Button,
+    type ButtonProps,
+    Menu,
+    type MenuItemProps,
+} from './components';
 export {useForm, createFormContext} from './form';
 
 export * from './theme';

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -29,6 +29,7 @@
         "@coveord/plasma-tokens": "workspace:*",
         "@emotion/react": "11.10.5",
         "@emotion/server": "11.10.0",
+        "@faker-js/faker": "7.6.0",
         "@mantine/carousel": "5.9.2",
         "@mantine/core": "5.9.2",
         "@mantine/dates": "5.9.2",
@@ -37,10 +38,10 @@
         "@mantine/modals": "5.9.2",
         "@mantine/next": "5.9.2",
         "@mantine/prism": "5.9.2",
+        "@tanstack/match-sorter-utils": "8.7.6",
         "clsx": "1.2.1",
         "codesandbox-import-utils": "2.2.3",
         "embla-carousel-react": "7.0.4",
-        "faker": "4.1.0",
         "flagg": "1.1.2",
         "lodash.kebabcase": "4.1.1",
         "lorem-ipsum": "2.0.4",
@@ -66,7 +67,6 @@
         "underscore": "1.13.1"
     },
     "devDependencies": {
-        "@types/faker": "4.1.12",
         "@types/hoist-non-react-statics": "3.3.1",
         "@types/lodash.kebabcase": "4.1.7",
         "@types/lorem-ipsum": "2.0.0",

--- a/packages/website/src/examples/layout/Table/TableClientSide.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableClientSide.demo.tsx
@@ -1,0 +1,65 @@
+import {
+    ColumnDef,
+    createColumnHelper,
+    Table,
+    getSortedRowModel,
+    TableProps,
+    getPaginationRowModel,
+    getFilteredRowModel,
+    FilterFn,
+} from '@coveord/plasma-mantine';
+import {faker} from '@faker-js/faker';
+import {rankItem} from '@tanstack/match-sorter-utils';
+import {useState} from 'react';
+
+export type Person = {
+    firstName: string;
+    lastName: string;
+    age: number;
+};
+
+const makeData = (len: number) =>
+    Array(len)
+        .fill(0)
+        .map(() => ({
+            firstName: faker.name.firstName(),
+            lastName: faker.name.lastName(),
+            age: faker.datatype.number(40),
+        }));
+
+const fuzzyFilter: FilterFn<Person> = (row, columnId, value) => rankItem(row.getValue(columnId), value).passed;
+export default () => {
+    const columnHelper = createColumnHelper<Person>();
+    const columns: Array<ColumnDef<Person>> = [
+        columnHelper.accessor('firstName', {
+            header: 'First name',
+            cell: (info) => info.row.original.firstName,
+        }),
+        columnHelper.accessor('lastName', {
+            header: 'Last name',
+            cell: (info) => info.row.original.lastName,
+        }),
+        columnHelper.accessor('age', {
+            header: 'Age',
+            cell: (info) => info.row.original.age,
+        }),
+    ];
+    const [data] = useState(() => makeData(45));
+    const options: TableProps<Person>['options'] = {
+        globalFilterFn: fuzzyFilter,
+        getFilteredRowModel: getFilteredRowModel(),
+        getPaginationRowModel: getPaginationRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+    };
+    return (
+        <Table data={data} columns={columns} options={options} initialState={{pagination: {pageSize: 5}}}>
+            <Table.Header>
+                <Table.Filter placeholder="Search" />
+            </Table.Header>
+            <Table.Footer>
+                <Table.PerPage values={[5, 10, 25]} />
+                <Table.Pagination totalPages={null} />
+            </Table.Footer>
+        </Table>
+    );
+};

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -1,6 +1,7 @@
 import {TableMetadata} from '@coveord/plasma-components-props-analyzer';
 import TableDemo from '@examples/layout/Table/Table.demo.tsx';
 import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo.tsx';
+import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -15,6 +16,9 @@ const DemoPage = () => (
         demo={<TableDemo noPadding layout="vertical" />}
         examples={{
             multiSelect: <TableMultiSelectionDemo noPadding title="Table with bulk selection of rows" />,
+            clientSide: (
+                <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
+            ),
         }}
     />
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,6 +584,7 @@ importers:
       '@coveord/plasma-tokens': workspace:*
       '@emotion/react': 11.10.5
       '@emotion/server': 11.10.0
+      '@faker-js/faker': 7.6.0
       '@mantine/carousel': 5.9.2
       '@mantine/core': 5.9.2
       '@mantine/dates': 5.9.2
@@ -592,7 +593,7 @@ importers:
       '@mantine/modals': 5.9.2
       '@mantine/next': 5.9.2
       '@mantine/prism': 5.9.2
-      '@types/faker': 4.1.12
+      '@tanstack/match-sorter-utils': 8.7.6
       '@types/hoist-non-react-statics': 3.3.1
       '@types/lodash.kebabcase': 4.1.7
       '@types/lorem-ipsum': 2.0.0
@@ -608,7 +609,6 @@ importers:
       clsx: 1.2.1
       codesandbox-import-utils: 2.2.3
       embla-carousel-react: 7.0.4
-      faker: 4.1.0
       flagg: 1.1.2
       lint-staged: 9.5.0
       lodash.kebabcase: 4.1.1
@@ -650,6 +650,7 @@ importers:
       '@coveord/plasma-tokens': link:../tokens
       '@emotion/react': 11.10.5_fan5qbzahqtxlm5dzefqlqx5ia
       '@emotion/server': 11.10.0
+      '@faker-js/faker': 7.6.0
       '@mantine/carousel': 5.9.2_vzbzlksjql4iqmbkce5tizjbp4
       '@mantine/core': 5.9.2_nqa2babo2zxfxcmf2phkfqk5yi
       '@mantine/dates': 5.9.2_2pltzneqv4wv27mewoeyrtq5am
@@ -658,10 +659,10 @@ importers:
       '@mantine/modals': 5.9.2_uw7trfygy6zitf2mjy7qrym72y
       '@mantine/next': 5.9.2_zr4hdbjzuvmthwg2ulf6h3lsha
       '@mantine/prism': 5.9.2_uw7trfygy6zitf2mjy7qrym72y
+      '@tanstack/match-sorter-utils': 8.7.6
       clsx: 1.2.1
       codesandbox-import-utils: 2.2.3
       embla-carousel-react: 7.0.4_react@18.2.0
-      faker: 4.1.0
       flagg: 1.1.2
       lodash.kebabcase: 4.1.1
       lorem-ipsum: 2.0.4
@@ -686,7 +687,6 @@ importers:
       reselect: 4.1.5
       underscore: 1.13.1
     devDependencies:
-      '@types/faker': 4.1.12
       '@types/hoist-non-react-statics': 3.3.1
       '@types/lodash.kebabcase': 4.1.7
       '@types/lorem-ipsum': 2.0.0
@@ -1496,6 +1496,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@faker-js/faker/7.6.0:
+    resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    dev: false
 
   /@floating-ui/core/1.0.3:
     resolution: {integrity: sha512-27FDAEVHrAEQI1UV+7FIjZrFK862gBoAG0USoPMU7RoBCmaTDt6bnKVW/J2uPnOPI6TWqiWGtS7RFN+tN/k+vQ==}
@@ -2726,6 +2731,13 @@ packages:
       '@swc/core': 1.3.22
       jsonc-parser: 3.2.0
     dev: true
+
+  /@tanstack/match-sorter-utils/8.7.6:
+    resolution: {integrity: sha512-2AMpRiA6QivHOUiBpQAVxjiHAA68Ei23ZUMNaRJrN6omWiSFLoYrxGcT6BXtuzp0Jw4h6HZCmGGIM/gbwebO2A==}
+    engines: {node: '>=12'}
+    dependencies:
+      remove-accents: 0.4.2
+    dev: false
 
   /@tanstack/react-table/8.7.9_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-6MbbQn5AupSOkek1+6IYu+1yZNthAKTRZw9tW92Vi6++iRrD1GbI3lKTjJalf8lEEKOqapPzQPE20nywu0PjCA==}
@@ -7613,6 +7625,7 @@ packages:
 
   /faker/4.1.0:
     resolution: {integrity: sha512-ILKg69P6y/D8/wSmDXw35Ly0re8QzQ8pMfBCflsGiZG2ZjMUNLYNexA6lz5pkmJlepVdsiDFUxYAzPQ9/+iGLA==}
+    dev: true
 
   /fancy-log/1.3.3:
     resolution: {integrity: sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==}
@@ -14218,6 +14231,10 @@ packages:
       remark-stringify: 6.0.4
       unified: 7.1.0
     dev: true
+
+  /remove-accents/0.4.2:
+    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
+    dev: false
 
   /remove-bom-buffer/3.0.0:
     resolution: {integrity: sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==}


### PR DESCRIPTION
### Proposed Changes

Add options prop to the Mantine table. This enables the developer to create client side filtering, pagination, sorting, etc.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
