### PR TITLE
fix(datepicker): +maxDate prop to rangeDatePickerProps since the new …

### DIFF
--- a/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
+++ b/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
@@ -37,7 +37,7 @@ export interface DateRangePickerInlineCalendarProps
     /**
      * Props for RangeCalendar displayed in the popover
      */
-    rangeCalendarProps?: Omit<
+    rangeCalendarProps?: {maxDate?: Date} & Omit<
         CalendarBaseProps,
         'value' | 'onChange' | 'isDateInRange' | 'isDateFirstInRange' | 'isDateLastInRange'
     >;

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -95,7 +95,10 @@ export default () => {
                 <Table.Actions>{(datum: IExampleRowData) => <TableActions datum={datum} />}</Table.Actions>
                 <UserPredicate />
                 <Table.Filter placeholder="Search posts by title" />
-                <Table.DateRangePicker presets={DatePickerPresets} />
+                <Table.DateRangePicker
+                    rangeCalendarProps={{maxDate: dayjs().endOf('day').toDate()}}
+                    presets={DatePickerPresets}
+                />
             </Table.Header>
             <Table.Footer>
                 <Table.PerPage />


### PR DESCRIPTION
…type does include it

### Proposed Changes

maxDate is not included in the new CaledarBaseProps interface from mantine 6 (which is still needed for the table datepicker). Just a simple add-on on that prop

This will let us set a max date and disable everything after that date

![image](https://user-images.githubusercontent.com/52010042/227263372-ed0cc26f-3c90-488b-b611-1bad312eeeb6.png)

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
