### PR TITLE
fix(table): disable row selection when table is loading

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -15,7 +15,7 @@ import defaultsDeep from 'lodash.defaultsdeep';
 import {Children, Fragment, ReactElement, ReactNode, useCallback, useEffect, useState} from 'react';
 
 import {TableActions} from './TableActions';
-import {TableCollapsibleColumn, TableAccordionColumn} from './TableCollapsibleColumn';
+import {TableAccordionColumn, TableCollapsibleColumn} from './TableCollapsibleColumn';
 import {onTableChangeEvent, TableContext, TableFormType} from './TableContext';
 import {TableDateRangePicker} from './TableDateRangePicker';
 import {TableFilter} from './TableFilter';
@@ -163,6 +163,7 @@ export interface TableProps<T> {
         | 'enableMultiRowSelection'
         | 'getRowId'
         | 'getRowCanExpand'
+        | 'enableRowSelection'
     >;
 }
 
@@ -214,6 +215,7 @@ export const Table: TableType = <T,>({
         enableMultiRowSelection: !!multiRowSelectionEnabled,
         getRowId,
         getRowCanExpand: (row: Row<T>) => !!getExpandChildren?.(row.original) ?? false,
+        enableRowSelection: !loading,
         ...options,
     });
     const [state, setState] = useState<TableState>(table.initialState);

--- a/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
@@ -35,6 +35,22 @@ describe('Table.Actions', () => {
         expect(screen.getByRole('button', {name: 'Eat vegetable'})).toBeVisible();
     });
 
+    it('does not display the action when a loading row is selected', async () => {
+        const user = userEvent.setup({delay: null});
+        render(
+            <Table<RowData> data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns} loading={true}>
+                <Table.Header>
+                    <Table.Actions>{(datum: RowData) => <Button>Eat {datum.name}</Button>}</Table.Actions>
+                </Table.Header>
+            </Table>
+        );
+        await user.click(screen.getByRole('cell', {name: 'fruit'}));
+        expect(screen.getByRole('row', {name: 'fruit', selected: false})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Eat fruit'})).not.toBeInTheDocument();
+        expect(screen.getByRole('row', {name: 'vegetable', selected: false})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Eat vegetable'})).not.toBeInTheDocument();
+    });
+
     describe('when multi row selection is enabled', () => {
         it('passes down an array of selected rows', async () => {
             const user = userEvent.setup({delay: null});


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-1147

`enableRowSelection` option from tanStack table is now handled with the loading prop. Table row are not selectable anymore when the table rows are loading (Skeleton)

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
