### PR TITLE
ci(pnpm): add CI support for pnpm 8

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ runs:
               registry-url: 'https://registry.npmjs.org'
         - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
           with:
-              version: 7
+              version: 8
               run_install: false
         - name: Get pnpm store directory
           id: pnpm-cache

--- a/.github/actions/snyk-pnpm/package-lock.json
+++ b/.github/actions/snyk-pnpm/package-lock.json
@@ -9,9 +9,9 @@
             "version": "1.0.0",
             "license": "ISC",
             "devDependencies": {
-                "@pnpm/lockfile-file": "5.2.0",
-                "@pnpm/types": "8.4.0",
-                "@types/node": "18.6.1",
+                "@pnpm/lockfile-file": "8.0.1",
+                "@pnpm/types": "9.0.0",
+                "@types/node": "18.15.11",
                 "read-yaml-file": "2.1.0",
                 "ts-node": "10.9.1",
                 "type-fest": "2.17.0",
@@ -57,114 +57,150 @@
             }
         },
         "node_modules/@pnpm/constants": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/constants/-/constants-6.1.0.tgz",
-            "integrity": "sha512-L6AiU3OXv9kjKGTJN9j8n1TeJGDcLX9atQlZvAkthlvbXjvKc5SKNWESc/eXhr5nEfuMWhQhiKHDJCpYejmeCQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/constants/-/constants-7.0.0.tgz",
+            "integrity": "sha512-YA2EO2+uKrDWhtEhsbLdArJwQBr1n5VpCJzz+cLLQ98gbSKCOHAR8qwbn1wChcZitTVAr0HVyxO146nL/wujXg==",
             "dev": true,
             "engines": {
-                "node": ">=14.19"
+                "node": ">=16.14"
+            },
+            "funding": {
+                "url": "https://opencollective.com/pnpm"
+            }
+        },
+        "node_modules/@pnpm/crypto.base32-hash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/crypto.base32-hash/-/crypto.base32-hash-2.0.0.tgz",
+            "integrity": "sha512-3ttOeHBpmWRbgJrpDQ8Nwd3W8s8iuiP5YZM0JRyKWaMtX8lu9d7/AKyxPmhYsMJuN+q/1dwHa7QFeDZJ53b0oA==",
+            "dev": true,
+            "dependencies": {
+                "rfc4648": "^1.5.2"
+            },
+            "engines": {
+                "node": ">=16.14"
+            },
+            "funding": {
+                "url": "https://opencollective.com/pnpm"
+            }
+        },
+        "node_modules/@pnpm/dependency-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/dependency-path/-/dependency-path-2.1.0.tgz",
+            "integrity": "sha512-so0+DWHaJ2oTxws8LQ3kmanxoxO/JAfRB7o1QQCOjTVTlK0vFrKSRj9xZVHBZoWq2C9GbIj1V0Gmcwz7zMs/EQ==",
+            "dev": true,
+            "dependencies": {
+                "@pnpm/crypto.base32-hash": "2.0.0",
+                "@pnpm/types": "9.0.0",
+                "encode-registry": "^3.0.0",
+                "semver": "^7.3.8"
+            },
+            "engines": {
+                "node": ">=16.14"
             },
             "funding": {
                 "url": "https://opencollective.com/pnpm"
             }
         },
         "node_modules/@pnpm/error": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@pnpm/error/-/error-3.0.1.tgz",
-            "integrity": "sha512-hMlbWbFcfcfolNfSjKjpeaZFow71kNg438LZ8rAd01swiVIYRUf/sRv8gGySru6AijYfz5UqslpIJRDbYBkgQA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/error/-/error-5.0.0.tgz",
+            "integrity": "sha512-8Bezq6YSSorPyaiQIr3lWF7hTIuatBTPWVCO7rbgJAGw4pq6t3DmLoN2K3EznVHMBIaqEBmkfB1lkKvXaJIVbw==",
             "dev": true,
             "dependencies": {
-                "@pnpm/constants": "6.1.0"
+                "@pnpm/constants": "7.0.0"
             },
             "engines": {
-                "node": ">=14.19"
+                "node": ">=16.14"
             },
             "funding": {
                 "url": "https://opencollective.com/pnpm"
             }
         },
         "node_modules/@pnpm/git-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/git-utils/-/git-utils-0.1.0.tgz",
-            "integrity": "sha512-W3zsG9585cKL+FqgcT+IfTgZX5C+CbNkFjOnJN+qbysT1N30+BbvEByCcDMsTy7QDrAk6oS7WU1Rym3U2xlh2Q==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/git-utils/-/git-utils-1.0.0.tgz",
+            "integrity": "sha512-lUI+XrzOJN4zdPGOGnFUrmtXAXpXi8wD8OI0nWOZmlh+raqbLzC3VkXu1zgaduOK6YonOcnQW88O+ojav1rAdA==",
             "dev": true,
             "dependencies": {
-                "execa": "npm:safe-execa@^0.1.1"
+                "execa": "npm:safe-execa@0.1.2"
             },
             "engines": {
-                "node": ">=14.6"
+                "node": ">=16.14"
             },
             "funding": {
                 "url": "https://opencollective.com/pnpm"
             }
         },
         "node_modules/@pnpm/lockfile-file": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/lockfile-file/-/lockfile-file-5.2.0.tgz",
-            "integrity": "sha512-VRQsf/8BxCshMWENW7uuqVLgB9qD2U/6GwELewMeuhz7TEon01393DJMs+MY+TcVufI6j0ZldIdVq0qxfFCnxA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@pnpm/lockfile-file/-/lockfile-file-8.0.1.tgz",
+            "integrity": "sha512-3ztE/5Phy8aIk2d2ntD9wPSetFoe3YAQ3inhvBOEhvJo9BYgdclLGivrPnHyPOZw0dRRhir12oGDSwrYuR32dg==",
             "dev": true,
             "dependencies": {
-                "@pnpm/constants": "6.1.0",
-                "@pnpm/error": "3.0.1",
-                "@pnpm/git-utils": "0.1.0",
-                "@pnpm/lockfile-types": "4.2.0",
-                "@pnpm/merge-lockfile-changes": "3.0.6",
-                "@pnpm/types": "8.4.0",
+                "@pnpm/constants": "7.0.0",
+                "@pnpm/dependency-path": "2.1.0",
+                "@pnpm/error": "5.0.0",
+                "@pnpm/git-utils": "1.0.0",
+                "@pnpm/lockfile-types": "5.0.0",
+                "@pnpm/merge-lockfile-changes": "5.0.0",
+                "@pnpm/types": "9.0.0",
+                "@pnpm/util.lex-comparator": "1.0.0",
                 "@zkochan/rimraf": "^2.1.2",
                 "comver-to-semver": "^1.0.0",
-                "js-yaml": "npm:@zkochan/js-yaml@^0.0.6",
+                "js-yaml": "npm:@zkochan/js-yaml@0.0.6",
                 "normalize-path": "^3.0.0",
-                "ramda": "^0.28.0",
-                "semver": "^7.3.7",
+                "ramda": "npm:@pnpm/ramda@0.28.1",
+                "semver": "^7.3.8",
                 "sort-keys": "^4.2.0",
                 "strip-bom": "^4.0.0",
-                "write-file-atomic": "^3.0.3"
+                "write-file-atomic": "^5.0.0"
             },
             "engines": {
-                "node": ">=14.6"
+                "node": ">=16.14"
             },
             "funding": {
                 "url": "https://opencollective.com/pnpm"
             },
             "peerDependencies": {
-                "@pnpm/logger": "^4.0.0"
+                "@pnpm/logger": "^5.0.0"
             }
         },
         "node_modules/@pnpm/lockfile-file/node_modules/write-file-atomic": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+            "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
             "dev": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
-                "is-typedarray": "^1.0.0",
-                "signal-exit": "^3.0.2",
-                "typedarray-to-buffer": "^3.1.5"
+                "signal-exit": "^3.0.7"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@pnpm/lockfile-types": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/lockfile-types/-/lockfile-types-4.2.0.tgz",
-            "integrity": "sha512-8/t9YrC8VSJgEJv/m1UQMNPHs3Tu4Ow7shpuIDPD5sqjNw3lICB9ybbPlO+6/bkb9/D8QizbBigbVsDybWR9Hw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/lockfile-types/-/lockfile-types-5.0.0.tgz",
+            "integrity": "sha512-2M82hciNNIczVtWmQF3eSXPFVWvGWBvq+vssBkSIP0tZW/izYyvkUf2NN8ktNrB/w0jDCVEzujC6RXiRR9b1bg==",
             "dev": true,
             "dependencies": {
-                "@pnpm/types": "8.4.0"
+                "@pnpm/types": "9.0.0"
             },
             "engines": {
-                "node": ">=14.6"
+                "node": ">=16.14"
             },
             "funding": {
                 "url": "https://opencollective.com/pnpm"
             }
         },
         "node_modules/@pnpm/logger": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/logger/-/logger-4.0.0.tgz",
-            "integrity": "sha512-SIShw+k556e7S7tLZFVSIHjCdiVog1qWzcKW2RbLEHPItdisAFVNIe34kYd9fMSswTlSRLS/qRjw3ZblzWmJ9Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/logger/-/logger-5.0.0.tgz",
+            "integrity": "sha512-YfcB2QrX+Wx1o6LD1G2Y2fhDhOix/bAY/oAnMpHoNLsKkWIRbt1oKLkIFvxBMzLwAEPqnYWguJrYC+J6i4ywbw==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "bole": "^4.0.0",
+                "bole": "^5.0.0",
                 "ndjson": "^2.0.0"
             },
             "engines": {
@@ -172,33 +208,42 @@
             }
         },
         "node_modules/@pnpm/merge-lockfile-changes": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@pnpm/merge-lockfile-changes/-/merge-lockfile-changes-3.0.6.tgz",
-            "integrity": "sha512-ZG67OpIFTPkP9X0MBgX7dwHMvRH9zdSpZ052X8PMoXOvoVqT+pN3dgUz+F4OqWl/+dwgrLZkBJXTRFTHGByakQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/merge-lockfile-changes/-/merge-lockfile-changes-5.0.0.tgz",
+            "integrity": "sha512-iYR4hCGTMJDp1THLrySkW3NOR/UkKLKRxpDoNdtDv/tsl0KN3lzGnaNKmBNQVh0AS0EW8YViP2MZJRPAKj3BTg==",
             "dev": true,
             "dependencies": {
-                "@pnpm/lockfile-types": "4.2.0",
+                "@pnpm/lockfile-types": "5.0.0",
                 "comver-to-semver": "^1.0.0",
-                "ramda": "^0.28.0",
-                "semver": "^7.3.4"
+                "ramda": "npm:@pnpm/ramda@0.28.1",
+                "semver": "^7.3.8"
             },
             "engines": {
-                "node": ">=14.6"
+                "node": ">=16.14"
             },
             "funding": {
                 "url": "https://opencollective.com/pnpm"
             }
         },
         "node_modules/@pnpm/types": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-8.4.0.tgz",
-            "integrity": "sha512-sq/UdSq/jWCpYglw9SFmvR8qzUEi0p2oZIO0AHjkWWQg4Qrolf6DgD0WWmLiEP2WxHjbYeyD3ZzWzQor1+6cvw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-9.0.0.tgz",
+            "integrity": "sha512-+nNqpNvqb1u3WW/cHDo7tGjqJBWWe4GAHEdELrz4QMQwGAtG/1GF6NMc0cewdwgU2k67CI3JHGu4quZJnMEUJg==",
             "dev": true,
             "engines": {
-                "node": ">=14.6"
+                "node": ">=16.14"
             },
             "funding": {
                 "url": "https://opencollective.com/pnpm"
+            }
+        },
+        "node_modules/@pnpm/util.lex-comparator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/util.lex-comparator/-/util.lex-comparator-1.0.0.tgz",
+            "integrity": "sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.22.0"
             }
         },
         "node_modules/@tsconfig/node10": {
@@ -226,9 +271,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.6.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-            "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
+            "version": "18.15.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+            "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
             "dev": true
         },
         "node_modules/@zkochan/rimraf": {
@@ -298,9 +343,9 @@
             "dev": true
         },
         "node_modules/bole": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/bole/-/bole-4.0.0.tgz",
-            "integrity": "sha512-Bk/2qoyOSlwU1dnDFk/oPM2FCNKAlYlBHfpAgwGX+K9HUtxSvmIAQCmMWMOvE6BlHHRCwsH1MxJe/r1ieodxqQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/bole/-/bole-5.0.3.tgz",
+            "integrity": "sha512-4o8wk9dlpU0e69sXhIsPIaFfXgOvj6en2GgZkG8hadkqNEqYKcz9Y70ijg7Kjq9hz2prJkWXljca5OBJZ451xg==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -360,6 +405,18 @@
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/encode-registry": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/encode-registry/-/encode-registry-3.0.0.tgz",
+            "integrity": "sha512-2fRYji8K6FwYuQ6EPBKR/J9mcqb7kIoNqt1vGvJr3NrvKfncRiNm00Oxo6gi/YJF8R5Sp2bNFSFdGKTG0rje1Q==",
+            "dev": true,
+            "dependencies": {
+                "mem": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/execa": {
@@ -507,12 +564,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-            "dev": true
-        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -557,6 +608,34 @@
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
+        "node_modules/map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "dependencies": {
+                "p-defer": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/mem": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+            "dev": true,
+            "dependencies": {
+                "map-age-cleaner": "^0.1.3",
+                "mimic-fn": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/mem?sponsor=1"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -564,12 +643,12 @@
             "dev": true
         },
         "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
             "dev": true,
             "engines": {
-                "node": ">=6"
+                "node": ">=8"
             }
         },
         "node_modules/minimatch": {
@@ -585,11 +664,14 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
-            "peer": true
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/ndjson": {
             "version": "2.0.0",
@@ -656,6 +738,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/onetime/node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -681,9 +781,10 @@
             "dev": true
         },
         "node_modules/ramda": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-            "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+            "name": "@pnpm/ramda",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@pnpm/ramda/-/ramda-0.28.1.tgz",
+            "integrity": "sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -716,9 +817,9 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -729,6 +830,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/rfc4648": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.2.tgz",
+            "integrity": "sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg==",
+            "dev": true
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
@@ -767,9 +874,9 @@
             "peer": true
         },
         "node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -926,15 +1033,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
-            "dependencies": {
-                "is-typedarray": "^1.0.0"
-            }
-        },
         "node_modules/typescript": {
             "version": "4.7.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -1044,102 +1142,129 @@
             }
         },
         "@pnpm/constants": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/constants/-/constants-6.1.0.tgz",
-            "integrity": "sha512-L6AiU3OXv9kjKGTJN9j8n1TeJGDcLX9atQlZvAkthlvbXjvKc5SKNWESc/eXhr5nEfuMWhQhiKHDJCpYejmeCQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/constants/-/constants-7.0.0.tgz",
+            "integrity": "sha512-YA2EO2+uKrDWhtEhsbLdArJwQBr1n5VpCJzz+cLLQ98gbSKCOHAR8qwbn1wChcZitTVAr0HVyxO146nL/wujXg==",
             "dev": true
         },
-        "@pnpm/error": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@pnpm/error/-/error-3.0.1.tgz",
-            "integrity": "sha512-hMlbWbFcfcfolNfSjKjpeaZFow71kNg438LZ8rAd01swiVIYRUf/sRv8gGySru6AijYfz5UqslpIJRDbYBkgQA==",
+        "@pnpm/crypto.base32-hash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/crypto.base32-hash/-/crypto.base32-hash-2.0.0.tgz",
+            "integrity": "sha512-3ttOeHBpmWRbgJrpDQ8Nwd3W8s8iuiP5YZM0JRyKWaMtX8lu9d7/AKyxPmhYsMJuN+q/1dwHa7QFeDZJ53b0oA==",
             "dev": true,
             "requires": {
-                "@pnpm/constants": "6.1.0"
+                "rfc4648": "^1.5.2"
+            }
+        },
+        "@pnpm/dependency-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/dependency-path/-/dependency-path-2.1.0.tgz",
+            "integrity": "sha512-so0+DWHaJ2oTxws8LQ3kmanxoxO/JAfRB7o1QQCOjTVTlK0vFrKSRj9xZVHBZoWq2C9GbIj1V0Gmcwz7zMs/EQ==",
+            "dev": true,
+            "requires": {
+                "@pnpm/crypto.base32-hash": "2.0.0",
+                "@pnpm/types": "9.0.0",
+                "encode-registry": "^3.0.0",
+                "semver": "^7.3.8"
+            }
+        },
+        "@pnpm/error": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/error/-/error-5.0.0.tgz",
+            "integrity": "sha512-8Bezq6YSSorPyaiQIr3lWF7hTIuatBTPWVCO7rbgJAGw4pq6t3DmLoN2K3EznVHMBIaqEBmkfB1lkKvXaJIVbw==",
+            "dev": true,
+            "requires": {
+                "@pnpm/constants": "7.0.0"
             }
         },
         "@pnpm/git-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/git-utils/-/git-utils-0.1.0.tgz",
-            "integrity": "sha512-W3zsG9585cKL+FqgcT+IfTgZX5C+CbNkFjOnJN+qbysT1N30+BbvEByCcDMsTy7QDrAk6oS7WU1Rym3U2xlh2Q==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/git-utils/-/git-utils-1.0.0.tgz",
+            "integrity": "sha512-lUI+XrzOJN4zdPGOGnFUrmtXAXpXi8wD8OI0nWOZmlh+raqbLzC3VkXu1zgaduOK6YonOcnQW88O+ojav1rAdA==",
             "dev": true,
             "requires": {
-                "execa": "npm:safe-execa@^0.1.1"
+                "execa": "npm:safe-execa@0.1.2"
             }
         },
         "@pnpm/lockfile-file": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/lockfile-file/-/lockfile-file-5.2.0.tgz",
-            "integrity": "sha512-VRQsf/8BxCshMWENW7uuqVLgB9qD2U/6GwELewMeuhz7TEon01393DJMs+MY+TcVufI6j0ZldIdVq0qxfFCnxA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@pnpm/lockfile-file/-/lockfile-file-8.0.1.tgz",
+            "integrity": "sha512-3ztE/5Phy8aIk2d2ntD9wPSetFoe3YAQ3inhvBOEhvJo9BYgdclLGivrPnHyPOZw0dRRhir12oGDSwrYuR32dg==",
             "dev": true,
             "requires": {
-                "@pnpm/constants": "6.1.0",
-                "@pnpm/error": "3.0.1",
-                "@pnpm/git-utils": "0.1.0",
-                "@pnpm/lockfile-types": "4.2.0",
-                "@pnpm/merge-lockfile-changes": "3.0.6",
-                "@pnpm/types": "8.4.0",
+                "@pnpm/constants": "7.0.0",
+                "@pnpm/dependency-path": "2.1.0",
+                "@pnpm/error": "5.0.0",
+                "@pnpm/git-utils": "1.0.0",
+                "@pnpm/lockfile-types": "5.0.0",
+                "@pnpm/merge-lockfile-changes": "5.0.0",
+                "@pnpm/types": "9.0.0",
+                "@pnpm/util.lex-comparator": "1.0.0",
                 "@zkochan/rimraf": "^2.1.2",
                 "comver-to-semver": "^1.0.0",
-                "js-yaml": "npm:@zkochan/js-yaml@^0.0.6",
+                "js-yaml": "npm:@zkochan/js-yaml@0.0.6",
                 "normalize-path": "^3.0.0",
-                "ramda": "^0.28.0",
-                "semver": "^7.3.7",
+                "ramda": "npm:@pnpm/ramda@0.28.1",
+                "semver": "^7.3.8",
                 "sort-keys": "^4.2.0",
                 "strip-bom": "^4.0.0",
-                "write-file-atomic": "^3.0.3"
+                "write-file-atomic": "^5.0.0"
             },
             "dependencies": {
                 "write-file-atomic": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-                    "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+                    "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
                     "dev": true,
                     "requires": {
                         "imurmurhash": "^0.1.4",
-                        "is-typedarray": "^1.0.0",
-                        "signal-exit": "^3.0.2",
-                        "typedarray-to-buffer": "^3.1.5"
+                        "signal-exit": "^3.0.7"
                     }
                 }
             }
         },
         "@pnpm/lockfile-types": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/lockfile-types/-/lockfile-types-4.2.0.tgz",
-            "integrity": "sha512-8/t9YrC8VSJgEJv/m1UQMNPHs3Tu4Ow7shpuIDPD5sqjNw3lICB9ybbPlO+6/bkb9/D8QizbBigbVsDybWR9Hw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/lockfile-types/-/lockfile-types-5.0.0.tgz",
+            "integrity": "sha512-2M82hciNNIczVtWmQF3eSXPFVWvGWBvq+vssBkSIP0tZW/izYyvkUf2NN8ktNrB/w0jDCVEzujC6RXiRR9b1bg==",
             "dev": true,
             "requires": {
-                "@pnpm/types": "8.4.0"
+                "@pnpm/types": "9.0.0"
             }
         },
         "@pnpm/logger": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/logger/-/logger-4.0.0.tgz",
-            "integrity": "sha512-SIShw+k556e7S7tLZFVSIHjCdiVog1qWzcKW2RbLEHPItdisAFVNIe34kYd9fMSswTlSRLS/qRjw3ZblzWmJ9Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/logger/-/logger-5.0.0.tgz",
+            "integrity": "sha512-YfcB2QrX+Wx1o6LD1G2Y2fhDhOix/bAY/oAnMpHoNLsKkWIRbt1oKLkIFvxBMzLwAEPqnYWguJrYC+J6i4ywbw==",
             "dev": true,
             "peer": true,
             "requires": {
-                "bole": "^4.0.0",
+                "bole": "^5.0.0",
                 "ndjson": "^2.0.0"
             }
         },
         "@pnpm/merge-lockfile-changes": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@pnpm/merge-lockfile-changes/-/merge-lockfile-changes-3.0.6.tgz",
-            "integrity": "sha512-ZG67OpIFTPkP9X0MBgX7dwHMvRH9zdSpZ052X8PMoXOvoVqT+pN3dgUz+F4OqWl/+dwgrLZkBJXTRFTHGByakQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/merge-lockfile-changes/-/merge-lockfile-changes-5.0.0.tgz",
+            "integrity": "sha512-iYR4hCGTMJDp1THLrySkW3NOR/UkKLKRxpDoNdtDv/tsl0KN3lzGnaNKmBNQVh0AS0EW8YViP2MZJRPAKj3BTg==",
             "dev": true,
             "requires": {
-                "@pnpm/lockfile-types": "4.2.0",
+                "@pnpm/lockfile-types": "5.0.0",
                 "comver-to-semver": "^1.0.0",
-                "ramda": "^0.28.0",
-                "semver": "^7.3.4"
+                "ramda": "npm:@pnpm/ramda@0.28.1",
+                "semver": "^7.3.8"
             }
         },
         "@pnpm/types": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-8.4.0.tgz",
-            "integrity": "sha512-sq/UdSq/jWCpYglw9SFmvR8qzUEi0p2oZIO0AHjkWWQg4Qrolf6DgD0WWmLiEP2WxHjbYeyD3ZzWzQor1+6cvw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-9.0.0.tgz",
+            "integrity": "sha512-+nNqpNvqb1u3WW/cHDo7tGjqJBWWe4GAHEdELrz4QMQwGAtG/1GF6NMc0cewdwgU2k67CI3JHGu4quZJnMEUJg==",
+            "dev": true
+        },
+        "@pnpm/util.lex-comparator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/util.lex-comparator/-/util.lex-comparator-1.0.0.tgz",
+            "integrity": "sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==",
             "dev": true
         },
         "@tsconfig/node10": {
@@ -1167,9 +1292,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.6.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-            "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
+            "version": "18.15.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+            "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
             "dev": true
         },
         "@zkochan/rimraf": {
@@ -1221,9 +1346,9 @@
             "dev": true
         },
         "bole": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/bole/-/bole-4.0.0.tgz",
-            "integrity": "sha512-Bk/2qoyOSlwU1dnDFk/oPM2FCNKAlYlBHfpAgwGX+K9HUtxSvmIAQCmMWMOvE6BlHHRCwsH1MxJe/r1ieodxqQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/bole/-/bole-5.0.3.tgz",
+            "integrity": "sha512-4o8wk9dlpU0e69sXhIsPIaFfXgOvj6en2GgZkG8hadkqNEqYKcz9Y70ijg7Kjq9hz2prJkWXljca5OBJZ451xg==",
             "dev": true,
             "peer": true,
             "requires": {
@@ -1275,6 +1400,15 @@
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
+        },
+        "encode-registry": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/encode-registry/-/encode-registry-3.0.0.tgz",
+            "integrity": "sha512-2fRYji8K6FwYuQ6EPBKR/J9mcqb7kIoNqt1vGvJr3NrvKfncRiNm00Oxo6gi/YJF8R5Sp2bNFSFdGKTG0rje1Q==",
+            "dev": true,
+            "requires": {
+                "mem": "^8.0.0"
+            }
         },
         "execa": {
             "version": "npm:safe-execa@0.1.2",
@@ -1386,12 +1520,6 @@
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-            "dev": true
-        },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1429,6 +1557,25 @@
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
+        "mem": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "^0.1.3",
+                "mimic-fn": "^3.1.0"
+            }
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1436,9 +1583,9 @@
             "dev": true
         },
         "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
             "dev": true
         },
         "minimatch": {
@@ -1451,9 +1598,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
             "peer": true
         },
@@ -1502,7 +1649,21 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
+            },
+            "dependencies": {
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                    "dev": true
+                }
             }
+        },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -1523,9 +1684,9 @@
             "dev": true
         },
         "ramda": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-            "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+            "version": "npm:@pnpm/ramda@0.28.1",
+            "resolved": "https://registry.npmjs.org/@pnpm/ramda/-/ramda-0.28.1.tgz",
+            "integrity": "sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==",
             "dev": true
         },
         "read-yaml-file": {
@@ -1550,9 +1711,9 @@
             }
         },
         "readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
             "peer": true,
             "requires": {
@@ -1560,6 +1721,12 @@
                 "string_decoder": "^1.1.1",
                 "util-deprecate": "^1.0.1"
             }
+        },
+        "rfc4648": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.2.tgz",
+            "integrity": "sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg==",
+            "dev": true
         },
         "rimraf": {
             "version": "3.0.2",
@@ -1578,9 +1745,9 @@
             "peer": true
         },
         "semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"
@@ -1684,15 +1851,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.17.0.tgz",
             "integrity": "sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==",
             "dev": true
-        },
-        "typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
-            "requires": {
-                "is-typedarray": "^1.0.0"
-            }
         },
         "typescript": {
             "version": "4.7.4",

--- a/.github/actions/snyk-pnpm/package.json
+++ b/.github/actions/snyk-pnpm/package.json
@@ -11,9 +11,9 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "devDependencies": {
-        "@pnpm/lockfile-file": "5.2.0",
-        "@pnpm/types": "8.4.0",
-        "@types/node": "18.6.1",
+        "@pnpm/lockfile-file": "8.0.1",
+        "@pnpm/types": "9.0.0",
+        "@types/node": "18.15.11",
         "read-yaml-file": "2.1.0",
         "ts-node": "10.9.1",
         "type-fest": "2.17.0",

--- a/.github/actions/snyk-pnpm/src/generateNpmLockfile.ts
+++ b/.github/actions/snyk-pnpm/src/generateNpmLockfile.ts
@@ -1,4 +1,4 @@
-import {Lockfile} from '@pnpm/lockfile-types';
+import {LockfileV6} from '@pnpm/lockfile-types';
 
 import {
     NpmLockedPackageDependency,
@@ -10,7 +10,7 @@ import {
 } from './Interfaces';
 import {getDependencyFullname, getPathPackageDesc} from './processPnpmLockfile';
 
-function getPackage(lockfile: Lockfile, packageDesc: PnpmPackageDesc): NpmLockedPackageDependency {
+function getPackage(lockfile: LockfileV6, packageDesc: PnpmPackageDesc): NpmLockedPackageDependency {
     const snapshot = (lockfile.packages || {})[packageDesc.fullname];
     if (snapshot === undefined) {
         throw new Error(`Failed to lookup ${packageDesc.fullname} in packages`);
@@ -50,7 +50,7 @@ function getSubdependencyFromDependency(dep: NpmLockedPackageDependency): NpmLoc
     return subdep;
 }
 
-export function generateNpmLock(lockfile: Lockfile): NpmPackageLock {
+export function generateNpmLock(lockfile: LockfileV6): NpmPackageLock {
     const deps = {} as NpmLockedPackageDependencyMap;
     const subdeps = {} as NpmLockedPackageDependencyMap;
 
@@ -72,7 +72,7 @@ export function generateNpmLock(lockfile: Lockfile): NpmPackageLock {
                 const fullname = getDependencyFullname(name, version);
                 const snapshot = (lockfile.packages || {})[fullname];
                 if (snapshot === undefined) {
-                    throw new Error(`Failed to lookup ${name} in packages`);
+                    throw new Error(`Failed to lookup ${fullname} in packages`);
                 }
                 const packageDesc = getPathPackageDesc(fullname, snapshot);
                 // secondary dependencies are declared in the 'dependencies' of a package

--- a/.github/actions/snyk-pnpm/src/generatePackageJson.ts
+++ b/.github/actions/snyk-pnpm/src/generatePackageJson.ts
@@ -1,39 +1,29 @@
-import {Lockfile, ResolvedDependencies} from '@pnpm/lockfile-types';
+import {LockfileV6, ResolvedDependenciesOfImporters} from '@pnpm/lockfile-types';
 import {PackageJson} from 'type-fest';
 
 function isLocalPackage(resolvedVersion: string): boolean {
     return /^link:/.test(resolvedVersion);
 }
 
-function convertResolvedDepsToSpecifiedDeps(
-    resolvedDeps: ResolvedDependencies,
-    specifiers: ResolvedDependencies
-): PackageJson.Dependency {
+function convertResolvedDepsToSpecifiedDeps(resolvedDeps: ResolvedDependenciesOfImporters): PackageJson.Dependency {
     const deps = {} as PackageJson.Dependency;
     if (resolvedDeps) {
-        Object.entries(resolvedDeps).forEach(([packageName, resolvedVersion]) => {
-            if (!isLocalPackage(resolvedVersion)) {
-                const specifiedVersion = specifiers[packageName];
-                deps[packageName] = specifiedVersion;
+        Object.entries(resolvedDeps).forEach(([packageName, {version, specifier}]) => {
+            if (!isLocalPackage(version)) {
+                deps[packageName] = specifier;
             }
         });
     }
     return deps;
 }
 
-export function generatePackageJson(lockfile: Lockfile): PackageJson {
+export function generatePackageJson(lockfile: LockfileV6): PackageJson {
     const deps = {} as PackageJson.Dependency;
     const devDeps = {} as PackageJson.Dependency;
 
     for (const [projectName, projectSnapshot] of Object.entries(lockfile.importers)) {
-        Object.assign(
-            deps,
-            convertResolvedDepsToSpecifiedDeps(projectSnapshot.dependencies, projectSnapshot.specifiers)
-        );
-        Object.assign(
-            devDeps,
-            convertResolvedDepsToSpecifiedDeps(projectSnapshot.devDependencies, projectSnapshot.specifiers)
-        );
+        Object.assign(deps, convertResolvedDepsToSpecifiedDeps(projectSnapshot.dependencies));
+        Object.assign(devDeps, convertResolvedDepsToSpecifiedDeps(projectSnapshot.devDependencies));
     }
     return {dependencies: deps, devDependencies: devDeps};
 }

--- a/.github/actions/snyk-pnpm/src/processPnpmLockfile.ts
+++ b/.github/actions/snyk-pnpm/src/processPnpmLockfile.ts
@@ -1,10 +1,10 @@
 import readYamlFile from 'read-yaml-file';
-import {Lockfile, PackageSnapshot} from '@pnpm/lockfile-types';
+import {LockfileV6, PackageSnapshot} from '@pnpm/lockfile-types';
 import {PnpmPackageDesc, PnpmPackageDescType} from './Interfaces';
 
-export async function readLockfile(lockfilePath: string): Promise<Lockfile | null> {
+export async function readLockfile(lockfilePath: string): Promise<LockfileV6 | null> {
     try {
-        return await readYamlFile<Lockfile>(lockfilePath);
+        return await readYamlFile<LockfileV6>(lockfilePath);
     } catch (err) {
         if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
             throw err;
@@ -31,17 +31,18 @@ export function getGithubPackageDesc(uri: string, packageSnapshot: PackageSnapsh
 
 /**
  *Package names look like:
- * - /@pnpm/error/1.0.0
- * - /@pnpm/lockfile-file/1.1.3_@pnpm+logger@2.1.1
- * - /@emotion/core/10.0.14_react@16.8.6
- * - /@uc/modal-loader/0.7.1_2eb23211954108c6f87c7fe8e90d1312
- * - npm.example.com/axios/0.19.0
- * - npm.example.com/@sentry/node/5.1.0_@other@1.2.3
+ * - /@pnpm/error@1.0.0
+ * - /@pnpm/lockfile-file@1.1.3_@pnpm+logger@2.1.1
+ * - /@emotion/core@10.0.14_react@16.8.6
+ * - /@uc/modal-loader@0.7.1_2eb23211954108c6f87c7fe8e90d1312
+ * - /eslint-plugin-import@2.26.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)
+ * - npm.example.com/axios@0.19.0
+ * - npm.example.com/@sentry/node@5.1.0_@other@1.2.3
  * - github.com/LewisArdern/eslint-plugin-angularjs-security-rules/41da01727c87119bd523e69e22af2d04ab558ec9
  */
 export function getPathPackageDesc(fullname: string, packageSnapshot: PackageSnapshot): PnpmPackageDesc {
     if (!fullname.startsWith('github.com/')) {
-        const result = /^[^\/]*\/((?:@[^\/]+\/)?[^\/]+)\/(.*)$/.exec(fullname);
+        const result = /^[^\/]*\/((?:@[^\/]+\/)?[^@]+)@(.*)$/.exec(fullname);
         if (result == null) {
             throw new Error(`Error parsing package name ${fullname}`);
         }
@@ -71,5 +72,5 @@ export function getPathPackageDesc(fullname: string, packageSnapshot: PackageSna
 }
 
 export function getDependencyFullname(name: string, version: string): string {
-    return /^\d/.test(version) ? ['', name, version].join('/') : version;
+    return /^\d/.test(version) ? `/${name}@${version}` : version;
 }


### PR DESCRIPTION
### Proposed Changes

The CD is failing since the package lock was update to version 6. The snyk action required a few changes to work with this new version of the pnpm lockfile.

<img width="1312" alt="image" src="https://user-images.githubusercontent.com/35579930/229842479-f7a8d794-907e-4b8a-b8db-75366bcb3a25.png">


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
