### PR TITLE
chore(fast-xml-parser): remove is-svg dependency to remove vulnerability

### DIFF
--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -37,7 +37,6 @@
     },
     "dependencies": {
         "codemirror": "5.59.4",
-        "is-svg": "4.3.2",
         "rc-slider": "8.7.1",
         "react-diff-view": "2.4.10"
     },

--- a/packages/style/svgWrapper.js
+++ b/packages/style/svgWrapper.js
@@ -1,19 +1,16 @@
 import * as $ from 'jquery';
 import * as _ from 'underscore';
-import * as isSVG from 'is-svg';
 import {camelize, humanize} from 'underscore.string';
 
 import {svg as svgEnum} from './tmp/svg.js';
 
 const formatSvgName = (svgName) => camelize(humanize(svgName), true);
 
-const isSvgStringValid = (svgString) => isSVG(svgString);
-
 const renderSvg = (svgString, svgClass, attr) => {
     svgClass = svgClass || '';
     attr = attr || {};
 
-    if (svgString && isSvgStringValid(svgString)) {
+    if (svgString) {
         const svgHTML = $($.parseHTML(svgString));
         svgHTML[0].setAttribute('class', svgClass);
         _.mapObject(attr, (value, key) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,7 +472,6 @@ importers:
       gulp-rename: 1.4.0
       gulp-svgmin: 3.0.0
       gulp-uglify: 3.0.2
-      is-svg: 4.3.2
       jquery: 3.6.0
       lint-staged: 9.5.0
       merge-stream: 1.0.1
@@ -494,7 +493,6 @@ importers:
       webpack-cli: 5.0.1
     dependencies:
       codemirror: 5.59.4
-      is-svg: 4.3.2
       rc-slider: 8.7.1
       react-diff-view: 2.4.10
     devDependencies:
@@ -6089,8 +6087,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -8251,13 +8249,6 @@ packages:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: false
 
-  /fast-xml-parser/3.21.1:
-    resolution: {integrity: sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==}
-    hasBin: true
-    dependencies:
-      strnum: 1.0.5
-    dev: false
-
   /fastest-levenshtein/1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
@@ -10068,13 +10059,6 @@ packages:
     resolution: {integrity: sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /is-svg/4.3.2:
-    resolution: {integrity: sha512-mM90duy00JGMyjqIVHu9gNTjywdZV+8qNasX8cm/EEYZ53PHDgajvbBwNVvty5dwSAxLUD3p3bdo+7sR/UMrpw==}
-    engines: {node: '>=6'}
-    dependencies:
-      fast-xml-parser: 3.21.1
-    dev: false
 
   /is-symbol/1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
@@ -16092,10 +16076,6 @@ packages:
     resolution: {integrity: sha512-A21Xsm1XzUkK0qK1ZrytDUvqsQWict2Cykhvi0fBQntGG5JSprESasEyV1EZ/4CiR5WB5KjzLTrP/bO37B0wPg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
-
-  /strnum/1.0.5:
-    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
-    dev: false
 
   /strtok3/6.3.0:
     resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}


### PR DESCRIPTION
### Proposed Changes

There was a vulnerability detected in `fast-xml-parser`, which was used in plasma by `is-svg`. As `SVGWrapper` deprecated, I just remove the check "is-svg" to be able to remove the vulnerability. 

The removal of this check was approved by Germain, so yeah, trust me, it's ok.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
