### PR TITLE
fix(sticky footer): z index to 15

### DIFF
--- a/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
@@ -12,7 +12,7 @@ const useStyles = createStyles(() => ({
     footer: {
         position: 'sticky',
         bottom: 0,
-        zIndex: 1,
+        zIndex: 15,
         backgroundColor: 'white',
     },
 }));


### PR DESCRIPTION
### Proposed Changes

feeling the deja vu with https://github.com/coveo/plasma/pull/3097 ?

The sticky footer with its z-index of 1 get supplanted quite easily by the reste of the mantine's generated classes.

![image](https://user-images.githubusercontent.com/45688129/227017394-96e630dd-2c06-4acb-aa5d-b8cb070857ca.png)
![image](https://user-images.githubusercontent.com/45688129/227017533-f5b262a6-2e99-47c8-99c9-4939af61cb66.png)

Is bumping arbitrary the z-index to 15 the right solution ?

### Potential Breaking Changes

unless the footer begins to show over modals, I think we will be fine

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
