### PR TITLE
fix(mantine): adjust table sort icons

### DIFF
--- a/packages/mantine/src/components/table/Th.tsx
+++ b/packages/mantine/src/components/table/Th.tsx
@@ -1,4 +1,4 @@
-import {ArrowHeadDownSize16Px, ArrowHeadUpSize16Px} from '@coveord/plasma-react-icons';
+import {ArrowDownSize16Px, ArrowUpSize16Px, DoubleArrowHeadVSize16Px} from '@coveord/plasma-react-icons';
 import {Center, createStyles, Group, Text, UnstyledButton} from '@mantine/core';
 import {defaultColumnSizing, flexRender, Header} from '@tanstack/react-table';
 
@@ -26,13 +26,15 @@ interface ThProps<T> {
 }
 
 const SortingIcons = {
-    asc: ArrowHeadDownSize16Px,
-    desc: ArrowHeadUpSize16Px,
+    asc: ArrowUpSize16Px,
+    desc: ArrowDownSize16Px,
+    none: DoubleArrowHeadVSize16Px,
 };
 
 const SortingLabels = {
     asc: 'ascending',
     desc: 'descending',
+    none: 'none',
 } as const;
 
 export const Th = <T,>({header}: ThProps<T>) => {
@@ -55,15 +57,15 @@ export const Th = <T,>({header}: ThProps<T>) => {
     }
 
     const onSort = header.column.getToggleSortingHandler();
-    const sortingOrder = header.column.getIsSorted();
-    const Icon = SortingIcons[sortingOrder || header.column.getFirstSortDir()];
+    const sortingOrder = header.column.getIsSorted() || 'none';
+    const Icon = SortingIcons[sortingOrder];
 
     return (
-        <th className={classes.th} style={{width}} aria-sort={sortingOrder ? SortingLabels[sortingOrder] : 'none'}>
+        <th className={classes.th} style={{width}} aria-sort={SortingLabels[sortingOrder]}>
             <UnstyledButton onClick={onSort} className={classes.control}>
                 <Group position="apart" noWrap>
                     <Text size="xs">{flexRender(header.column.columnDef.header, header.getContext())}</Text>
-                    <Center sx={(theme) => ({color: sortingOrder ? theme.colors.action[8] : undefined})}>
+                    <Center>
                         <Icon height={14} />
                     </Center>
                 </Group>

--- a/packages/mantine/src/components/table/__tests__/Th.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Th.spec.tsx
@@ -22,15 +22,11 @@ describe('Th', () => {
         ];
         render(<Table data={data} columns={columns} />);
 
-        // icons are loadable, wait for them to load
-        await screen.findByRole('img', {name: 'arrowHeadDown'});
-        await screen.findByRole('img', {name: 'arrowHeadUp'});
-
         const headers = screen.getAllByRole('button');
         expect(headers.length).toBe(2);
 
-        expect(headers[0]).toHaveAccessibleName('name arrowHeadDown');
-        expect(headers[1]).toHaveAccessibleName('type arrowHeadUp');
+        expect(headers[0]).toHaveAccessibleName(/name doubleArrowHead/i);
+        expect(headers[1]).toHaveAccessibleName(/type doubleArrowHead/i);
     });
 
     it('changes the sort icon when clicking on a table header', async () => {
@@ -41,22 +37,17 @@ describe('Th', () => {
         const onChange = vi.fn();
         render(<Table data={data} columns={columns} onChange={onChange} />);
 
-        // icons are loadable, wait for them to load
-        await screen.findAllByRole('img', {name: 'arrowHeadDown'});
-        await screen.findAllByRole('img', {name: 'arrowHeadUp'});
-
-        userEvent.click(screen.getByRole('button', {name: /name arrowheaddown/i}));
+        userEvent.click(screen.getByRole('button', {name: /name doubleArrowHead/i}));
         await waitFor(() => {
             expect(onChange).toHaveBeenCalledWith(expect.objectContaining({sorting: [{id: 'name', desc: false}]}));
         });
 
-        userEvent.click(screen.getByRole('button', {name: 'name arrowHeadDown'}));
+        userEvent.click(screen.getByRole('button', {name: /name arrowUp/i}));
         await waitFor(() => {
             expect(onChange).toHaveBeenCalledWith(expect.objectContaining({sorting: [{id: 'name', desc: true}]}));
         });
 
-        await waitFor(() => expect(screen.queryByRole('button', {name: 'name arrowHeadUp'})).toBeVisible());
-        userEvent.click(screen.getByRole('button', {name: 'name arrowHeadUp'}));
+        userEvent.click(screen.getByRole('button', {name: /name arrowDown/i}));
         await waitFor(() => {
             expect(onChange).toHaveBeenCalledWith(expect.objectContaining({sorting: [{id: 'name', desc: false}]}));
         });


### PR DESCRIPTION
### Proposed Changes

Change the icons used for table sorting

Before:

Unsorted
<img width="321" alt="image" src="https://user-images.githubusercontent.com/35579930/217955270-7cfd0bfa-8ca4-4d65-bf7e-4c32eb990324.png">
Sorted ascending
<img width="338" alt="image" src="https://user-images.githubusercontent.com/35579930/217955331-f7a86efb-c55e-4114-8eaa-8e3528aaa981.png">
Sorted descending
<img width="314" alt="image" src="https://user-images.githubusercontent.com/35579930/217955369-997de9ed-58fc-4bf7-9c94-c23f259d278c.png">

After:

Unsorted
<img width="328" alt="image" src="https://user-images.githubusercontent.com/35579930/217955998-4ad13cb2-9345-45c7-a1f6-5ecc9efa3049.png">

Sorted ascending
<img width="333" alt="image" src="https://user-images.githubusercontent.com/35579930/217956083-4d000b51-795f-48d2-a663-9d9488798114.png">

Sorted descending
<img width="327" alt="image" src="https://user-images.githubusercontent.com/35579930/217956041-7b6ae8d6-bebe-43cb-98d3-1a3b88409e2e.png">


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
