### PR TITLE
fix(ModalWizard): some fixes to the ModalWizard

### DIFF
--- a/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
+++ b/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
@@ -20,7 +20,7 @@ const useStyles = createStyles(() => ({
 
 type ModalWizardStylesNames = Selectors<typeof useStyles>;
 
-interface ModalWizardProps
+export interface ModalWizardProps
     extends Omit<DefaultProps<ModalWizardStylesNames>, 'classNames' | 'styles'>,
         Omit<ModalProps, 'centered' | 'title'> {
     /**

--- a/packages/mantine/src/components/modal-wizard/ModalWizardStep.tsx
+++ b/packages/mantine/src/components/modal-wizard/ModalWizardStep.tsx
@@ -16,7 +16,7 @@ export interface ModalWizardStepProps {
     /**
      * A link to the documentation for the current step
      */
-    docLink: string;
+    docLink?: string;
 
     /**
      * A tooltip label for the docLink


### PR DESCRIPTION
CTCORE-8959

### Proposed Changes
This exports the `ModalWizardProps` interface and makes the `docLink` prop of the `ModalWizardStep` optional.

### Potential Breaking Changes

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
