### PR TITLE
feat(mantine, collection): added getItemId props for ReactHookForm - CTCORE-9124

### DIFF
--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -12,8 +12,8 @@ import {
     useComponentDefaultProps,
 } from '@mantine/core';
 import {ReorderPayload} from '@mantine/form/lib/types';
-import {useDidUpdate, useId} from '@mantine/hooks';
-import {ReactNode} from 'react';
+import {useDidUpdate} from '@mantine/hooks';
+import {ReactNode, useId} from 'react';
 import {DragDropContext, Droppable} from 'react-beautiful-dnd';
 
 import {Button} from '../button';
@@ -40,6 +40,16 @@ interface CollectionProps<T>
      * @default []
      */
     value?: T[];
+    /**
+     * Defines how each item is uniquely identified. It is highly recommended that you specify this prop to an ID that makes sense.
+     *
+     * This method is required when using this component with ReactHookForm.
+     *
+     * @see {@link https://react-hook-form.com/api/usefieldarray/} for using a collection with ReactHookForm.
+     *
+     * @param originalItem The original item
+     */
+    getItemId?: (originalItem: T) => string;
     /**
      * Unused, has no effect
      */
@@ -146,6 +156,7 @@ export const Collection = <T,>(props: CollectionProps<T>) => {
         descriptionProps,
         error,
         errorProps,
+        getItemId,
 
         // Style props
         classNames,
@@ -156,7 +167,7 @@ export const Collection = <T,>(props: CollectionProps<T>) => {
         ...others
     } = useComponentDefaultProps('Collection', defaultProps as CollectionProps<T>, props);
     const {classes, cx} = useStyles(null, {classNames, name: 'Collection', styles, unstyled});
-    const collectionID = useId('dnd-droppable');
+    const collectionID = useId();
 
     const hasOnlyOneItem = value.length === 1;
 
@@ -188,7 +199,7 @@ export const Collection = <T,>(props: CollectionProps<T>) => {
 
     const items = value.map((item, index) => (
         <CollectionItem
-            key={index}
+            key={(getItemId?.(item) ?? index) as string}
             disabled={disabled}
             draggable={draggable}
             index={index}

--- a/packages/mantine/src/components/collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/collection/CollectionItem.tsx
@@ -62,7 +62,7 @@ const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionIte
     const removeButton = removable && onRemove ? <RemoveButton onClick={onRemove} /> : null;
 
     return (
-        <Draggable index={index} draggableId={index.toString()}>
+        <Draggable key={index} index={index} draggableId={index.toString()}>
             {(provided, {isDragging}) => (
                 <Group
                     ref={provided.innerRef}

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -57,6 +57,7 @@
         "react": "18.2.0",
         "react-diff-view": "2.4.10",
         "react-dom": "18.2.0",
+        "react-hook-form": "7.43.9",
         "react-markdown": "7.1.2",
         "react-redux": "7.2.6",
         "redux": "4.2.1",

--- a/packages/website/src/examples/form/collection/Collection.demo.tsx
+++ b/packages/website/src/examples/form/collection/Collection.demo.tsx
@@ -24,7 +24,7 @@ export default () => {
             newItem={{name: '', done: false}}
             {...form.getInputProps('todoList')}
         >
-            {(task, index) => (
+            {(_task, index) => (
                 <>
                     <TextInput
                         // Autofocus is annoying when playing with the sandbox but you should have this on otherwise

--- a/packages/website/src/examples/form/collection/CollectionWithReactHookForm.demo.tsx
+++ b/packages/website/src/examples/form/collection/CollectionWithReactHookForm.demo.tsx
@@ -1,0 +1,67 @@
+import {Checkbox, Collection, TextInput} from '@coveord/plasma-mantine';
+import {Controller, useForm, useFieldArray} from 'react-hook-form';
+
+export default () => {
+    const {control} = useForm({
+        defaultValues: {
+            todoList: [
+                {name: 'wash the dishes', done: true},
+                {name: 'take out the trash', done: false},
+                {name: 'vacuum the floors', done: false},
+            ],
+        },
+        mode: 'onBlur',
+    });
+
+    const itemId = 'internal-id';
+    const {fields, insert, move, remove} = useFieldArray({control, keyName: itemId, name: 'todoList'});
+
+    return (
+        <Controller
+            control={control}
+            name="todoList"
+            render={({fieldState: {error}}) => (
+                <Collection<{name: string; done: boolean; 'internal-id'?: string}>
+                    draggable
+                    addLabel="Add task"
+                    description="These will have to be done by next week"
+                    label="List of tasks"
+                    newItem={{name: '', done: false}}
+                    error={error?.message}
+                    onReorderItem={({from, to}) => {
+                        move(from, to);
+                    }}
+                    onRemoveItem={remove}
+                    onInsertItem={(value, index: number) => {
+                        insert(index, value);
+                    }}
+                    value={fields}
+                    getItemId={(item) => item[itemId]}
+                >
+                    {(_task, index) => (
+                        <>
+                            <Controller
+                                control={control}
+                                name={`todoList.${index}.name` as const}
+                                render={({field, fieldState: {error: errorFieldName}}) => (
+                                    <TextInput
+                                        {...field}
+                                        error={errorFieldName?.message}
+                                        placeholder="Do something ..."
+                                    />
+                                )}
+                            />
+                            <Controller
+                                control={control}
+                                name={`todoList.${index}.done` as const}
+                                render={({field: {value, ...restField}, fieldState: {error: errorFieldDone}}) => (
+                                    <Checkbox checked={value} {...restField} error={errorFieldDone?.message} />
+                                )}
+                            />
+                        </>
+                    )}
+                </Collection>
+            )}
+        />
+    );
+};

--- a/packages/website/src/pages/form/Collection.tsx
+++ b/packages/website/src/pages/form/Collection.tsx
@@ -1,5 +1,6 @@
 import {CollectionMetadata} from '@coveord/plasma-components-props-analyzer';
 import CollectionDemo from '@examples/form/collection/Collection.demo?demo';
+import CollectionWithReactHookFormDemo from '@examples/form/collection/CollectionWithReactHookForm.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -12,5 +13,8 @@ export default () => (
         id="Collection"
         demo={<CollectionDemo />}
         propsMetadata={CollectionMetadata}
+        examples={{
+            reactHookForm: <CollectionWithReactHookFormDemo title="Collection with ReactHookForm" />,
+        }}
     />
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,6 +935,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      react-hook-form:
+        specifier: 7.43.9
+        version: 7.43.9(react@18.2.0)
       react-markdown:
         specifier: 7.1.2
         version: 7.1.2(@types/react@18.0.25)(react@18.2.0)
@@ -14216,6 +14219,15 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  /react-hook-form@7.43.9(react@18.2.0):
+    resolution: {integrity: sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /react-infinite-scroll-component@4.5.3(prop-types@15.8.1)(react@18.2.0):
     resolution: {integrity: sha512-8O0PIeYZx0xFVS1ChLlLl/1obn64vylzXeheLsm+t0qUibmet7U6kDaKFg6jVRQJwDikWBTcyqEFFsxrbFCO5w==}


### PR DESCRIPTION
### Proposed Changes

- [x] Added `getItemId` props for Collection component
- [x] [Added an example of using the Collection component with ReactHookForm](https://plasma.coveo.com/feature/feature/CTCORE-9124/form/Collection)

### Potential Breaking Changes

`None`

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
