### PR TITLE
fix(collection item): icons alignment

### DIFF
--- a/packages/mantine/src/components/collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/collection/CollectionItem.tsx
@@ -19,7 +19,7 @@ interface CollectionItemSharedProps extends DefaultProps<Selectors<typeof useSty
 const RemoveButton: FunctionComponent<{
     onClick: React.MouseEventHandler<HTMLButtonElement>;
 }> = ({onClick}) => (
-    <ActionIcon variant="subtle" onClick={onClick} color="action">
+    <ActionIcon sx={{alignSelf: 'center'}} variant="subtle" onClick={onClick} color="action">
         <RemoveSize16Px height={16} />
     </ActionIcon>
 );
@@ -69,7 +69,7 @@ const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionIte
                     {...provided.draggableProps}
                     className={cx(classes.item, {[classes.itemDragging]: isDragging})}
                 >
-                    <div {...provided.dragHandleProps}>
+                    <div {...provided.dragHandleProps} style={{alignSelf: 'center'}}>
                         <DragAndDropSize16Px height={16} />
                     </div>
                     {children}


### PR DESCRIPTION
### Proposed Changes

Alignment of the `<Collection />` component icons are ajusted to appear at the center on their Y axis.
Valid for the drad and drop icon and the remove icon.

BEFORE
![2023-02-22_15-11](https://user-images.githubusercontent.com/45688129/220748726-21bd3aea-7dec-4aed-b137-31fcf8cb24b2.png)


AFTER
![2023-02-22_15-02](https://user-images.githubusercontent.com/45688129/220748651-9b583ea1-8ee4-4f03-890c-01b6d92f1a7c.png)



 

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
