### PR TITLE
fix(z indexes): unset skeleton and segmented control

### DIFF
--- a/packages/mantine/src/components/table/Table.styles.ts
+++ b/packages/mantine/src/components/table/Table.styles.ts
@@ -26,7 +26,6 @@ const useStyles = createStyles<string, TableStylesParams>((theme, {hasHeader, mu
             top: hasHeader ? 69 : 0,
             backgroundColor: theme.colorScheme === 'dark' ? theme.black : theme.white,
             transition: 'box-shadow 150ms ease',
-            zIndex: 12, // skeleton is 11
 
             '&::after': {
                 content: '""',

--- a/packages/mantine/src/components/table/TableHeader.tsx
+++ b/packages/mantine/src/components/table/TableHeader.tsx
@@ -9,7 +9,7 @@ const useStyles = createStyles((theme) => ({
     root: {
         position: 'sticky',
         top: 0,
-        zIndex: 13, // skeleton is 11
+        zIndex: 1,
         backgroundColor: theme.colors.gray[1],
         borderBottom: `1px solid ${theme.colors.gray[3]}`,
     },

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -236,5 +236,20 @@ export const plasmaTheme: MantineThemeOverride = {
                 color: 'info',
             },
         },
+        Skeleton: {
+            styles: {
+                visible: {
+                    '&::before': {zIndex: 'unset'},
+                    '&::after': {zIndex: 'unset'},
+                },
+            },
+        },
+        Segmented: {
+            styles: {
+                control: {
+                    zIndex: 'unset',
+                },
+            },
+        },
     },
 };


### PR DESCRIPTION
### Proposed Changes

FIX: https://coveord.atlassian.net/browse/UITOOL-1260
FIX: https://coveord.atlassian.net/browse/UITOOL-1232 and  https://coveord.atlassian.net/browse/UITOOL-1233

fixing layout issues by unsetting and diminishing some z-indexes

![image](https://user-images.githubusercontent.com/45688129/227326630-7b5f9f0e-932f-4ff3-9259-54bd62a48cde.png)

[simplescreenrecorder-2023-03-23_15.17.16.webm](https://user-images.githubusercontent.com/45688129/227326678-c2e90902-96d1-4347-8c0d-0092e2b2c1ac.webm)

### Potential Breaking Changes

Hiding stuff we want visible. 
But its way less risky to reduce z-indexes than to increase them.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
