### PR TITLE
feat(mantine): add onCopy callback to CopyToClipboard

### DIFF
--- a/packages/mantine/src/components/copyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/copyToClipboard/CopyToClipboard.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
-
-import {CheckSize24Px, CopySize24Px} from '@coveord/plasma-react-icons';
-import {TextInput, CopyButton, Tooltip, ActionIcon, createStyles} from '@mantine/core';
+import {CheckSize16Px, CopySize16Px} from '@coveord/plasma-react-icons';
+import {ActionIcon, CopyButton, createStyles, TextInput, Tooltip} from '@mantine/core';
 
 export interface CopyToClipboardProps {
     /**
@@ -14,6 +12,10 @@ export interface CopyToClipboardProps {
      * @default false
      */
     withLabel?: boolean;
+    /**
+     * Called each time the value is copied to the clipboard
+     */
+    onCopy?: () => void;
 }
 
 const useStyles = createStyles((theme) => ({
@@ -22,19 +24,25 @@ const useStyles = createStyles((theme) => ({
     },
 }));
 
-const CopyToClipboardButton: React.FunctionComponent<{value: string}> = ({value}) => (
+const CopyToClipboardButton: React.FunctionComponent<Omit<CopyToClipboardProps, 'withLabel'>> = ({value, onCopy}) => (
     <CopyButton value={value} timeout={2000}>
         {({copied, copy}) => (
-            <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="top">
-                <ActionIcon color={copied ? 'teal' : 'gray'} onClick={copy}>
-                    {copied ? <CheckSize24Px /> : <CopySize24Px />}
+            <Tooltip label={copied ? 'Copied' : 'Copy'}>
+                <ActionIcon
+                    color={copied ? 'success' : 'gray'}
+                    onClick={() => {
+                        copy();
+                        onCopy?.();
+                    }}
+                >
+                    {copied ? <CheckSize16Px height={16} /> : <CopySize16Px height={16} />}
                 </ActionIcon>
             </Tooltip>
         )}
     </CopyButton>
 );
 
-export const CopyToClipboard: React.FunctionComponent<CopyToClipboardProps> = ({value, withLabel}) => {
+export const CopyToClipboard: React.FunctionComponent<CopyToClipboardProps> = ({withLabel, ...others}) => {
     const {classes} = useStyles();
 
     return withLabel ? (
@@ -42,11 +50,11 @@ export const CopyToClipboard: React.FunctionComponent<CopyToClipboardProps> = ({
             classNames={{
                 input: classes.input,
             }}
-            value={value}
+            value={others.value}
             readOnly
-            rightSection={<CopyToClipboardButton value={value} />}
+            rightSection={<CopyToClipboardButton {...others} />}
         />
     ) : (
-        <CopyToClipboardButton value={value} />
+        <CopyToClipboardButton {...others} />
     );
 };

--- a/packages/mantine/src/components/copyToClipboard/__tests__/CopyToClipboard.spec.tsx
+++ b/packages/mantine/src/components/copyToClipboard/__tests__/CopyToClipboard.spec.tsx
@@ -1,9 +1,9 @@
-import {render, screen} from '@test-utils';
+import {render, screen, userEvent} from '@test-utils';
 
 import {CopyToClipboard} from '../CopyToClipboard';
 
 describe('CopyToClipboard', () => {
-    it('should display only a button by default', () => {
+    it('displays only a button by default', () => {
         const testValue = 'text value';
         render(<CopyToClipboard value={testValue} />);
 
@@ -21,5 +21,15 @@ describe('CopyToClipboard', () => {
             expect(screen.getByRole('button', {name: /copy/i})).toBeVisible();
             expect(document.querySelector('input')).toBeInTheDocument();
         });
+    });
+
+    it('calls onCopy callback when the users copy the value to the clipboard', async () => {
+        const onCopySpy = vi.fn();
+        const user = userEvent.setup();
+        render(<CopyToClipboard value="whatever" onCopy={onCopySpy} />);
+
+        await user.click(screen.getByRole('button', {name: /copy/i}));
+
+        expect(onCopySpy).toHaveBeenCalled();
     });
 });

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -146,6 +146,7 @@ export const plasmaTheme: MantineThemeOverride = {
                 withArrow: true,
                 withinPortal: true,
                 multiline: true,
+                zIndex: 10000,
             },
         },
         Loader: {


### PR DESCRIPTION
### Proposed Changes

Add an `onCopy` callback prop to the CopyToClipboard component. We need this to facilitate analytics tracking in our project.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
