### PR TITLE
feat(mantine, table): create a consumer semantic component

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -26,6 +26,7 @@ import {TableHeader} from './TableHeader';
 import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
+import {TableConsumer} from './TableConsumer';
 import {TableSelectableColumn} from './TableSelectableColumn';
 import {Th} from './Th';
 import {useRowSelection} from './useRowSelection';
@@ -55,6 +56,7 @@ export const Table: TableType = <T,>({
     const convertedChildren = Children.toArray(children) as ReactElement[];
     const header = convertedChildren.find((child) => child.type === TableHeader);
     const footer = convertedChildren.find((child) => child.type === TableFooter);
+    const consumer = convertedChildren.find((child) => child.type === TableConsumer);
 
     const {predicates, dateRange, ...initialStateWithoutForm} = initialState;
     const form = useForm<TableFormType>({
@@ -189,6 +191,7 @@ export const Table: TableType = <T,>({
                     getPageCount: table.getPageCount,
                 }}
             >
+                {consumer}
                 {!rows.length && !isFiltered && !loading ? (
                     noDataChildren
                 ) : (
@@ -235,3 +238,4 @@ Table.Predicate = TablePredicate;
 Table.CollapsibleColumn = TableCollapsibleColumn;
 Table.AccordionColumn = TableAccordionColumn;
 Table.DateRangePicker = TableDateRangePicker;
+Table.Consumer = TableConsumer;

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -7,8 +7,8 @@ import {
     TableState as TanstackTableState,
 } from '@tanstack/table-core';
 import {Dispatch, ReactElement, ReactNode, RefObject} from 'react';
-import {DateRangePickerValue} from '../date-range-picker/DateRangePickerInlineCalendar';
 
+import {DateRangePickerValue} from '../date-range-picker/DateRangePickerInlineCalendar';
 import {TableActions} from './TableActions';
 import {TableAccordionColumn, TableCollapsibleColumn} from './TableCollapsibleColumn';
 import {TableDateRangePicker} from './TableDateRangePicker';
@@ -18,6 +18,7 @@ import {TableHeader} from './TableHeader';
 import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
+import {TableConsumer} from './TableConsumer';
 
 export type RowSelectionWithData<TData> = Record<string, TData>;
 export interface RowSelectionState<TData> {
@@ -206,4 +207,5 @@ export interface TableType {
     DateRangePicker: typeof TableDateRangePicker;
     CollapsibleColumn: typeof TableCollapsibleColumn;
     AccordionColumn: typeof TableAccordionColumn;
+    Consumer: typeof TableConsumer;
 }

--- a/packages/mantine/src/components/table/TableConsumer.tsx
+++ b/packages/mantine/src/components/table/TableConsumer.tsx
@@ -1,0 +1,3 @@
+import type {FunctionComponent, ReactNode} from 'react';
+
+export const TableConsumer: FunctionComponent<{children: ReactNode}> = ({children}) => <>{children}</>;

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -137,6 +137,31 @@ describe('Table', () => {
         expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
     });
 
+    it('updates the table when a component in Table.Consumer triggers a change', async () => {
+        const user = userEvent.setup();
+        const spy = vi.fn();
+        const Fixture = () => {
+            const {onChange} = useTable();
+            return <button onClick={() => onChange()}>Click me</button>;
+        };
+        render(
+            <Table onChange={spy} data={[{id: '🆔', firstName: 'first', lastName: 'last'}]} columns={columns}>
+                <Table.Consumer>
+                    <Fixture />
+                </Table.Consumer>
+            </Table>
+        );
+
+        expect(screen.getByRole('button', {name: 'Click me'})).toBeVisible();
+        expect(spy).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole('button', {name: 'Click me'}));
+
+        await waitFor(() => {
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('shows a loading animation', () => {
         const doRender = (props: Omit<TableProps<RowData>, 'columns'>) => {
             const NoData = () => {

--- a/packages/website/src/examples/layout/Table/TableConsumer.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableConsumer.demo.tsx
@@ -1,0 +1,67 @@
+import {ColumnDef, createColumnHelper, onTableChangeEvent, Table, useTable} from '@coveord/plasma-mantine';
+import {FunctionComponent, useEffect, useState} from 'react';
+
+interface PostData {
+    id: number;
+    title: string;
+}
+
+const columnHelper = createColumnHelper<PostData>();
+const columns: Array<ColumnDef<PostData>> = [
+    columnHelper.accessor('id', {
+        header: 'Post ID',
+        enableSorting: false,
+    }),
+    columnHelper.accessor('title', {
+        header: 'Title',
+        enableSorting: false,
+    }),
+];
+
+export default () => {
+    const [data, setData] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    const fetchData: onTableChangeEvent<PostData> = async () => {
+        setLoading(true);
+        try {
+            const response = await fetch('https://jsonplaceholder.typicode.com/posts');
+            const body = await response.json();
+
+            // slow down the fetch, to make the refresh more obvious
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            setData(body);
+        } catch (e) {
+            console.error(e);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <Table<PostData>
+            data={data}
+            getRowId={({id}) => id.toString()}
+            columns={columns}
+            onMount={fetchData}
+            onChange={fetchData}
+            loading={loading}
+        >
+            <Table.Consumer>
+                {/* Refresh the component every 10s, look at your network tab to validate it works */}
+                <IntervalRefresh every={10 * 1000} />
+            </Table.Consumer>
+        </Table>
+    );
+};
+
+const IntervalRefresh: FunctionComponent<{every: number}> = ({every}) => {
+    const {onChange} = useTable();
+    useEffect(() => {
+        const timer = setInterval(() => onChange(), every);
+        return () => clearInterval(timer);
+    }, [every]);
+
+    return null;
+};

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -3,6 +3,7 @@ import TableDemo from '@examples/layout/Table/Table.demo?demo';
 import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
 import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo?demo';
 import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo?demo';
+import TableConsumerDemo from '@examples/layout/Table/TableConsumer.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -21,6 +22,7 @@ const DemoPage = () => (
                 <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
             ),
             emptyState: <TableEmptyStateDemo noPadding title="Table with empty states" />,
+            consumer: <TableConsumerDemo noPadding title="Table with a child component using the hook to re-fetch" />,
         }}
     />
 );


### PR DESCRIPTION
### Proposed Changes

Create a new `Table.Consumer` component. This component should be used to wrap "renderless" components that triggers `onChange` on the table in some way. For instance, a component that automatically refresh every X seconds, or a component that listen for changes in the URL, etc

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
