### PR TITLE
refactor(mantine): extract table styles into its own file

### DIFF
--- a/packages/mantine/src/components/table/Table.styles.ts
+++ b/packages/mantine/src/components/table/Table.styles.ts
@@ -1,0 +1,58 @@
+import {createStyles} from '@mantine/core';
+
+interface TableStylesParams {
+    hasHeader: boolean;
+    multiRowSelectionEnabled: boolean;
+}
+
+const useStyles = createStyles<string, TableStylesParams>((theme, {hasHeader, multiRowSelectionEnabled}) => {
+    const rowBackgroundColor =
+        theme.colorScheme === 'dark'
+            ? theme.fn.rgba(theme.colors[theme.primaryColor][7], 0.2)
+            : theme.colors[theme.primaryColor][0];
+    return {
+        table: {
+            width: '100%',
+            '& td:first-of-type, th:first-of-type > *': {
+                paddingLeft: theme.spacing.xl,
+            },
+            '& tbody td': {
+                verticalAlign: 'top',
+            },
+        },
+
+        header: {
+            position: 'sticky',
+            top: hasHeader ? 69 : 0,
+            backgroundColor: theme.colorScheme === 'dark' ? theme.black : theme.white,
+            transition: 'box-shadow 150ms ease',
+            zIndex: 12, // skeleton is 11
+
+            '&::after': {
+                content: '""',
+                position: 'absolute',
+                left: 0,
+                right: 0,
+                bottom: 0,
+                borderBottom: `1px solid ${theme.colors.gray[2]}`,
+            },
+        },
+
+        rowSelected: {
+            backgroundColor: multiRowSelectionEnabled ? undefined : rowBackgroundColor,
+        },
+
+        rowCollapsibleButtonCell: {
+            textAlign: 'right',
+            padding: `${theme.spacing.xs / 2}px ${theme.spacing.sm}px !important`,
+        },
+
+        row: {
+            '&:hover': {
+                backgroundColor: rowBackgroundColor,
+            },
+        },
+    };
+});
+
+export default useStyles;

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -1,4 +1,4 @@
-import {Box, Center, Collapse, createStyles, Loader, Skeleton, Table as MantineTable} from '@mantine/core';
+import {Box, Center, Collapse, Loader, Skeleton, Table as MantineTable} from '@mantine/core';
 import {useForm} from '@mantine/form';
 import {useClickOutside, useDidUpdate} from '@mantine/hooks';
 import {
@@ -15,6 +15,7 @@ import debounce from 'lodash.debounce';
 import defaultsDeep from 'lodash.defaultsdeep';
 import {Children, Fragment, ReactElement, ReactNode, useCallback, useEffect, useState} from 'react';
 
+import useStyles from './Table.styles';
 import {TableActions} from './TableActions';
 import {TableAccordionColumn, TableCollapsibleColumn} from './TableCollapsibleColumn';
 import {onTableChangeEvent, TableContext, TableFormType} from './TableContext';
@@ -28,61 +29,6 @@ import {TablePredicate} from './TablePredicate';
 import {TableSelectableColumn} from './TableSelectableColumn';
 import {Th} from './Th';
 import {useRowSelection} from './useRowSelection';
-
-interface TableStylesParams {
-    hasHeader: boolean;
-    multiRowSelectionEnabled: boolean;
-}
-
-const useStyles = createStyles<string, TableStylesParams>((theme, {hasHeader, multiRowSelectionEnabled}) => {
-    const rowBackgroundColor =
-        theme.colorScheme === 'dark'
-            ? theme.fn.rgba(theme.colors[theme.primaryColor][7], 0.2)
-            : theme.colors[theme.primaryColor][0];
-    return {
-        table: {
-            width: '100%',
-            '& td:first-of-type, th:first-of-type > *': {
-                paddingLeft: theme.spacing.xl,
-            },
-            '& tbody td': {
-                verticalAlign: 'top',
-            },
-        },
-
-        header: {
-            position: 'sticky',
-            top: hasHeader ? 69 : 0,
-            backgroundColor: theme.colorScheme === 'dark' ? theme.black : theme.white,
-            transition: 'box-shadow 150ms ease',
-            zIndex: 12, // skeleton is 11
-
-            '&::after': {
-                content: '""',
-                position: 'absolute',
-                left: 0,
-                right: 0,
-                bottom: 0,
-                borderBottom: `1px solid ${theme.colors.gray[2]}`,
-            },
-        },
-
-        rowSelected: {
-            backgroundColor: multiRowSelectionEnabled ? undefined : rowBackgroundColor,
-        },
-
-        rowCollapsibleButtonCell: {
-            textAlign: 'right',
-            padding: `${theme.spacing.xs / 2}px ${theme.spacing.sm}px !important`,
-        },
-
-        row: {
-            '&:hover': {
-                backgroundColor: rowBackgroundColor,
-            },
-        },
-    };
-});
 
 export interface TableProps<T> {
     /**


### PR DESCRIPTION
### Proposed Changes

As we're adding more features to the table component, its file is growing in size. Since mantine stores components styles in  separate files for all of its component in its codebase I figured it could not hurt to do it for our table too.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
