### PR TITLE
fix(mantine): modal wizard header border bottom

### DIFF
--- a/packages/mantine/src/components/modal-wizard/__tests__/ModalWizard.spec.tsx
+++ b/packages/mantine/src/components/modal-wizard/__tests__/ModalWizard.spec.tsx
@@ -1,4 +1,5 @@
 import {render, screen, userEvent} from '@test-utils';
+
 import {ModalWizard} from '../ModalWizard';
 
 describe('ModalWizard', () => {
@@ -340,5 +341,25 @@ describe('ModalWizard', () => {
         await user.click(closeButton);
         expect(handleDirtyState).toHaveBeenCalledTimes(1);
         expect(onClose).toHaveBeenCalledTimes(0);
+    });
+
+    it('hides the progress bar when showProgressBar is false for a given step', async () => {
+        const user = userEvent.setup();
+        render(
+            <ModalWizard opened={true} onClose={vi.fn()}>
+                <ModalWizard.Step title="Step 1" validateStep={() => ({isValid: true})} showProgressBar={false}>
+                    Content step 1
+                </ModalWizard.Step>
+                <ModalWizard.Step title="Step 2" validateStep={() => ({isValid: true})}>
+                    Content step 2
+                </ModalWizard.Step>
+            </ModalWizard>
+        );
+
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', {name: /next/i}));
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
 });

--- a/packages/website/src/examples/layout/ModalWizard/ModalWizard.demo.tsx
+++ b/packages/website/src/examples/layout/ModalWizard/ModalWizard.demo.tsx
@@ -11,6 +11,8 @@ export default () => {
                 <ModalWizard.Step
                     docLink="https://coveo.com"
                     title="Current Step is 1"
+                    showProgressBar={false}
+                    countsAsProgress={false}
                     description="Description of step 1"
                     validateStep={() => ({isValid: true})}
                     docLinkTooltipLabel="Tooltip label"


### PR DESCRIPTION
### Proposed Changes

Display a border bottom on the modal wizard header when the progress bar is hidden.

https://user-images.githubusercontent.com/35579930/224437090-7ca97a53-446d-4458-9576-6f4f64b6f0cb.mov

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
