### PR TITLE
feat(mantine button): add async handler

### DIFF
--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -43,6 +43,7 @@
         "@mantine/form": "5.9.2",
         "@mantine/hooks": "5.9.2",
         "@mantine/modals": "5.9.2",
+        "@mantine/notifications": "5.9.2",
         "@swc/cli": "0.1.62",
         "@swc/core": "1.3.35",
         "@swc/jest": "0.2.23",

--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -1,21 +1,54 @@
 import {Button as MantineButton, ButtonProps as MantineButtonProps} from '@mantine/core';
-import {forwardRef} from 'react';
+import {forwardRef, useState, MouseEventHandler, MouseEvent} from 'react';
 
 import {createPolymorphicComponent} from '../../utils';
 import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from './ButtonWithDisabledTooltip';
 
-export interface ButtonProps extends MantineButtonProps, ButtonWithDisabledTooltipProps {}
+export interface ButtonProps extends MantineButtonProps, ButtonWithDisabledTooltipProps {
+    /* Handler executed on click */
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+const useLoadingHandler = (handler: MouseEventHandler<HTMLButtonElement>) => {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+        const possiblePromise: unknown = handler(event);
+        try {
+            if (possiblePromise instanceof Promise) {
+                setIsLoading(true);
+                await possiblePromise;
+                setIsLoading(false);
+            }
+        } catch (err) {
+            setIsLoading(false);
+            console.error(err);
+        }
+    };
+
+    return {isLoading, handleClick};
+};
 
 const _Button = forwardRef<HTMLButtonElement, ButtonProps>(
-    ({disabledTooltip, disabled, disabledTooltipProps, ...others}, ref) => (
-        <ButtonWithDisabledTooltip
-            disabled={disabled}
-            disabledTooltip={disabledTooltip}
-            disabledTooltipProps={disabledTooltipProps}
-        >
-            <MantineButton ref={ref} disabled={disabled} {...others} />
-        </ButtonWithDisabledTooltip>
-    )
+    ({disabledTooltip, disabled, disabledTooltipProps, loading, onClick, ...others}, ref) => {
+        const {isLoading, handleClick} = useLoadingHandler(onClick);
+        return (
+            <ButtonWithDisabledTooltip
+                disabled={disabled}
+                disabledTooltip={disabledTooltip}
+                disabledTooltipProps={disabledTooltipProps}
+            >
+                <MantineButton
+                    loaderProps={{variant: 'oval'}}
+                    ref={ref}
+                    loading={isLoading || loading}
+                    onClick={handleClick}
+                    disabled={disabled}
+                    {...others}
+                />
+            </ButtonWithDisabledTooltip>
+        );
+    }
 );
 
 export const Button = createPolymorphicComponent<'button', ButtonProps, {Group: typeof MantineButton.Group}>(_Button);

--- a/packages/mantine/src/components/button/__tests__/Button.spec.tsx
+++ b/packages/mantine/src/components/button/__tests__/Button.spec.tsx
@@ -1,4 +1,4 @@
-import {render} from '@test-utils';
+import {render, screen, userEvent, waitFor, within} from '@test-utils';
 
 import {Button} from '../Button';
 
@@ -8,5 +8,80 @@ describe('Button', () => {
         expect(() => {
             render(<Button.Group></Button.Group>);
         }).not.toThrow();
+    });
+
+    describe('onClick Promise handler', () => {
+        it('uses the native loading prop if passed', () => {
+            render(
+                <>
+                    <Button loading={true}>I am loading</Button>
+                    <Button loading={false}>I am not loading</Button>
+                </>
+            );
+            expect(within(screen.getByRole('button', {name: /I am loading/i})).getByRole('presentation')).toBeVisible();
+            expect(
+                within(screen.queryByRole('button', {name: /I am not loading/i})).queryByRole('presentation')
+            ).not.toBeInTheDocument();
+        });
+
+        it('shows a loader while the promise is waiting to be resolved', async () => {
+            let resolve: () => void;
+            let isResolved = false;
+
+            const promise = () =>
+                new Promise<void>((res) => {
+                    resolve = res;
+                }).then(() => {
+                    isResolved = true;
+                });
+
+            render(<Button onClick={promise}>promise handler</Button>);
+
+            userEvent.click(screen.getByRole('button', {name: /promise handler/i}));
+
+            expect(
+                await within(screen.getByRole('button', {name: /promise handler/i})).findByRole('presentation')
+            ).toBeVisible();
+
+            resolve();
+
+            await waitFor(() => {
+                expect(isResolved).toBeTruthy();
+            });
+
+            expect(
+                within(screen.queryByRole('button', {name: /promise handler/i})).queryByRole('presentation')
+            ).not.toBeInTheDocument();
+        });
+
+        it('removes the loading if a promise is rejected', async () => {
+            let reject: () => void;
+            let isRejected = false;
+
+            const promise = () =>
+                new Promise<void>((res, rej) => {
+                    reject = rej;
+                }).catch(() => {
+                    isRejected = true;
+                });
+
+            render(<Button onClick={promise}>promise handler</Button>);
+
+            userEvent.click(screen.getByRole('button', {name: /promise handler/i}));
+
+            expect(
+                await within(screen.getByRole('button', {name: /promise handler/i})).findByRole('presentation')
+            ).toBeVisible();
+
+            reject();
+
+            await waitFor(() => {
+                expect(isRejected).toBeTruthy();
+            });
+
+            expect(
+                within(screen.queryByRole('button', {name: /promise handler/i})).queryByRole('presentation')
+            ).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -2,6 +2,7 @@ import {Tuple} from '@mantine/core';
 
 import {PlasmaColors} from './theme/PlasmaColors';
 
+export * from '@mantine/notifications';
 export * from '@mantine/carousel';
 export * from '@mantine/core';
 export type {FormValidateInput} from '@mantine/form/lib/types';
@@ -9,6 +10,7 @@ export * from '@mantine/hooks';
 export * from '@tanstack/table-core';
 export * from './components';
 export * from '@mantine/form';
+export {NotificationProps} from '@mantine/notifications';
 export {Pagination} from '@mantine/core';
 // explicitly overriding mantine components
 export {

--- a/packages/website/src/examples/form/button/Button.demo.tsx
+++ b/packages/website/src/examples/form/button/Button.demo.tsx
@@ -1,3 +1,3 @@
-import {Button} from '@coveord/plasma-mantine';
+import {Button, showNotification} from '@coveord/plasma-mantine';
 
-export default () => <Button onClick={() => alert('button clicked')}>Default button</Button>;
+export default () => <Button onClick={() => showNotification({message: 'Button clicked'})}>Default button</Button>;

--- a/packages/website/src/examples/form/button/ButtonSecondary.demo.tsx
+++ b/packages/website/src/examples/form/button/ButtonSecondary.demo.tsx
@@ -1,7 +1,7 @@
-import {Button} from '@coveord/plasma-mantine';
+import {Button, showNotification} from '@coveord/plasma-mantine';
 
 export default () => (
-    <Button variant="outline" onClick={() => alert('button clicked')}>
+    <Button variant="outline" onClick={() => showNotification({message: 'Button clicked'})}>
         Secondary button
     </Button>
 );

--- a/packages/website/src/examples/form/button/ButtonWithAsyncLoader.demo.tsx
+++ b/packages/website/src/examples/form/button/ButtonWithAsyncLoader.demo.tsx
@@ -1,0 +1,14 @@
+import {Button, showNotification} from '@coveord/plasma-mantine';
+
+const somethingAsync = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const promise = async () => {
+    await somethingAsync(3000);
+    showNotification({
+        title: 'Saved successfully',
+        message: 'The save disabled was put in a loading state while it was waiting for the save to resolve.',
+        autoClose: false,
+    });
+};
+
+export default () => <Button onClick={promise}>Save</Button>;

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -11,7 +11,7 @@ import '../styles/props-table.scss';
 import '../styles/spacing.scss';
 import '../styles/tile.scss';
 
-import {Plasmantine} from '@coveord/plasma-mantine';
+import {NotificationsProvider, Plasmantine} from '@coveord/plasma-mantine';
 import {Defaults} from '@coveord/plasma-react';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -67,14 +67,16 @@ const MyApp = ({Component, pageProps}: AppProps) => {
             <Provider store={Store}>
                 <EngineProvider>
                     <Plasmantine>
-                        <Header />
-                        <div className="flex flex-auto pb4" style={{height: 'calc(100vh - 90px)'}}>
-                            <Navigation />
-                            <div className="coveo-form flex-auto relative overflow-auto demo-content">
-                                {isLegacy ? <LegacyWarningBanner /> : null}
-                                <Component {...pageProps} />
+                        <NotificationsProvider position="top-center">
+                            <Header />
+                            <div className="flex flex-auto pb4" style={{height: 'calc(100vh - 90px)'}}>
+                                <Navigation />
+                                <div className="coveo-form flex-auto relative overflow-auto demo-content">
+                                    {isLegacy ? <LegacyWarningBanner /> : null}
+                                    <Component {...pageProps} />
+                                </div>
                             </div>
-                        </div>
+                        </NotificationsProvider>
                     </Plasmantine>
                 </EngineProvider>
             </Provider>

--- a/packages/website/src/pages/form/Button.tsx
+++ b/packages/website/src/pages/form/Button.tsx
@@ -2,6 +2,7 @@ import {ButtonMetadata} from '@coveord/plasma-components-props-analyzer';
 import ButtonDemo from '@examples/form/button/Button.demo.tsx';
 import ButtonDisabledDemo from '@examples/form/button/ButtonDisabled.demo.tsx';
 import ButtonSecondaryDemo from '@examples/form/button/ButtonSecondary.demo.tsx';
+import ButtonWithAsyncLoader from '@examples/form/button/ButtonWithAsyncLoader.demo.tsx';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -16,6 +17,7 @@ const ButtonPage = () => (
         examples={{
             secondary: <ButtonSecondaryDemo center title="Secondary" />,
             disabled: <ButtonDisabledDemo center title="Disabled" />,
+            promiseHandler: <ButtonWithAsyncLoader center title="Async click handler" />,
         }}
         sourcePath="/packages/mantine/src/components/button/Button.tsx"
         propsMetadata={ButtonMetadata}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,7 @@ importers:
       '@mantine/form': 5.9.2
       '@mantine/hooks': 5.9.2
       '@mantine/modals': 5.9.2
+      '@mantine/notifications': 5.9.2
       '@mantine/utils': 5.10.1
       '@monaco-editor/react': 4.4.5
       '@swc/cli': 0.1.62
@@ -172,6 +173,7 @@ importers:
       '@mantine/form': 5.9.2_react@18.2.0
       '@mantine/hooks': 5.9.2_react@18.2.0
       '@mantine/modals': 5.9.2_uw7trfygy6zitf2mjy7qrym72y
+      '@mantine/notifications': 5.9.2_uw7trfygy6zitf2mjy7qrym72y
       '@swc/cli': 0.1.62_@swc+core@1.3.35
       '@swc/core': 1.3.35
       '@swc/jest': 0.2.23_@swc+core@1.3.35
@@ -2158,6 +2160,22 @@ packages:
       - '@emotion/react'
       - '@emotion/server'
     dev: false
+
+  /@mantine/notifications/5.9.2_uw7trfygy6zitf2mjy7qrym72y:
+    resolution: {integrity: sha512-w/7LLH8p6oOPqSZdLIA/Tx7MvJWnVGNW9PB//fN2sc9hbPjI3o9zrYqbvLVFjCTJv7l8olCOHx+wvQKCpIcdqw==}
+    peerDependencies:
+      '@mantine/core': 5.9.2
+      '@mantine/hooks': 5.9.2
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@mantine/core': 5.9.2_uwo7cluufwlxrxqmkyjahngi5e
+      '@mantine/hooks': 5.9.2_react@18.2.0
+      '@mantine/utils': 5.9.2_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-transition-group: 4.4.2_biqbaboplfbrettd7655fr4n2y
+    dev: true
 
   /@mantine/prism/5.9.2_uw7trfygy6zitf2mjy7qrym72y:
     resolution: {integrity: sha512-dY4K9CC7yfUcn5Z16iWTQ67+yKFZm3IUR9aTFdFNkVOvk0Vgn7D5n5CzAKsWaEj/Wvj474Yf+r//RafNoUXxig==}
@@ -6751,7 +6769,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.6
       csstype: 3.1.1
-    dev: false
 
   /dom-serializer/0.1.1:
     resolution: {integrity: sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==}
@@ -13786,6 +13803,20 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       react-lifecycles-compat: 3.0.4
     dev: false
+
+  /react-transition-group/4.4.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@babel/runtime': 7.20.6
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: true
 
   /react-transition-group/4.4.5_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}


### PR DESCRIPTION
### Proposed Changes

Override of the Mantine Button to make the addition of an async handler.

New button in the Demo page to show the async handler use case

switched the Alert to a notification. Because the promise is not fulfilled until we click `ok` to dismiss the alert and the loading of the button hanged in the demo, and that looked weird.

[simplescreenrecorder-2023-02-24_11.02.21.webm](https://user-images.githubusercontent.com/45688129/221226996-5c18f912-d22d-4285-af10-7d119fd37191.webm)


### Potential Breaking Changes

none that I can think of

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
