### PR TITLE
feat(modalwizard): Pass new step index during onPrevious and onNext in ModalWizard

### DIFF
--- a/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
+++ b/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
@@ -54,12 +54,12 @@ export interface ModalWizardProps
     /**
      * A callback function that is executed when the user clicks on the next button
      */
-    onNext?: () => unknown;
+    onNext?: (newStep: number) => unknown;
 
     /**
      * A callback function that is executed when the user clicks on the previous button
      */
-    onPrevious?: () => unknown;
+    onPrevious?: (newStep: number) => unknown;
 
     /**
      * A function that is executed when user completes all the steps.
@@ -164,7 +164,7 @@ export const ModalWizard: ModalWizardType = ({
         },
         []
     );
-
+    console.log('currentStep', currentStepIndex);
     return (
         <Modal
             opened={opened}
@@ -210,7 +210,7 @@ export const ModalWizard: ModalWizardType = ({
                             if (isFirstStep) {
                                 handleClose(true);
                             } else {
-                                onPrevious?.();
+                                onPrevious?.(currentStepIndex - 1);
                                 setCurrentStepIndex(currentStepIndex - 1);
                             }
                         }}
@@ -224,7 +224,7 @@ export const ModalWizard: ModalWizardType = ({
                             if (isLastStep) {
                                 onFinish?.() ?? handleClose(false);
                             } else {
-                                onNext?.();
+                                onNext?.(currentStepIndex + 1);
                                 setCurrentStepIndex(currentStepIndex + 1);
                             }
                         }}


### PR DESCRIPTION
### Proposed Changes

The onPrevious and onNext functions of the plasmantine ModalWizard component have no parameters, the new step should be added as parameters

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
