### PR TITLE
fix(select dropdown container): bump zindex

### DIFF
--- a/packages/style/scss/controls/dropdown.scss
+++ b/packages/style/scss/controls/dropdown.scss
@@ -261,7 +261,7 @@
 }
 
 .select-dropdown-container {
-    z-index: $table-header-z-index;
+    z-index: 15;
     background-color: var(--white);
     border-radius: 8px;
 


### PR DESCRIPTION
## Proposed Changes

### scope
select dropdown is rendering under the header on top of the mantine's table.

### description

I do not know if blindly bumping the z index of the dropdown to supplant the table header is the way to go.
![2023-03-22_13-49](https://user-images.githubusercontent.com/45688129/226995530-de0ec731-795b-469c-843e-118edde58c53.png)

![2023-03-22_13-50](https://user-images.githubusercontent.com/45688129/226995547-c53dee1a-f8f2-4f4b-9695-f0b8877d5bb8.png)

right now the class generated by mantine have `zindex: 13`
stronger than the dropdown `zindex 2`

I arbitrarily decided to bump the zindex of the dropdown to 15. 

Also, I do not know if I should use a CSS variable.


### Potential Breaking Changes

Its hard to tell if at some point the dropdown will not just appear over stuff we do not want it to go over.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
