### PR TITLE
fix(style): inline svgs and fonts in generated stylesheet

### DIFF
--- a/packages/style/gulpfile.js
+++ b/packages/style/gulpfile.js
@@ -90,7 +90,7 @@ gulp.task('sprites', () => {
             pngSprite.gulp({
                 cssPath: 'sprites.scss',
                 pngPath: '../dist/images/CoveoStyleGuide.Sprites.png',
-                relPath: '/images/CoveoStyleGuide.Sprites.png',
+                relPath: '../dist/images/CoveoStyleGuide.Sprites.png',
                 eachTemplate: template,
                 namespace: 'coveo-sprites',
             })

--- a/packages/style/scss/common/font.scss
+++ b/packages/style/scss/common/font.scss
@@ -3,8 +3,8 @@
     font-family: 'source_code_pro_regular';
     font-style: normal;
 
-    src: url('/fonts/SourceCodePro-Regular.eot');
-    src: url('/fonts/SourceCodePro-Regular.eot?#iefix') format('embedded-opentype'),
-        url('/fonts/SourceCodePro-Regular.woff') format('woff'),
-        url('/fonts/SourceCodePro-Regular.ttf') format('truetype');
+    src: url('../resources/fonts/SourceCodePro-Regular.eot');
+    src: url('../resources/fonts/SourceCodePro-Regular.eot?#iefix') format('embedded-opentype'),
+        url('../resources/fonts/SourceCodePro-Regular.woff') format('woff'),
+        url('../resources/fonts/SourceCodePro-Regular.ttf') format('truetype');
 }

--- a/packages/style/scss/controls/checkboxes.scss
+++ b/packages/style/scss/controls/checkboxes.scss
@@ -69,7 +69,7 @@
                 position: absolute;
                 top: var(--svg-checked-top);
                 left: var(--svg-checked-left);
-                content: url('/icons/svg/content/checkbox.svg');
+                content: url('../resources/icons/svg/content/checkbox.svg');
             }
 
             &:disabled {
@@ -84,7 +84,7 @@
                 position: absolute;
                 top: var(--svg-underterminate-top);
                 left: var(--svg-underterminate-left);
-                content: url('/icons/svg/content/undeterminate-checkbox.svg');
+                content: url('../resources/icons/svg/content/undeterminate-checkbox.svg');
             }
 
             &:disabled {
@@ -103,13 +103,13 @@
             &:checked {
                 & + button:before {
                     position: absolute;
-                    content: url('/icons/svg/content/disabled-checkbox.svg');
+                    content: url('../resources/icons/svg/content/disabled-checkbox.svg');
                 }
             }
 
             &:indeterminate + button:before {
                 position: absolute;
-                content: url('/icons/svg/content/disabled-undeterminate-checkbox.svg');
+                content: url('../resources/icons/svg/content/disabled-undeterminate-checkbox.svg');
             }
 
             & ~ .help-text,

--- a/packages/style/scss/controls/radios.scss
+++ b/packages/style/scss/controls/radios.scss
@@ -63,7 +63,7 @@ $labelIndent: $radio-button-size + $radio-button-option-height;
                 z-index: 1;
                 width: $radio-button-option-height;
                 height: $radio-button-option-height;
-                content: url('/icons/svg/content/radiocheck.svg');
+                content: url('../resources/icons/svg/content/radiocheck.svg');
             }
 
             &:hover {
@@ -94,7 +94,7 @@ $labelIndent: $radio-button-size + $radio-button-option-height;
                     z-index: 1;
                     width: $radio-button-option-height;
                     height: $radio-button-option-height;
-                    content: url('/icons/svg/content/disabled-radiocheck.svg');
+                    content: url('../resources/icons/svg/content/disabled-radiocheck.svg');
                 }
             }
         }

--- a/packages/style/scss/controls/slide-toggle-double.scss
+++ b/packages/style/scss/controls/slide-toggle-double.scss
@@ -27,7 +27,7 @@ input.coveo-slide-toggle-double[type='checkbox'] {
         box-sizing: initial;
         width: 33px;
         height: 16px;
-        background: var(--deprecated-medium-grey) url('/images/misc/two_option_toggle.png') 0 0;
+        background: var(--deprecated-medium-grey) url('../resources/images/misc/two_option_toggle.png') 0 0;
         border: 3px solid var(--deprecated-medium-grey);
         border-radius: 3px;
 

--- a/packages/style/scss/controls/slider.scss
+++ b/packages/style/scss/controls/slider.scss
@@ -54,7 +54,7 @@ div.slider-container {
         width: $slider-handle-width;
         height: $slider-handle-height;
         margin-top: $slider-handle-margin-top;
-        background: url('/icons/svg/slider-handle.svg') no-repeat;
+        background: url('../resources/icons/svg/slider-handle.svg') no-repeat;
         background-size: $slider-handle-background-size;
         border: none;
         border-radius: $slider-handle-border-radius;

--- a/packages/style/scss/sprites.scss
+++ b/packages/style/scss/sprites.scss
@@ -9,7 +9,7 @@
 .coveo-sprites-tables-sort_asc {
     display: inline-block;
     overflow: hidden;
-    background-image: url('/images/CoveoStyleGuide.Sprites.png');
+    background-image: url('../dist/images/CoveoStyleGuide.Sprites.png');
     background-repeat: no-repeat;
     background-size: 103px 16px;
 }


### PR DESCRIPTION
### Proposed Changes

In #3044 I changed the imports to use absolute paths because I had issues with the relative path but it turns out that just removing a `../` fixes everything and inlines the assets in the generated file

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
