### PR TITLE
fix(mantine, header): move the DocAnchor in the title to avoid wrapping issues

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -1,5 +1,5 @@
 import {QuestionSize16Px} from '@coveord/plasma-react-icons';
-import {Anchor, Breadcrumbs, DefaultProps, Divider, Flex, Group, Stack, Text, Title, Tooltip} from '@mantine/core';
+import {Anchor, Breadcrumbs, DefaultProps, Divider, Group, Stack, Text, Title, Tooltip} from '@mantine/core';
 import {Children, FunctionComponent, ReactElement, ReactNode} from 'react';
 
 export interface HeaderProps extends DefaultProps {
@@ -48,12 +48,10 @@ export const Header: HeaderType = ({description, borderBottom, children, variant
             >
                 <Stack spacing={0}>
                     {breadcrumbs}
-                    <Flex align="center">
-                        <Title order={variant === 'page' ? 1 : 3} color={variant === 'page' ? 'gray.5' : undefined}>
-                            {otherChildren}
-                        </Title>
+                    <Title order={variant === 'page' ? 1 : 3} color={variant === 'page' ? 'gray.5' : undefined}>
+                        {otherChildren}
                         {docAnchor}
-                    </Flex>
+                    </Title>
                     <Text size={variant === 'page' ? 'md' : 'sm'} color="gray.6">
                         {description}
                     </Text>
@@ -92,7 +90,7 @@ export interface HeaderDocAnchorProps {
 
 const HeaderDocAnchor: FunctionComponent<HeaderDocAnchorProps> = ({href: docLink, label: docLinkTooltipLabel}) => (
     <Tooltip label={docLinkTooltipLabel} disabled={!docLinkTooltipLabel} position="right">
-        <Anchor inline href={docLink} target="_blank" ml="xs">
+        <Anchor inline href={docLink} target="_blank" ml="xs" style={{verticalAlign: 'middle'}}>
             <QuestionSize16Px height={16} />
         </Anchor>
     </Tooltip>

--- a/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -37,15 +37,11 @@ exports[`Header > renders the specified breadcrumbs above the title 1`] = `
           Three
         </a>
       </div>
-      <div
-        class="mantine-xg7kom"
+      <h1
+        class="mantine-Text-root mantine-Title-root mantine-d1yoif"
       >
-        <h1
-          class="mantine-Text-root mantine-Title-root mantine-d1yoif"
-        >
-          Title
-        </h1>
-      </div>
+        Title
+      </h1>
       <div
         class="mantine-Text-root mantine-1w25z6f"
       />


### PR DESCRIPTION
### Proposed Changes

Before:
<img width="621" alt="image" src="https://user-images.githubusercontent.com/260007/232777851-72d84b6f-a3fe-4628-8491-ca952a8cd351.png">

<img width="633" alt="image" src="https://user-images.githubusercontent.com/260007/232778031-d7f7411e-cb3b-4c03-b039-4a6c03232664.png">

After:
<img width="550" alt="image" src="https://user-images.githubusercontent.com/260007/232778299-0d43fbdd-f426-4319-8231-b94eaacf7b0e.png">

<img width="630" alt="image" src="https://user-images.githubusercontent.com/260007/232778139-8d997e4c-7362-4d28-a8f6-da8fc6859e02.png">

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
