### PR TITLE
Fix export NotificationProps as type and button without onClick

### DIFF
--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -9,11 +9,11 @@ export interface ButtonProps extends MantineButtonProps, ButtonWithDisabledToolt
     onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-const useLoadingHandler = (handler: MouseEventHandler<HTMLButtonElement>) => {
+const useLoadingHandler = (handler?: MouseEventHandler<HTMLButtonElement>) => {
     const [isLoading, setIsLoading] = useState(false);
 
     const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
-        const possiblePromise: unknown = handler(event);
+        const possiblePromise: unknown = handler?.(event);
         try {
             if (possiblePromise instanceof Promise) {
                 setIsLoading(true);

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -10,7 +10,7 @@ export * from '@mantine/hooks';
 export * from '@tanstack/table-core';
 export * from './components';
 export * from '@mantine/form';
-export {NotificationProps} from '@mantine/notifications';
+export {type NotificationProps} from '@mantine/notifications';
 export {Pagination} from '@mantine/core';
 // explicitly overriding mantine components
 export {


### PR DESCRIPTION
### Proposed Changes

Don't throw if the button doesn't have onClick prop
Export NotificationProps as a type

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
