### PR TITLE
fix(button): allowed fullwidth on button with tooltip button

### DIFF
--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -1,5 +1,5 @@
 import {Button as MantineButton, ButtonProps as MantineButtonProps} from '@mantine/core';
-import {forwardRef, useState, MouseEventHandler, MouseEvent} from 'react';
+import {forwardRef, MouseEvent, MouseEventHandler, useState} from 'react';
 
 import {createPolymorphicComponent} from '../../utils';
 import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from './ButtonWithDisabledTooltip';
@@ -37,6 +37,7 @@ const _Button = forwardRef<HTMLButtonElement, ButtonProps>(
                 disabled={disabled}
                 disabledTooltip={disabledTooltip}
                 disabledTooltipProps={disabledTooltipProps}
+                fullWidth={others.fullWidth}
             >
                 <MantineButton
                     loaderProps={{variant: 'oval'}}

--- a/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
+++ b/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
@@ -17,13 +17,17 @@ export interface ButtonWithDisabledTooltipProps {
      * Additional tooltip props to set on the disabled button tooltip
      */
     disabledTooltipProps?: Omit<TooltipProps, 'disabled' | 'label' | 'children'>;
+    /**
+     * Sets button width to 100% of parent element
+     */
+    fullWidth?: boolean;
 }
 
 const _ButtonWithDisabledTooltip = forwardRef<HTMLDivElement, ButtonWithDisabledTooltipProps>(
-    ({disabledTooltip, disabled, children, disabledTooltipProps, ...others}, ref) =>
+    ({disabledTooltip, disabled, children, disabledTooltipProps, fullWidth, ...others}, ref) =>
         disabledTooltip ? (
             <Tooltip label={disabledTooltip} disabled={!disabled} {...disabledTooltipProps}>
-                <Box ref={ref} sx={{'&:hover': {cursor: 'not-allowed'}}} {...others}>
+                <Box ref={ref} sx={{'&:hover': {cursor: 'not-allowed'}, width: fullWidth && '100%'}} {...others}>
                     {children}
                 </Box>
             </Tooltip>


### PR DESCRIPTION
### Proposed Changes

+fullWidth prop on disabledButtonWithTooltip so that the fullWidth can be applied (as of today, if you set a tooltip on a button and you use fullWidth prop, it is not applied. This pr fixes this

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
