### PR TITLE
feat(mantine): add onRowSelectionChange prop to table

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -43,6 +43,7 @@ export const Table: TableType = <T,>({
     loading = false,
     doubleClickAction,
     multiRowSelectionEnabled,
+    onRowSelectionChange,
     options = {},
 }: TableProps<T>) => {
     const convertedChildren = Children.toArray(children) as ReactElement[];
@@ -75,6 +76,7 @@ export const Table: TableType = <T,>({
     }));
     const {clearSelection, getSelectedRow, getSelectedRows, outsideClickRef} = useRowSelection(table, {
         multiRowSelectionEnabled,
+        onRowSelectionChange,
     });
     const isFiltered =
         !!state.globalFilter ||

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -166,6 +166,12 @@ export interface TableProps<T> {
      */
     doubleClickAction?: (datum: T) => void;
     /**
+     * Function called whenever the row selection changes
+     *
+     * @param selectedRows The selected rows
+     */
+    onRowSelectionChange?: (selectedRows: T[]) => void;
+    /**
      * Whether the user can select multiple rows in order to perform actions in bulk
      *
      * @default false

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -350,6 +350,41 @@ describe('Table', () => {
             expect(screen.queryAllByRole('row', {selected: true})).toEqual([]);
         });
 
+        it('calls the onRowSelectionChange prop when the row selection changes', async () => {
+            const onRowSelectionChangeSpy = vi.fn();
+            const user = userEvent.setup({delay: null});
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                    ]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                    onRowSelectionChange={onRowSelectionChangeSpy}
+                />
+            );
+            await user.click(screen.getByRole('row', {name: /jane doe/i}));
+            expect(onRowSelectionChangeSpy).toHaveBeenCalledTimes(1);
+            expect(onRowSelectionChangeSpy).toHaveBeenCalledWith([{id: '🆔-2', firstName: 'Jane', lastName: 'Doe'}]);
+
+            onRowSelectionChangeSpy.mockClear();
+
+            await user.click(screen.getByRole('row', {name: /john smith/i}));
+            expect(onRowSelectionChangeSpy).toHaveBeenCalledTimes(1);
+            expect(onRowSelectionChangeSpy).toHaveBeenCalledWith([
+                {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+            ]);
+
+            onRowSelectionChangeSpy.mockClear();
+
+            await user.click(screen.getByRole('checkbox', {name: /unselect all from this page/i}));
+            expect(onRowSelectionChangeSpy).toHaveBeenCalledTimes(1);
+            expect(onRowSelectionChangeSpy).toHaveBeenCalledWith([]);
+        });
+
         it('does not clear the row selection when clicking outside the table', async () => {
             const user = userEvent.setup({delay: null});
             render(

--- a/packages/mantine/src/components/table/useRowSelection.ts
+++ b/packages/mantine/src/components/table/useRowSelection.ts
@@ -6,7 +6,10 @@ import {RowSelectionWithData, TableProps, TableState} from './Table.types';
 
 export const useRowSelection = <T>(
     table: Table<T>,
-    {multiRowSelectionEnabled}: Pick<TableProps<T>, 'multiRowSelectionEnabled'>
+    {
+        onRowSelectionChange,
+        multiRowSelectionEnabled,
+    }: Pick<TableProps<T>, 'onRowSelectionChange' | 'multiRowSelectionEnabled'>
 ) => {
     const outsideClickRef = useClickOutside(() => {
         if (!multiRowSelectionEnabled) {
@@ -39,6 +42,8 @@ export const useRowSelection = <T>(
                         newRowSelection[rowId] = rows[rowId]?.original ?? (true as T);
                     }
                 });
+
+                onRowSelectionChange?.(Object.values(newRowSelection));
 
                 return {
                     ...old,

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -68,6 +68,9 @@ export default () => {
             onMount={fetchData}
             onChange={fetchData}
             loading={loading}
+            onRowSelectionChange={(selectedRows) =>
+                console.info(`Row selection changed, selected rows: ${selectedRows.map(({id}) => id).join(', ')}`)
+            }
             multiRowSelectionEnabled
             initialState={{
                 rowSelection: {


### PR DESCRIPTION
### Proposed Changes

Adding a prop on the table that allows to act whenever the row selection changes. The reason I am providing a new prop for this instead of just forcing people to reuse the onChange prop is that onChange only gets called when the table needs to refresh its data. Row selection has no effect on the data shown in the table, it just selects it.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
