### PR TITLE
ci(CD): switch CD to a manual trigger

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,10 +1,6 @@
 name: CD
 
-on:
-    push:
-        branches:
-            - master
-            - next
+on: workflow_dispatch
 
 concurrency:
     group: ${{ github.ref_name }}
@@ -12,7 +8,8 @@ concurrency:
 
 jobs:
     cd:
-        name: Continous Delivery
+        name: Continuous Delivery
+        if: github.ref_name == 'master' || github.ref_name == 'next'
         runs-on: ubuntu-latest
         environment: production
         permissions:
@@ -46,7 +43,7 @@ jobs:
             - name: Publish
               uses: ./.github/actions/publish
               env:
-                  DEBUG: "*"
+                  DEBUG: '*'
                   DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
             - name: Deploy


### PR DESCRIPTION
### Proposed Changes

Since Plasma is a library, it makes more sense to bundle multiple changes together in the same release, rather than releasing on each commit. Doing this will reduce the number of breaking releases and will allow releases to be more stable, because we can wait until all the changes and fixes are there before choosing to release.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
