### PR TITLE
fix(mantine, table): table cells alignment

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -136,7 +136,11 @@ export const Table: TableType = <T,>({
                                     [classes.rowCollapsibleButtonCell]: cell.column.id === TableCollapsibleColumn.id,
                                 })}
                             >
-                                <Skeleton visible={loading} sx={!loading ? {borderRadius: 0} : undefined}>
+                                <Skeleton
+                                    style={{display: 'inline-block'}}
+                                    visible={loading}
+                                    sx={!loading ? {borderRadius: 0} : undefined}
+                                >
                                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                 </Skeleton>
                             </td>


### PR DESCRIPTION
### Proposed Changes

Changed the display alignment of the Skeleton in the table. This prevents alignment issue with elements like Button or Progress

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
