### PR TITLE
fix(sticky footer): top border will not dissapear

### DIFF
--- a/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
@@ -25,13 +25,11 @@ export const StickyFooter: FunctionComponent<PropsWithChildren<StickyFooterProps
     const {classes} = useStyles();
 
     return (
-        <>
+        <Box className={classes.footer}>
             {borderTop ? <Divider size="xs" /> : null}
-            <Box className={classes.footer}>
-                <Group position="right" spacing="sm" p="lg" {...others}>
-                    {children}
-                </Group>
-            </Box>
-        </>
+            <Group position="right" spacing="sm" p="lg" {...others}>
+                {children}
+            </Group>
+        </Box>
     );
 };


### PR DESCRIPTION
### Proposed Changes

The sticky footer will not lose its border while sticking.

**Examples**
before: 
[simplescreenrecorder-2023-03-15_08.03.37.webm](https://user-images.githubusercontent.com/45688129/225305506-c83d298f-6d3a-4909-a105-b88b16eaf809.webm)
after
[simplescreenrecorder-2023-03-15_08.05.56.webm](https://user-images.githubusercontent.com/45688129/225305538-c718b5ee-b50f-459c-8e49-3179428ad61c.webm)


### Potential Breaking Changes

none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
     - I do not think I can properly test that even by scrolling
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
