### PR TITLE
Allow Mantine table to have an initial row selection

### DIFF
--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -29,6 +29,7 @@
         "@tanstack/react-table": "8.7.9",
         "@tanstack/table-core": "8.7.9",
         "dayjs": "1.11.3",
+        "fast-deep-equal": "3.1.3",
         "lodash.debounce": "4.0.8",
         "lodash.defaultsdeep": "4.6.1",
         "monaco-editor": "0.34.0",

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -5,7 +5,7 @@ import {
     CoreOptions,
     InitialTableState as TanstackInitialTableState,
     TableOptions,
-    TableState,
+    TableState as TanstackTableState,
 } from '@tanstack/table-core';
 import {Dispatch, ReactElement, ReactNode, RefObject} from 'react';
 
@@ -19,9 +19,19 @@ import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
 
-export type onTableChangeEvent = (params: TableState & TableFormType) => void;
+export type RowSelectionWithData<TData> = Record<string, TData>;
+export interface RowSelectionState<TData> {
+    rowSelection: RowSelectionWithData<TData>;
+}
 
-export interface InitialTableState extends TanstackInitialTableState, Partial<TableFormType> {}
+export interface TableState<TData> extends Omit<TanstackTableState, 'rowSelection'>, RowSelectionState<TData> {}
+
+export interface InitialTableState<TData>
+    extends Omit<TanstackInitialTableState, 'rowSelection'>,
+        Partial<RowSelectionState<TData>>,
+        Partial<TableFormType> {}
+
+export type onTableChangeEvent<TData> = (params: TableState<TData> & TableFormType) => void;
 
 export type TableFormType = {
     /**
@@ -48,11 +58,11 @@ export type TableContextType<TData> = {
      *
      * @see https://tanstack.com/table/v8/docs/api/core/table#state
      */
-    state: TableState;
+    state: TableState<TData>;
     /**
      * Function to update the table state
      */
-    setState: Dispatch<(prevState: TableState) => TableState>;
+    setState: Dispatch<(prevState: TableState<TData>) => TableState<TData>>;
     /**
      * Whether the table currently as any kind of filter applied.
      * Useful to determine if the noDataChildren is an empty state or just the result of a filter
@@ -112,13 +122,13 @@ export interface TableProps<T> {
      *
      * @param state the state of the table
      */
-    onMount?: onTableChangeEvent;
+    onMount?: onTableChangeEvent<T>;
     /**
      * Function called when the table should update
      *
      * @param state the state of the table
      */
-    onChange?: onTableChangeEvent;
+    onChange?: onTableChangeEvent<T>;
     /**
      * Function that generates the expandable content of a row
      * Return null for rows that don't need to be expandable
@@ -150,7 +160,7 @@ export interface TableProps<T> {
     /**
      * Initial state of the table
      */
-    initialState?: InitialTableState;
+    initialState?: InitialTableState<T>;
     /**
      * Action passed when user double clicks on a row
      */

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -5,7 +5,7 @@ import {FunctionComponent} from 'react';
 import {Table} from '../Table';
 import {useTable} from '../TableContext';
 
-type RowData = {firstName: string; lastName?: string};
+type RowData = {id: string; firstName: string; lastName?: string};
 
 const columnHelper = createColumnHelper<RowData>();
 const columns: Array<ColumnDef<RowData>> = [
@@ -15,7 +15,13 @@ const columns: Array<ColumnDef<RowData>> = [
 
 describe('Table', () => {
     it('renders the data', () => {
-        render(<Table data={[{firstName: 'first', lastName: 'last'}]} columns={columns} />);
+        render(
+            <Table
+                getRowId={({id}) => id}
+                data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
+                columns={columns}
+            />
+        );
 
         expect(screen.getByRole('columnheader', {name: 'firstName'})).toBeVisible();
         expect(screen.getByRole('columnheader', {name: 'lastName'})).toBeVisible();
@@ -45,7 +51,7 @@ describe('Table', () => {
                 enableSorting: false,
             }),
         ];
-        render(<Table data={[{firstName: 'first', lastName: 'last'}]} columns={customColumns} />);
+        render(<Table data={[{id: '🆔', firstName: 'first', lastName: 'last'}]} columns={customColumns} />);
 
         expect(screen.getByRole('columnheader', {name: 'First Name'})).toBeVisible();
         expect(screen.getByRole('columnheader', {name: 'Last Name'})).toBeVisible();
@@ -141,7 +147,8 @@ describe('Table', () => {
         ];
         render(
             <Table
-                data={[{firstName: 'first', lastName: 'last'}]}
+                getRowId={({id}) => id}
+                data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
                 getExpandChildren={(row: RowData) => <Fixture row={row} />}
                 columns={customColumns}
             />
@@ -172,10 +179,11 @@ describe('Table', () => {
         ];
         render(
             <Table
+                getRowId={({id}) => id}
                 data={[
-                    {firstName: 'Luke', lastName: 'Skywalker'},
-                    {firstName: 'Lea', lastName: 'Skywalker'},
-                    {firstName: 'Han', lastName: 'Solo'},
+                    {id: '🆔-1', firstName: 'Luke', lastName: 'Skywalker'},
+                    {id: '🆔-2', firstName: 'Lea', lastName: 'Skywalker'},
+                    {id: '🆔-3', firstName: 'Han', lastName: 'Solo'},
                 ]}
                 getExpandChildren={(row: RowData) => (row.lastName === 'Skywalker' ? <Fixture row={row} /> : null)}
                 columns={customColumns}
@@ -200,9 +208,10 @@ describe('Table', () => {
         ];
         render(
             <Table
+                getRowId={({id}) => id}
                 data={[
-                    {firstName: 'Jack', lastName: 'Russel'},
-                    {firstName: 'Golden', lastName: 'Retriever'},
+                    {id: '🆔-1', firstName: 'Jack', lastName: 'Russel'},
+                    {id: '🆔-2', firstName: 'Golden', lastName: 'Retriever'},
                 ]}
                 getExpandChildren={(row: RowData) => <Fixture row={row} />}
                 columns={customColumns}
@@ -234,14 +243,18 @@ describe('Table', () => {
         const doubleClickSpy = vi.fn();
         render(
             <Table<RowData>
-                data={[{firstName: 'Mario'}, {firstName: 'Luigi'}]}
+                getRowId={({id}) => id}
+                data={[
+                    {id: '🆔-1', firstName: 'Mario'},
+                    {id: '🆔-2', firstName: 'Luigi'},
+                ]}
                 columns={columns}
                 doubleClickAction={doubleClickSpy}
             ></Table>
         );
         await user.dblClick(screen.getByRole('cell', {name: 'Mario'}));
         expect(doubleClickSpy).toHaveBeenCalledTimes(1);
-        expect(doubleClickSpy).toHaveBeenCalledWith({firstName: 'Mario'});
+        expect(doubleClickSpy).toHaveBeenCalledWith({id: '🆔-1', firstName: 'Mario'});
     });
 
     it('reset row selection when user click outside the table', async () => {
@@ -250,9 +263,10 @@ describe('Table', () => {
             <div>
                 <div>I'm a header</div>
                 <Table
+                    getRowId={({id}) => id}
                     data={[
-                        {firstName: 'first', lastName: 'last'},
-                        {firstName: 'patate', lastName: 'king'},
+                        {id: '🆔-1', firstName: 'first', lastName: 'last'},
+                        {id: '🆔-2', firstName: 'patate', lastName: 'king'},
                     ]}
                     columns={columns}
                 />
@@ -276,9 +290,10 @@ describe('Table', () => {
         it('displays a checkbox as the first cell of each row', () => {
             render(
                 <Table
+                    getRowId={({id}) => id}
                     data={[
-                        {firstName: 'John', lastName: 'Smith'},
-                        {firstName: 'Jane', lastName: 'Doe'},
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
                     ]}
                     columns={columns}
                     multiRowSelectionEnabled
@@ -293,13 +308,33 @@ describe('Table', () => {
             });
         });
 
+        it('selects the rows specified in the initial state on mount', () => {
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                    ]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                    initialState={{
+                        rowSelection: {'🆔-2': {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'}},
+                    }}
+                />
+            );
+
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
+        });
+
         it('selects all rows of the current page when clicking on the checkbox that is in the column header', async () => {
             const user = userEvent.setup({delay: null});
             render(
                 <Table
+                    getRowId={({id}) => id}
                     data={[
-                        {firstName: 'John', lastName: 'Smith'},
-                        {firstName: 'Jane', lastName: 'Doe'},
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
                     ]}
                     columns={columns}
                     multiRowSelectionEnabled
@@ -321,9 +356,10 @@ describe('Table', () => {
                 <div>
                     <div>I'm a header</div>
                     <Table
+                        getRowId={({id}) => id}
                         data={[
-                            {firstName: 'first', lastName: 'last'},
-                            {firstName: 'patate', lastName: 'king'},
+                            {id: '🆔-1', firstName: 'first', lastName: 'last'},
+                            {id: '🆔-2', firstName: 'patate', lastName: 'king'},
                         ]}
                         columns={columns}
                         multiRowSelectionEnabled
@@ -348,9 +384,10 @@ describe('Table', () => {
             const user = userEvent.setup({delay: null});
             render(
                 <Table
+                    getRowId={({id}) => id}
                     data={[
-                        {firstName: 'John', lastName: 'Smith'},
-                        {firstName: 'Jane', lastName: 'Doe'},
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
                     ]}
                     columns={columns}
                     multiRowSelectionEnabled

--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -1,3 +1,3 @@
 export * from './Table';
 export {useTable} from './TableContext';
-export {type onTableChangeEvent, type InitialTableState, type TableProps} from './Table.types';
+export {type onTableChangeEvent, type InitialTableState, type TableState, type TableProps} from './Table.types';

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -15,6 +15,7 @@ export {
     Header,
     Table,
     type TableProps,
+    type TableState,
     type InitialTableState,
     type HeaderProps,
     Modal,

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -49,7 +49,7 @@ export default () => {
     const [loading, setLoading] = useState(true);
     const [pages, setPages] = useState(1);
 
-    const fetchData: onTableChangeEvent = async (state) => {
+    const fetchData: onTableChangeEvent<IExampleRowData> = async (state) => {
         setLoading(true);
         const searchParams = new URLSearchParams({
             _sort: state.sorting?.[0]?.id ?? 'userId',

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -37,7 +37,7 @@ export default () => {
     const [loading, setLoading] = useState(true);
     const [pages, setPages] = useState(1);
 
-    const fetchData: onTableChangeEvent = async (state) => {
+    const fetchData: onTableChangeEvent<IExampleRowData> = async (state) => {
         setLoading(true);
         const searchParams = new URLSearchParams({
             _page: (state.pagination.pageIndex + 1).toString(),
@@ -69,6 +69,22 @@ export default () => {
             onChange={fetchData}
             loading={loading}
             multiRowSelectionEnabled
+            initialState={{
+                rowSelection: {
+                    '1': {
+                        userId: 1,
+                        id: 1,
+                        title: 'sunt aut facere repellat provident occaecati excepturi optio reprehenderit',
+                        body: 'quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto',
+                    },
+                    '2': {
+                        userId: 1,
+                        id: 2,
+                        title: 'qui est esse',
+                        body: 'est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla',
+                    },
+                },
+            }}
         >
             <Table.Header>
                 <Table.Actions>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,7 @@ importers:
       eslint-plugin-testing-library: 5.7.2
       eslint-plugin-vitest: 0.0.32
       eslint-plugin-vitest-globals: 1.2.0
+      fast-deep-equal: 3.1.3
       identity-obj-proxy: 3.0.0
       jest: 29.2.1
       jest-environment-jsdom: 29.1.2
@@ -158,6 +159,7 @@ importers:
       '@tanstack/react-table': 8.7.9_biqbaboplfbrettd7655fr4n2y
       '@tanstack/table-core': 8.7.9
       dayjs: 1.11.3
+      fast-deep-equal: 3.1.3
       lodash.debounce: 4.0.8
       lodash.defaultsdeep: 4.6.1
       monaco-editor: 0.34.0


### PR DESCRIPTION
### Proposed Changes

Fix the Mantine table so that it supports having rows initially selected via the `initialState` prop.

**I added an example for initially selected rows on the website, be sure to check it out!**

I had to do some type hacking to the `rowSelection` state to make it work. Normally the tanstack table `rowSelection` state is of type `Record<string, boolean>`. My fix is to highjack that state so that it becomes `Record<string, TData>`. It works fine as long as TData is not `falsy` which never occurs in reality.

### Potential Breaking Changes

The type of `initialState.rowSelection` is changed from `Record<string, boolean>` to `Record<string, TData>` which is what we would expect anyway and fixes a lot of problems, so I am not planning to mark the commit as a breaking change.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
