### PR TITLE
fix(mantine): hide table on unfiltered empty state

### DIFF
--- a/packages/mantine/src/__tests__/VitestSetup.ts
+++ b/packages/mantine/src/__tests__/VitestSetup.ts
@@ -1,5 +1,10 @@
-import matchers from '@testing-library/jest-dom/matchers';
+import matchers, {TestingLibraryMatchers} from '@testing-library/jest-dom/matchers';
 import {cleanup} from '@testing-library/react';
+declare global {
+    namespace Vi {
+        interface JestAssertion<T = any> extends jest.Matchers<void, T>, TestingLibraryMatchers<T, void> {}
+    }
+}
 expect.extend(matchers);
 Object.defineProperty(window, 'matchMedia', {
     writable: true,

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -223,6 +223,11 @@ export const Table: TableType = <T,>({
         onStateChange: setState,
     }));
     const {clearSelection, getSelectedRow, getSelectedRows} = useRowSelection(table);
+    const isFiltered =
+        !!state.globalFilter ||
+        Object.keys(form.values?.predicates ?? {}).some((predicate) => !!form.values.predicates[predicate]) ||
+        !!form.values.dateRange?.[0] ||
+        !!form.values.dateRange?.[1];
 
     const triggerChange = () => onChange?.({...state, ...form.values});
 
@@ -238,7 +243,7 @@ export const Table: TableType = <T,>({
     }, [state.globalFilter, state.sorting, state.pagination, form.values]);
 
     const clearFilters = useCallback(() => {
-        form.setFieldValue('predicates', {});
+        form.setFieldValue('predicates', initialState.predicates ?? {});
         setState((prevState) => ({...prevState, globalFilter: ''}));
     }, []);
 
@@ -313,6 +318,7 @@ export const Table: TableType = <T,>({
                 value={{
                     onChange: triggerChange,
                     state,
+                    isFiltered,
                     setState,
                     clearFilters,
                     getSelectedRow,
@@ -324,28 +330,34 @@ export const Table: TableType = <T,>({
                     getPageCount: table.getPageCount,
                 }}
             >
-                {header}
-                <MantineTable className={classes.table} horizontalSpacing="sm" verticalSpacing="xs" pb="sm">
-                    <thead className={classes.header}>
-                        {table.getHeaderGroups().map((headerGroup) => (
-                            <tr key={headerGroup.id}>
-                                {headerGroup.headers.map((columnHeader) => (
-                                    <Th key={columnHeader.id} header={columnHeader} />
+                {!rows.length && !isFiltered && !loading ? (
+                    noDataChildren
+                ) : (
+                    <>
+                        {header}
+                        <MantineTable className={classes.table} horizontalSpacing="sm" verticalSpacing="xs" pb="sm">
+                            <thead className={classes.header}>
+                                {table.getHeaderGroups().map((headerGroup) => (
+                                    <tr key={headerGroup.id}>
+                                        {headerGroup.headers.map((columnHeader) => (
+                                            <Th key={columnHeader.id} header={columnHeader} />
+                                        ))}
+                                    </tr>
                                 ))}
-                            </tr>
-                        ))}
-                    </thead>
-                    <tbody>
-                        {rows.length ? (
-                            rows
-                        ) : (
-                            <tr>
-                                <td colSpan={columns.length}>{noDataChildren}</td>
-                            </tr>
-                        )}
-                    </tbody>
-                </MantineTable>
-                {footer}
+                            </thead>
+                            <tbody>
+                                {rows.length ? (
+                                    rows
+                                ) : (
+                                    <tr>
+                                        <td colSpan={columns.length}>{noDataChildren}</td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </MantineTable>
+                        {footer}
+                    </>
+                )}
             </TableContext.Provider>
         </Box>
     );

--- a/packages/mantine/src/components/table/TableContext.tsx
+++ b/packages/mantine/src/components/table/TableContext.tsx
@@ -36,6 +36,11 @@ type TableContextType = {
      */
     setState: Dispatch<(prevState: TableState) => TableState>;
     /**
+     * Whether the table currently as any kind of filter applied.
+     * Useful to determine if the noDataChildren is an empty state or just the result of a filter
+     */
+    isFiltered: boolean;
+    /**
      * Function that clears the filter and predicates
      */
     clearFilters: () => void;

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -66,7 +66,7 @@ const Demo = ({children, snippet, center = false, grow = false, title, layout, n
     return (
         <div className={classes.root}>
             {title ? (
-                <Title order={6} mb="xs">
+                <Title order={5} mb="xs">
                     {title}
                 </Title>
             ) : null}

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -98,8 +98,7 @@ export default () => {
 };
 
 const NoData: FunctionComponent = () => {
-    const {state, form, clearFilters} = useTable();
-    const isFiltered = !!state.globalFilter || !!form.values.predicates.user;
+    const {clearFilters, isFiltered} = useTable();
 
     return isFiltered ? (
         <BlankSlate>

--- a/packages/website/src/examples/layout/Table/TableEmptyState.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableEmptyState.demo.tsx
@@ -1,0 +1,58 @@
+import {BlankSlate, Button, ColumnDef, createColumnHelper, Table, Title, useTable} from '@coveord/plasma-mantine';
+import {NoContentSize32Px} from '@coveord/plasma-react-icons';
+
+export type Person = {
+    firstName: string;
+    lastName: string;
+    age: number;
+};
+
+const NoData = () => {
+    const {isFiltered, clearFilters, state} = useTable();
+
+    return isFiltered ? (
+        <BlankSlate>
+            <Title order={4}>No data found for filter "{state.globalFilter}"</Title>
+            <Button onClick={clearFilters}>Clear filter</Button>
+        </BlankSlate>
+    ) : (
+        <BlankSlate withBorder={false}>
+            <NoContentSize32Px height={64} />
+            <Title order={4}>Hello Empty State</Title>
+        </BlankSlate>
+    );
+};
+
+export default () => (
+    <Table
+        data={[]}
+        columns={columns}
+        noDataChildren={<NoData />}
+        initialState={{globalFilter: 'foo', pagination: {pageSize: 5}}}
+    >
+        <Table.Header>
+            <Table.Filter placeholder="Search" />
+        </Table.Header>
+        <Table.Footer>
+            <Table.PerPage values={[5, 10, 25]} />
+            <Table.Pagination totalPages={null} />
+        </Table.Footer>
+    </Table>
+);
+
+const columnHelper = createColumnHelper<Person>();
+
+const columns: Array<ColumnDef<Person>> = [
+    columnHelper.accessor('firstName', {
+        header: 'First name',
+        cell: (info) => info.row.original.firstName,
+    }),
+    columnHelper.accessor('lastName', {
+        header: 'Last name',
+        cell: (info) => info.row.original.lastName,
+    }),
+    columnHelper.accessor('age', {
+        header: 'Age',
+        cell: (info) => info.row.original.age,
+    }),
+];

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -73,8 +73,7 @@ export default () => {
 };
 
 const NoData: FunctionComponent = () => {
-    const {state, form, clearFilters} = useTable();
-    const isFiltered = !!state.globalFilter || !!form.values.predicates.user;
+    const {isFiltered, clearFilters} = useTable();
 
     return isFiltered ? (
         <BlankSlate>

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -2,6 +2,7 @@ import {TableMetadata} from '@coveord/plasma-components-props-analyzer';
 import TableDemo from '@examples/layout/Table/Table.demo.tsx';
 import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo.tsx';
 import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo.tsx';
+import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -19,6 +20,7 @@ const DemoPage = () => (
             clientSide: (
                 <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
             ),
+            emptyState: <TableEmptyStateDemo noPadding title="Table with empty states" />,
         }}
     />
 );


### PR DESCRIPTION
### Proposed Changes

When a table has no data and is unfiltered, show the `noDataChildren` but hide the header and footer. If the table is filtered, either by a regular filter, a predicate or a date range, show the `noDataChildren` with the header and footer.

Added a demo for it in the table section.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
