### PR TITLE
refactor(website, sandbox): use vite instead of CRA template

### DIFF
--- a/packages/website/build/demo-loader.js
+++ b/packages/website/build/demo-loader.js
@@ -7,15 +7,15 @@ function capitalizeFirstLetter(string) {
 module.exports = function (source) {
     const name = capitalizeFirstLetter(path.basename(this.resourcePath).split('.')[0]);
     const content = `
-import Demo from '@demo';
+import DemoContainer from '@demo';
 
 ${source.replace('export default', `const ${name}Preview =`)}
 
 const snippet = \`${source.replace(/\\|`|\$/g, '\\$&')}\`;
 const ${name}Demo = (props: DemoComponentProps) => (
-    <Demo snippet={snippet} {...props}>
+    <DemoContainer snippet={snippet} {...props}>
         <${name}Preview />
-    </Demo>
+    </DemoContainer>
 );
 export default ${name}Demo;
 `;

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -66,7 +66,7 @@ const Demo = ({children, snippet, center = false, grow = false, title, layout, n
         try {
             const res = await fetch(getCodeSandboxLink(snippet));
             const {sandbox_id} = await res.json();
-            window.open(`https://codesandbox.io/p/sandbox/${sandbox_id}?file=module=%2Fsrc%2FDemo.tsx`, '_blank');
+            window.open(`https://codesandbox.io/p/sandbox/${sandbox_id}?file=%2Fsrc%2FDemo.tsx`, '_blank');
         } catch (e) {
             console.error(e);
         }

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -62,7 +62,16 @@ const useStyles = createStyles((theme, {grow, noPadding}: DemoComponentProps) =>
 const Demo = ({children, snippet, center = false, grow = false, title, layout, noPadding}: DemoProps) => {
     const {classes} = useStyles({center, grow, noPadding});
     const clipboard = useClipboard();
-    const sandboxLink = getCodeSandboxLink(snippet);
+    const createSandbox = async () => {
+        try {
+            const res = await fetch(getCodeSandboxLink(snippet));
+            const {sandbox_id} = await res.json();
+            window.open(`https://codesandbox.io/p/sandbox/${sandbox_id}?file=module=%2Fsrc%2FDemo.tsx`, '_blank');
+        } catch (e) {
+            console.error(e);
+        }
+    };
+
     return (
         <div className={classes.root}>
             {title ? (
@@ -97,7 +106,7 @@ const Demo = ({children, snippet, center = false, grow = false, title, layout, n
                         </Tooltip>
 
                         <Tooltip label="Open in CodeSanbox" position="left">
-                            <ActionIcon<'a'> radius="sm" href={sandboxLink} target="_blank" component="a">
+                            <ActionIcon radius="sm" onClick={createSandbox}>
                                 <PlaySize16Px height={16} />
                             </ActionIcon>
                         </Tooltip>

--- a/packages/website/src/building-blocs/getCodeSandboxLink.tsx
+++ b/packages/website/src/building-blocs/getCodeSandboxLink.tsx
@@ -120,22 +120,41 @@ const indexHtml = `
 <!DOCTYPE html>
 <html>
 <body class="coveo-styleguide">
+    <div id="root" />
     <div id="Modals" />
     <div id="plasma-dropdowns" />
     <div id="App" />
+    <script type="module" src="./src/index.tsx"></script>
 </body>
 </html>
+`;
+
+const viteConfig = `
+import { defineConfig } from 'vite'
+import reactRefresh from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [reactRefresh()]
+})
 `;
 
 const getSandboxLink = (snippet: string): string => {
     const dependencies = getRawDependenciesFromSnippet(snippet);
     const parameters = getParameters({
-        template: 'create-react-app',
+        template: 'node',
         files: {
             'package.json': {
                 content: {
+                    scripts: {
+                        dev: 'vite',
+                        build: 'tsc && vite build',
+                        serve: 'vite preview',
+                    },
                     dependencies: addAndFineTuneDependencies(snippet, dependencies),
                     devDependencies: {
+                        vite: '^4.2.1',
+                        '@vitejs/plugin-react': '^3.1.0',
                         tslib: packageConfig.devDependencies.tslib,
                         typescript: packageConfig.devDependencies.typescript,
                         '@types/react': packageConfig.devDependencies['@types/react'],
@@ -156,12 +175,16 @@ const getSandboxLink = (snippet: string): string => {
                 content: '@import url("https://use.typekit.net/wqe4zqp.css");',
                 isBinary: false,
             },
+            'vite.config.ts': {
+                content: viteConfig,
+                isBinary: false,
+            },
+            'index.html': {
+                content: indexHtml,
+                isBinary: false,
+            },
             ...(snippetUsesPackage(snippet, '@coveord/plasma-react')
                 ? {
-                      'public/index.html': {
-                          content: indexHtml,
-                          isBinary: false,
-                      },
                       'src/Store.ts': {
                           content: storeTs,
                           isBinary: false,

--- a/packages/website/src/building-blocs/getCodeSandboxLink.tsx
+++ b/packages/website/src/building-blocs/getCodeSandboxLink.tsx
@@ -193,7 +193,7 @@ const getSandboxLink = (snippet: string): string => {
                 : {}),
         },
     });
-    return `https://codesandbox.io/api/v1/sandboxes/define?parameters=${parameters}&query=module=/src/Demo.tsx`;
+    return `https://codesandbox.io/api/v1/sandboxes/define?parameters=${parameters}&json=1`;
 };
 
 export default getSandboxLink;

--- a/packages/website/src/examples/form/button/Button.demo.tsx
+++ b/packages/website/src/examples/form/button/Button.demo.tsx
@@ -1,3 +1,4 @@
 import {Button, showNotification} from '@coveord/plasma-mantine';
 
-export default () => <Button onClick={() => showNotification({message: 'Button clicked'})}>Default button</Button>;
+const Demo = () => <Button onClick={() => showNotification({message: 'Button clicked'})}>Default button</Button>;
+export default Demo;

--- a/packages/website/src/examples/form/button/ButtonDisabled.demo.tsx
+++ b/packages/website/src/examples/form/button/ButtonDisabled.demo.tsx
@@ -1,7 +1,8 @@
 import {Button} from '@coveord/plasma-mantine';
 
-export default () => (
+const Demo = () => (
     <Button disabled disabledTooltip="This button is disabled" onClick={() => alert('button clicked')}>
         Disabled button
     </Button>
 );
+export default Demo;

--- a/packages/website/src/examples/form/button/ButtonSecondary.demo.tsx
+++ b/packages/website/src/examples/form/button/ButtonSecondary.demo.tsx
@@ -1,7 +1,8 @@
 import {Button, showNotification} from '@coveord/plasma-mantine';
 
-export default () => (
+const Demo = () => (
     <Button variant="outline" onClick={() => showNotification({message: 'Button clicked'})}>
         Secondary button
     </Button>
 );
+export default Demo;

--- a/packages/website/src/examples/form/button/ButtonWithAsyncLoader.demo.tsx
+++ b/packages/website/src/examples/form/button/ButtonWithAsyncLoader.demo.tsx
@@ -14,4 +14,5 @@ const promise = async () => {
     });
 };
 
-export default () => <Button onClick={promise}>Save</Button>;
+const Demo = () => <Button onClick={promise}>Save</Button>;
+export default Demo;

--- a/packages/website/src/examples/form/code-editor/CodeEditor.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditor.demo.tsx
@@ -1,6 +1,6 @@
 import {CodeEditor, useForm} from '@coveord/plasma-mantine';
 
-export default () => {
+const Demo = () => {
     const form = useForm({
         initialValues: {
             config: '{"key":"value"}',
@@ -31,3 +31,4 @@ export default () => {
         />
     );
 };
+export default Demo;

--- a/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
@@ -1,6 +1,6 @@
 import {CodeEditor, useForm} from '@coveord/plasma-mantine';
 
-export default () => {
+const Demo = () => {
     const form = useForm({
         initialValues: {
             code: 'def my_extension():\n\tprint("Not implemented yet.")\n\nmy_extension()',
@@ -17,3 +17,4 @@ export default () => {
         />
     );
 };
+export default Demo;

--- a/packages/website/src/examples/form/code-editor/CodeEditorXML.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorXML.demo.tsx
@@ -1,6 +1,6 @@
 import {CodeEditor, useForm} from '@coveord/plasma-mantine';
 
-export default () => {
+const Demo = () => {
     const form = useForm({
         initialValues: {
             markup: '<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em"><circle cx="8" cy="8" r="6.5" stroke="currentColor"/><path d="M5 8H11M8 5L8 11" stroke="currentColor" stroke-linecap="round"/></svg>',
@@ -17,3 +17,4 @@ export default () => {
         />
     );
 };
+export default Demo;

--- a/packages/website/src/examples/form/collection/Collection.demo.tsx
+++ b/packages/website/src/examples/form/collection/Collection.demo.tsx
@@ -1,6 +1,6 @@
 import {Checkbox, Collection, TextInput, useForm} from '@coveord/plasma-mantine';
 
-export default () => {
+const Demo = () => {
     const form = useForm({
         validateInputOnChange: true,
         initialValues: {
@@ -38,3 +38,4 @@ export default () => {
         </Collection>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/form/collection/CollectionWithReactHookForm.demo.tsx
+++ b/packages/website/src/examples/form/collection/CollectionWithReactHookForm.demo.tsx
@@ -1,7 +1,7 @@
 import {Checkbox, Collection, TextInput} from '@coveord/plasma-mantine';
 import {Controller, useForm, useFieldArray} from 'react-hook-form';
 
-export default () => {
+const Demo = () => {
     const {control} = useForm({
         defaultValues: {
             todoList: [
@@ -65,3 +65,4 @@ export default () => {
         />
     );
 };
+export default Demo;

--- a/packages/website/src/examples/form/copyToClipboard/CopyToClipboard.demo.tsx
+++ b/packages/website/src/examples/form/copyToClipboard/CopyToClipboard.demo.tsx
@@ -1,3 +1,4 @@
 import {CopyToClipboard} from '@coveord/plasma-mantine';
 
-export default () => <CopyToClipboard value="Copy me!" />;
+const Demo = () => <CopyToClipboard value="Copy me!" />;
+export default Demo;

--- a/packages/website/src/examples/form/copyToClipboard/CopyToClipboardWithLabel.demo.tsx
+++ b/packages/website/src/examples/form/copyToClipboard/CopyToClipboardWithLabel.demo.tsx
@@ -1,3 +1,4 @@
 import {CopyToClipboard} from '@coveord/plasma-mantine';
 
-export default () => <CopyToClipboard value="Copy me!" withLabel />;
+const Demo = () => <CopyToClipboard value="Copy me!" withLabel />;
+export default Demo;

--- a/packages/website/src/examples/foundations/Iconography/Iconography.demo.tsx
+++ b/packages/website/src/examples/foundations/Iconography/Iconography.demo.tsx
@@ -4,10 +4,11 @@ import {Tooltip} from '@mantine/core';
 // Control the size using "height" or "width" attributes (defaults to 1em)
 // The icon takes the same color as the text around it
 
-export default () => (
+const Demo = () => (
     <div style={{color: 'green'}}>
         <Tooltip label="Dollar" position="left">
             <DollarsSize64Px height={64} />
         </Tooltip>
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/foundations/TypeKit/H1.demo.tsx
+++ b/packages/website/src/examples/foundations/TypeKit/H1.demo.tsx
@@ -1,3 +1,4 @@
 import {Title} from '@coveord/plasma-mantine';
 
-export default () => <Title order={1}>The Relevance Company</Title>;
+const Demo = () => <Title order={1}>The Relevance Company</Title>;
+export default Demo;

--- a/packages/website/src/examples/foundations/TypeKit/H2.demo.tsx
+++ b/packages/website/src/examples/foundations/TypeKit/H2.demo.tsx
@@ -1,3 +1,4 @@
 import {Title} from '@coveord/plasma-mantine';
 
-export default () => <Title order={2}>The Relevance Company</Title>;
+const Demo = () => <Title order={2}>The Relevance Company</Title>;
+export default Demo;

--- a/packages/website/src/examples/foundations/TypeKit/H3.demo.tsx
+++ b/packages/website/src/examples/foundations/TypeKit/H3.demo.tsx
@@ -1,3 +1,4 @@
 import {Title} from '@coveord/plasma-mantine';
 
-export default () => <Title order={3}>The Relevance Company</Title>;
+const Demo = () => <Title order={3}>The Relevance Company</Title>;
+export default Demo;

--- a/packages/website/src/examples/foundations/TypeKit/H4.demo.tsx
+++ b/packages/website/src/examples/foundations/TypeKit/H4.demo.tsx
@@ -1,3 +1,4 @@
 import {Title} from '@coveord/plasma-mantine';
 
-export default () => <Title order={4}>The Relevance Company</Title>;
+const Demo = () => <Title order={4}>The Relevance Company</Title>;
+export default Demo;

--- a/packages/website/src/examples/foundations/TypeKit/H5.demo.tsx
+++ b/packages/website/src/examples/foundations/TypeKit/H5.demo.tsx
@@ -1,3 +1,4 @@
 import {Title} from '@coveord/plasma-mantine';
 
-export default () => <Title order={5}>The Relevance Company</Title>;
+const Demo = () => <Title order={5}>The Relevance Company</Title>;
+export default Demo;

--- a/packages/website/src/examples/foundations/TypeKit/H6.demo.tsx
+++ b/packages/website/src/examples/foundations/TypeKit/H6.demo.tsx
@@ -1,3 +1,4 @@
 import {Title} from '@coveord/plasma-mantine';
 
-export default () => <Title order={6}>The Relevance Company</Title>;
+const Demo = () => <Title order={6}>The Relevance Company</Title>;
+export default Demo;

--- a/packages/website/src/examples/layout/Header/Header.demo.tsx
+++ b/packages/website/src/examples/layout/Header/Header.demo.tsx
@@ -1,6 +1,6 @@
 import {Anchor, Button, Header} from '@coveord/plasma-mantine';
 
-export default () => (
+const Demo = () => (
     <Header description="The header description" borderBottom>
         <Header.Breadcrumbs>
             <Anchor>One</Anchor>
@@ -15,3 +15,4 @@ export default () => (
         </Header.Actions>
     </Header>
 );
+export default Demo;

--- a/packages/website/src/examples/layout/Modal/Modal.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/Modal.demo.tsx
@@ -1,7 +1,7 @@
 import {Button, Header, Modal, StickyFooter} from '@coveord/plasma-mantine';
 import {useState} from 'react';
 
-export default () => {
+const Demo = () => {
     const [opened, setOpened] = useState(false);
 
     return (
@@ -31,3 +31,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
@@ -1,7 +1,7 @@
 import {Button, CloseButton, Header, Modal, StickyFooter, Tabs} from '@coveord/plasma-mantine';
 import {useState} from 'react';
 
-export default () => {
+const Demo = () => {
     const [opened, setOpened] = useState(false);
 
     return (
@@ -41,3 +41,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/layout/ModalWizard/ModalWizard.demo.tsx
+++ b/packages/website/src/examples/layout/ModalWizard/ModalWizard.demo.tsx
@@ -1,7 +1,7 @@
 import {Box, Button, ModalWizard} from '@coveord/plasma-mantine';
 import {useState} from 'react';
 
-export default () => {
+const Demo = () => {
     const [opened, setOpened] = useState(false);
 
     return (
@@ -41,3 +41,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/layout/StickyFooter/StickyFooter.demo.tsx
+++ b/packages/website/src/examples/layout/StickyFooter/StickyFooter.demo.tsx
@@ -1,8 +1,9 @@
 import {Button, StickyFooter} from '@coveord/plasma-mantine';
 
-export default () => (
+const Demo = () => (
     <StickyFooter borderTop>
         <Button variant="outline">Cancel</Button>
         <Button variant="filled">Save</Button>
     </StickyFooter>
 );
+export default Demo;

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -45,7 +45,7 @@ const columns: Array<ColumnDef<IExampleRowData>> = [
     // Table.AccordionColumn as ColumnDef<IExampleRowData>,
 ];
 
-export default () => {
+const Demo = () => {
     const [data, setData] = useState(null);
     const [loading, setLoading] = useState(true);
     const [pages, setPages] = useState(1);
@@ -107,6 +107,7 @@ export default () => {
         </Table>
     );
 };
+export default Demo;
 
 const NoData: FunctionComponent = () => {
     const {clearFilters, isFiltered} = useTable();

--- a/packages/website/src/examples/layout/Table/TableClientSide.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableClientSide.demo.tsx
@@ -55,7 +55,7 @@ const options: TableProps<Person>['options'] = {
     getSortedRowModel: getSortedRowModel(),
 };
 
-export default () => {
+const Demo = () => {
     const data = useMemo(() => makeData(45), []);
     return (
         <Table
@@ -75,3 +75,4 @@ export default () => {
         </Table>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/layout/Table/TableConsumer.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableConsumer.demo.tsx
@@ -18,7 +18,7 @@ const columns: Array<ColumnDef<PostData>> = [
     }),
 ];
 
-export default () => {
+const Demo = () => {
     const [data, setData] = useState(null);
     const [loading, setLoading] = useState(true);
 
@@ -55,6 +55,7 @@ export default () => {
         </Table>
     );
 };
+export default Demo;
 
 const IntervalRefresh: FunctionComponent<{every: number}> = ({every}) => {
     const {onChange} = useTable();

--- a/packages/website/src/examples/layout/Table/TableEmptyState.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableEmptyState.demo.tsx
@@ -23,7 +23,7 @@ const NoData = () => {
     );
 };
 
-export default () => (
+const Demo = () => (
     <Table
         data={[]}
         columns={columns}
@@ -39,6 +39,7 @@ export default () => (
         </Table.Footer>
     </Table>
 );
+export default Demo;
 
 const columnHelper = createColumnHelper<Person>();
 

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -32,7 +32,7 @@ const columns: Array<ColumnDef<IExampleRowData>> = [
     }),
 ];
 
-export default () => {
+const Demo = () => {
     const [data, setData] = useState(null);
     const [loading, setLoading] = useState(true);
     const [pages, setPages] = useState(1);
@@ -102,6 +102,7 @@ export default () => {
         </Table>
     );
 };
+export default Demo;
 
 const NoData: FunctionComponent = () => {
     const {isFiltered, clearFilters} = useTable();

--- a/packages/website/src/examples/legacy/advanced/ActionBar/ActionBar.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/ActionBar/ActionBar.demo.tsx
@@ -13,7 +13,7 @@ import {useDispatch, useSelector} from 'react-redux';
 
 const MY_ID = 'action-bar-id';
 
-export default () => {
+const Demo = () => {
     const dispatch: IDispatch = useDispatch();
 
     const actions = useSelector(
@@ -37,6 +37,7 @@ export default () => {
         </>
     );
 };
+export default Demo;
 
 const BIG_LIST_OF_ACTIONS: IActionOptions[] = [
     ACTION_SEPARATOR,

--- a/packages/website/src/examples/legacy/advanced/InfoToken/critical.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/InfoToken/critical.demo.tsx
@@ -1,6 +1,6 @@
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <InfoToken type={InfoTokenType.Critical} size={InfoTokenSize.Small} mode={InfoTokenMode.Filled} />
         <InfoToken type={InfoTokenType.Critical} size={InfoTokenSize.Medium} mode={InfoTokenMode.Filled} />
@@ -10,3 +10,4 @@ export default () => (
         <InfoToken type={InfoTokenType.Critical} size={InfoTokenSize.Large} mode={InfoTokenMode.Stroked} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/InfoToken/info.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/InfoToken/info.demo.tsx
@@ -1,6 +1,6 @@
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <InfoToken type={InfoTokenType.Information} size={InfoTokenSize.Small} mode={InfoTokenMode.Filled} />
         <InfoToken type={InfoTokenType.Information} size={InfoTokenSize.Medium} mode={InfoTokenMode.Filled} />
@@ -10,3 +10,4 @@ export default () => (
         <InfoToken type={InfoTokenType.Information} size={InfoTokenSize.Large} mode={InfoTokenMode.Stroked} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/InfoToken/main.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/InfoToken/main.demo.tsx
@@ -1,5 +1,6 @@
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <InfoToken type={InfoTokenType.Information} size={InfoTokenSize.Large} mode={InfoTokenMode.Stroked} />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/InfoToken/question.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/InfoToken/question.demo.tsx
@@ -1,6 +1,6 @@
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <InfoToken type={InfoTokenType.Question} size={InfoTokenSize.Small} mode={InfoTokenMode.Filled} />
         <InfoToken type={InfoTokenType.Question} size={InfoTokenSize.Medium} mode={InfoTokenMode.Filled} />
@@ -10,3 +10,4 @@ export default () => (
         <InfoToken type={InfoTokenType.Question} size={InfoTokenSize.Large} mode={InfoTokenMode.Stroked} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/InfoToken/success.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/InfoToken/success.demo.tsx
@@ -1,6 +1,6 @@
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <InfoToken type={InfoTokenType.Success} size={InfoTokenSize.Small} mode={InfoTokenMode.Filled} />
         <InfoToken type={InfoTokenType.Success} size={InfoTokenSize.Medium} mode={InfoTokenMode.Filled} />
@@ -10,3 +10,4 @@ export default () => (
         <InfoToken type={InfoTokenType.Success} size={InfoTokenSize.Large} mode={InfoTokenMode.Stroked} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/InfoToken/tip.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/InfoToken/tip.demo.tsx
@@ -1,6 +1,6 @@
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <InfoToken type={InfoTokenType.Tip} size={InfoTokenSize.Small} mode={InfoTokenMode.Filled} />
         <InfoToken type={InfoTokenType.Tip} size={InfoTokenSize.Medium} mode={InfoTokenMode.Filled} />
@@ -10,3 +10,4 @@ export default () => (
         <InfoToken type={InfoTokenType.Tip} size={InfoTokenSize.Large} mode={InfoTokenMode.Stroked} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/InfoToken/warning.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/InfoToken/warning.demo.tsx
@@ -1,6 +1,6 @@
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <InfoToken type={InfoTokenType.Warning} size={InfoTokenSize.Small} mode={InfoTokenMode.Filled} />
         <InfoToken type={InfoTokenType.Warning} size={InfoTokenSize.Medium} mode={InfoTokenMode.Filled} />
@@ -10,3 +10,4 @@ export default () => (
         <InfoToken type={InfoTokenType.Warning} size={InfoTokenSize.Large} mode={InfoTokenMode.Stroked} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/LinkSvg/LinkSvg.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/LinkSvg/LinkSvg.demo.tsx
@@ -1,8 +1,9 @@
 import {LinkSvg} from '@coveord/plasma-react';
 import {ExternalSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <LinkSvg url="https://www.coveo.com/" icon={ExternalSize16Px}>
         Learn more about Coveo
     </LinkSvg>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/ListBox/empty.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/ListBox/empty.demo.tsx
@@ -1,7 +1,8 @@
 import {ListBox} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div style={{width: 300}}>
         <ListBox />
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/ListBox/loading.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/ListBox/loading.demo.tsx
@@ -1,7 +1,8 @@
 import {ListBox} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div style={{width: 300}}>
         <ListBox isLoading />
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/ListBox/main.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/ListBox/main.demo.tsx
@@ -1,6 +1,6 @@
 import {Badge, BadgeType, ListBox} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div style={{width: 300}}>
         <ListBox
             items={[
@@ -32,3 +32,4 @@ export default () => (
         />
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/ListBox/withFooter.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/ListBox/withFooter.demo.tsx
@@ -1,7 +1,7 @@
 import {ListBox} from '@coveord/plasma-react';
 import {ClockSize24Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <div style={{width: 300}}>
         <ListBox
             items={[
@@ -27,3 +27,4 @@ export default () => (
         />
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/OptionsCycle/OptionsCycle.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/OptionsCycle/OptionsCycle.demo.tsx
@@ -1,3 +1,4 @@
 import {OptionsCycleConnected} from '@coveord/plasma-react';
 
-export default () => <OptionsCycleConnected id="Cycle-1" options={['Option 1', 'Option 2', 'Option 3', 'Option 4']} />;
+const Demo = () => <OptionsCycleConnected id="Cycle-1" options={['Option 1', 'Option 2', 'Option 3', 'Option 4']} />;
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/OptionsCycle/OptionsCycleButton.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/OptionsCycle/OptionsCycleButton.demo.tsx
@@ -1,6 +1,6 @@
 import {OptionsCycleConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <OptionsCycleConnected
         id="Cycle-1"
         options={['Option 1', 'Option 2', 'Option 3', 'Option 4']}
@@ -9,3 +9,4 @@ export default () => (
         nextClassName="btn mod-border ml1 w4 center"
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/PartialStringMatch/PartialStringMatch.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/PartialStringMatch/PartialStringMatch.demo.tsx
@@ -1,6 +1,6 @@
 import {PartialStringMatch} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <PartialStringMatch partialMatch="pirate">
         <div className="p1">
             I’d love to drop anchor in your lagoon. And that was done without a single drop of rum… A pirate is a man
@@ -15,3 +15,4 @@ export default () => (
         </div>
     </PartialStringMatch>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/advanced/SlideY/main.demo.tsx
+++ b/packages/website/src/examples/legacy/advanced/SlideY/main.demo.tsx
@@ -4,7 +4,7 @@ import {useState} from 'react';
 
 const content = loremIpsum({count: 20});
 
-export default () => {
+const Demo = () => {
     const [opened, setOpened] = useState(false);
     return (
         <>
@@ -15,3 +15,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Badge/Badge.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Badge/Badge.demo.tsx
@@ -1,6 +1,6 @@
 import {Badge, BadgeType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <Badge label="Default" type={BadgeType.Default} />
         <Badge label="Beta" type={BadgeType.Beta} extraClasses={['ml1']} />
@@ -11,3 +11,4 @@ export default () => (
         <Badge label="Information" type={BadgeType.Information} extraClasses={['ml1']} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Badge/BadgeSmall.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Badge/BadgeSmall.demo.tsx
@@ -1,6 +1,6 @@
 import {Badge, BadgeType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <Badge isSmall label="Default" type={BadgeType.Default} />
         <Badge isSmall label="Beta" type={BadgeType.Beta} extraClasses={['ml1']} />
@@ -11,3 +11,4 @@ export default () => (
         <Badge isSmall label="Information" type={BadgeType.Information} extraClasses={['ml1']} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Badge/BadgeWithIcons.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Badge/BadgeWithIcons.demo.tsx
@@ -1,7 +1,7 @@
 import {Badge, BadgeIconPlacement} from '@coveord/plasma-react';
 import {LockSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <div className="flex">
         <Badge
             icon={LockSize16Px}
@@ -32,3 +32,4 @@ export default () => (
         <Badge isSmall icon={LockSize16Px} iconPlacement={BadgeIconPlacement.Right} extraClasses={['ml1']} />
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/ColorBar/ColorBar.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/ColorBar/ColorBar.demo.tsx
@@ -1,6 +1,6 @@
 import {ColorBar} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <ColorBar
         widthPerColor={{'#1372ec': 30, '#ffe300': 15, '#f05245': 10, '#1cebcf': 25, '#7d458f': 20}}
         tooltipPerColor={{
@@ -9,3 +9,4 @@ export default () => (
         }}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/ColorBar/ColorBarOverflow.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/ColorBar/ColorBarOverflow.demo.tsx
@@ -1,5 +1,6 @@
 import {ColorBar} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <ColorBar widthPerColor={{'#1372ec': 200, '#ffe300': 50, '#f05245': 300, '#1cebcf': 25, '#7d458f': 1000}} />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/ColorBar/ColorBarPartial.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/ColorBar/ColorBarPartial.demo.tsx
@@ -1,5 +1,6 @@
 import {ColorBar} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <ColorBar widthPerColor={{'#1372ec': 20, '#ffe300': 5, '#f05245': 10, '#1cebcf': 5, '#7d458f': 20}} />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/ColorDot/ColorDot.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/ColorDot/ColorDot.demo.tsx
@@ -1,4 +1,4 @@
-export default () => (
+const Demo = () => (
     <>
         <span className="inline-flex label">
             <i className="color-dot mr1" />
@@ -6,3 +6,4 @@ export default () => (
         </span>
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/ColorDot/ColorDotExecuting.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/ColorDot/ColorDotExecuting.demo.tsx
@@ -1,4 +1,4 @@
-export default () => (
+const Demo = () => (
     <>
         <i className="color-dot state-executing mr1" />
         <i className="color-dot state-executing state-critical mr1" />
@@ -12,3 +12,4 @@ export default () => (
         <i className="color-dot state-executing state-maintenance" />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/ColorDot/ColorDotSize.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/ColorDot/ColorDotSize.demo.tsx
@@ -1,4 +1,4 @@
-export default () => (
+const Demo = () => (
     <>
         <i className="color-dot mr1" />
         <i className="color-dot state-critical mr1" />
@@ -24,3 +24,4 @@ export default () => (
         <i className="color-dot mod-small state-maintenance" />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/IconBadge/IconBadge.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/IconBadge/IconBadge.demo.tsx
@@ -1,7 +1,7 @@
 import {IconBadge, IconBadgeType} from '@coveord/plasma-react';
 import {BellSize24Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <>
         <IconBadge icon={BellSize24Px} type={IconBadgeType.New} className="mr1" />
         <IconBadge icon={BellSize24Px} type={IconBadgeType.Information} className="mr1" />
@@ -9,3 +9,4 @@ export default () => (
         <IconBadge icon={BellSize24Px} type={IconBadgeType.Major} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/LastUpdated/LastUpdated.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/LastUpdated/LastUpdated.demo.tsx
@@ -1,3 +1,4 @@
 import {LastUpdated} from '@coveord/plasma-react';
 
-export default () => <LastUpdated />;
+const Demo = () => <LastUpdated />;
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/LastUpdated/LastUpdatedSpecifiedTime.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/LastUpdated/LastUpdatedSpecifiedTime.demo.tsx
@@ -2,7 +2,8 @@ import {LastUpdated} from '@coveord/plasma-react';
 
 const ONE_HOUR = 60 * 60 * 1000;
 
-export default () => {
+const Demo = () => {
     const OneHourAgo = new Date(new Date().getTime() - ONE_HOUR);
     return <LastUpdated time={OneHourAgo} label="Dernière modification à" />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Loading/Loading.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Loading/Loading.demo.tsx
@@ -1,3 +1,4 @@
 import {Loading} from '@coveord/plasma-react';
 
-export default () => <Loading />;
+const Demo = () => <Loading />;
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Loading/LoadingFullcontent.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Loading/LoadingFullcontent.demo.tsx
@@ -1,3 +1,4 @@
 import {Loading} from '@coveord/plasma-react';
 
-export default () => <Loading fullContent />;
+const Demo = () => <Loading fullContent />;
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Loading/LoadingSpinner.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Loading/LoadingSpinner.demo.tsx
@@ -1,9 +1,10 @@
 import {LoadingSpinner} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <LoadingSpinner size={16} />
         <LoadingSpinner />
         <LoadingSpinner size={32} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/StepProgressBar/StepProgressBar.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/StepProgressBar/StepProgressBar.demo.tsx
@@ -1,3 +1,4 @@
 import {StepProgressBar} from '@coveord/plasma-react';
 
-export default () => <StepProgressBar numberOfSteps={5} currentStep={2} />;
+const Demo = () => <StepProgressBar numberOfSteps={5} currentStep={2} />;
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/SyncFeedback/SyncFeedback.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/SyncFeedback/SyncFeedback.demo.tsx
@@ -1,6 +1,6 @@
 import {SyncFeedback, SyncFeedbackState} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <table className="table">
         <tr>
             <td>NONE</td>
@@ -30,3 +30,4 @@ export default () => (
         </tr>
     </table>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/SyncFeedback/SyncFeedbackLabel.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/SyncFeedback/SyncFeedbackLabel.demo.tsx
@@ -1,9 +1,10 @@
 import {SyncFeedback, SyncFeedbackState} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <SyncFeedback state={SyncFeedbackState.SYNCING} feedback="There is something happening" />
         <SyncFeedback state={SyncFeedbackState.SUCCESS} feedback="There was a success" />
         <SyncFeedback state={SyncFeedbackState.ERROR} feedback="There was an error" />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Toast/DownloadToast.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Toast/DownloadToast.demo.tsx
@@ -1,7 +1,8 @@
 import {Toast} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Toast title="Preparing file for download..." type="download">
         <div>some_file.csv</div>
     </Toast>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Toast/Toast.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Toast/Toast.demo.tsx
@@ -1,3 +1,4 @@
 import {Toast} from '@coveord/plasma-react';
 
-export default () => <Toast title="Hello World!" type="success" />;
+const Demo = () => <Toast title="Hello World!" type="success" />;
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Toast/ToastNotifier.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Toast/ToastNotifier.demo.tsx
@@ -19,9 +19,10 @@ const ShowToastButton: React.FunctionComponent = () => {
     );
 };
 
-export default () => (
+const Demo = () => (
     <>
         <ToastContainerConnected id="toast-container-id" />
         <ShowToastButton />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/feedback/Tooltip/Tooltip.demo.tsx
+++ b/packages/website/src/examples/legacy/feedback/Tooltip/Tooltip.demo.tsx
@@ -1,9 +1,10 @@
 import {Tooltip} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Tooltip title="I am a tooltip!" placement="right" noSpanWrapper>
         <button type="button" className="btn">
             Hover me!
         </button>
     </Tooltip>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/ActionableItem/ActionableItem.demo.tsx
+++ b/packages/website/src/examples/legacy/form/ActionableItem/ActionableItem.demo.tsx
@@ -1,6 +1,6 @@
 import {ActionableItem} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <ActionableItem
         id="🆔"
         onItemClick={() => alert('you triggered the main button')}
@@ -12,3 +12,4 @@ export default () => (
         click on the dots
     </ActionableItem>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Checkbox/Checkbox.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Checkbox/Checkbox.demo.tsx
@@ -1,7 +1,7 @@
 import {Checkbox, Label} from '@coveord/plasma-react';
 import {useState} from 'react';
 
-export default () => {
+const Demo = () => {
     const [checked, setChecked] = useState(false);
     return (
         <Checkbox checked={checked} onClick={() => setChecked(!checked)}>
@@ -9,3 +9,4 @@ export default () => {
         </Checkbox>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Checkbox/CheckboxConnected.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Checkbox/CheckboxConnected.demo.tsx
@@ -1,7 +1,8 @@
 import {CheckboxConnected, Label} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <CheckboxConnected>
         <Label>Label</Label>
     </CheckboxConnected>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Checkbox/CheckboxDisabled.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Checkbox/CheckboxDisabled.demo.tsx
@@ -1,7 +1,8 @@
 import {Checkbox, Label} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Checkbox disabled>
         <Label>Label</Label>
     </Checkbox>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Checkbox/GroupableCheckbox.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Checkbox/GroupableCheckbox.demo.tsx
@@ -1,6 +1,6 @@
 import {GroupableCheckboxConnected, Label} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <GroupableCheckboxConnected id="parent-id" isParent clearSides classes="mb1">
             <Label>Parent</Label>
@@ -16,3 +16,4 @@ export default () => (
         </GroupableCheckboxConnected>
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/CodeEditor/CodeEditor.demo.tsx
+++ b/packages/website/src/examples/legacy/form/CodeEditor/CodeEditor.demo.tsx
@@ -4,4 +4,5 @@ const defaultValue = `from math import pi as PI
 print(PI) // 3.141592653589793
 `;
 
-export default () => <CodeEditor value={defaultValue} mode={CodeMirrorModes.Python} options={{lineWrapping: true}} />;
+const Demo = () => <CodeEditor value={defaultValue} mode={CodeMirrorModes.Python} options={{lineWrapping: true}} />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/CodeEditor/CodeEditorReadonly.demo.tsx
+++ b/packages/website/src/examples/legacy/form/CodeEditor/CodeEditorReadonly.demo.tsx
@@ -4,4 +4,5 @@ const defaultValue = `from math import pi as PI
 print(PI) // 3.141592653589793
 `;
 
-export default () => <CodeEditor value={defaultValue} mode={CodeMirrorModes.Python} readOnly />;
+const Demo = () => <CodeEditor value={defaultValue} mode={CodeMirrorModes.Python} readOnly />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/ColorPicker/ColorPicker.demo.tsx
+++ b/packages/website/src/examples/legacy/form/ColorPicker/ColorPicker.demo.tsx
@@ -1,7 +1,8 @@
 import {ColorPicker} from '@coveord/plasma-react';
 import {ColorResult} from 'react-color';
 
-export default () => {
+const Demo = () => {
     const logColor = (color: ColorResult) => console.log(color);
     return <ColorPicker id="color-picker-id" defaultColor="#F37231" onChangeComplete={logColor} />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/ColorPicker/ColorPickerHiddenControls.demo.tsx
+++ b/packages/website/src/examples/legacy/form/ColorPicker/ColorPickerHiddenControls.demo.tsx
@@ -1,3 +1,4 @@
 import {ColorPicker} from '@coveord/plasma-react';
 
-export default () => <ColorPicker id="color-picker-id-2" styles={{default: {controls: {display: 'none'}}}} />;
+const Demo = () => <ColorPicker id="color-picker-id-2" styles={{default: {controls: {display: 'none'}}}} />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/ColorPicker/ColorPickerSelector.demo.tsx
+++ b/packages/website/src/examples/legacy/form/ColorPicker/ColorPickerSelector.demo.tsx
@@ -1,7 +1,7 @@
 import {useSelector} from 'react-redux';
 import {ColorPicker, PlasmaState, InputSelectors} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const selected = useSelector((state: PlasmaState) =>
         InputSelectors.getValue(state, {
             id: 'color-picker-id-3',
@@ -14,3 +14,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Countdown/Countdown.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Countdown/Countdown.demo.tsx
@@ -1,3 +1,4 @@
 import {Countdown} from '@coveord/plasma-react';
 
-export default () => <Countdown />;
+const Demo = () => <Countdown />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/DatePicker/DatePicker.demo.tsx
+++ b/packages/website/src/examples/legacy/form/DatePicker/DatePicker.demo.tsx
@@ -7,7 +7,7 @@ import {
 } from '@coveord/plasma-react';
 import moment from 'moment';
 
-export default () => (
+const Demo = () => (
     <DatePickerDropdownConnected
         id="range-date-picker"
         datesSelectionBoxes={selectionOptions}
@@ -17,6 +17,7 @@ export default () => (
         label="Select a date range"
     />
 );
+export default Demo;
 
 const selectionOptions: IDatesSelectionBox[] = [
     {

--- a/packages/website/src/examples/legacy/form/DatePicker/DatePickerReadonly.demo.tsx
+++ b/packages/website/src/examples/legacy/form/DatePicker/DatePickerReadonly.demo.tsx
@@ -1,6 +1,6 @@
 import {DatePickerDropdownConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <DatePickerDropdownConnected
         id="readonly-date-picker"
         datesSelectionBoxes={[
@@ -13,3 +13,4 @@ export default () => (
         readonly
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/DatePicker/SingleDatePicker.demo.tsx
+++ b/packages/website/src/examples/legacy/form/DatePicker/SingleDatePicker.demo.tsx
@@ -6,7 +6,7 @@ import {
 } from '@coveord/plasma-react';
 import moment from 'moment';
 
-export default () => (
+const Demo = () => (
     <DatePickerDropdownConnected
         id="single-date-picker"
         datesSelectionBoxes={selectionOptions}
@@ -17,6 +17,7 @@ export default () => (
         isLinkedToDateRange={false}
     />
 );
+export default Demo;
 
 const selectionOptions: IDatesSelectionBox[] = [
     {

--- a/packages/website/src/examples/legacy/form/Facet/Facet.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Facet/Facet.demo.tsx
@@ -1,6 +1,6 @@
 import {FacetConnected, IFacet} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const facet: IFacet = {name: 'facet-1', formattedName: 'Simple Facet'};
 
     const facetRows: IFacet[] = [
@@ -20,3 +20,4 @@ export default () => {
     ];
     return <FacetConnected facet={facet} facetRows={facetRows} />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Facet/FacetWithExclude.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Facet/FacetWithExclude.demo.tsx
@@ -1,6 +1,6 @@
 import {FacetConnected, IFacet} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const facet: IFacet = {name: 'facet-2', formattedName: 'Facet with exclude'};
 
     const facetRows: IFacet[] = [
@@ -15,3 +15,4 @@ export default () => {
     ];
     return <FacetConnected facet={facet} facetRows={facetRows} enableExclusions />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Facet/FacetWithMore.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Facet/FacetWithMore.demo.tsx
@@ -1,6 +1,6 @@
 import {FacetConnected, IFacet} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const facet: IFacet = {name: 'facet-3', formattedName: 'Facet with more'};
 
     const facetRows: IFacet[] = [
@@ -23,3 +23,4 @@ export default () => {
     ];
     return <FacetConnected facet={facet} facetRows={facetRows} maxRowsToShow={2} />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Filepicker/Filepicker.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Filepicker/Filepicker.demo.tsx
@@ -1,3 +1,4 @@
 import {Filepicker} from '@coveord/plasma-react';
 
-export default () => <Filepicker id="input-id" accept=".jpg,.png,.csv,.txt" placeholder="Choose a file..." />;
+const Demo = () => <Filepicker id="input-id" accept=".jpg,.png,.csv,.txt" placeholder="Choose a file..." />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FilterBox/FilterBox.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FilterBox/FilterBox.demo.tsx
@@ -1,3 +1,4 @@
 import {FilterBoxConnected} from '@coveord/plasma-react';
 
-export default () => <FilterBoxConnected id="filter-box-id-1" filterPlaceholder="Custom Placeholder" />;
+const Demo = () => <FilterBoxConnected id="filter-box-id-1" filterPlaceholder="Custom Placeholder" />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FilterBox/FilterBoxDisabled.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FilterBox/FilterBoxDisabled.demo.tsx
@@ -1,3 +1,4 @@
 import {FilterBoxConnected} from '@coveord/plasma-react';
 
-export default () => <FilterBoxConnected id="filter-box-id-3" disabled />;
+const Demo = () => <FilterBoxConnected id="filter-box-id-3" disabled />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FilterBox/FilterBoxMaxWidth.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FilterBox/FilterBoxMaxWidth.demo.tsx
@@ -1,3 +1,4 @@
 import {FilterBoxConnected} from '@coveord/plasma-react';
 
-export default () => <FilterBoxConnected id="filter-box-id-2" maxWidth={160} />;
+const Demo = () => <FilterBoxConnected id="filter-box-id-2" maxWidth={160} />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FlatSelect/FlatSelect.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FlatSelect/FlatSelect.demo.tsx
@@ -1,6 +1,6 @@
 import {FlatSelectConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <FlatSelectConnected
         id="flat-select-id"
         options={[
@@ -29,3 +29,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectAppendPrepend.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectAppendPrepend.demo.tsx
@@ -1,7 +1,7 @@
 import {FlatSelectConnected} from '@coveord/plasma-react';
 import {ZombieSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <FlatSelectConnected
         id="flat-select-append-prepend-id"
         options={[
@@ -24,3 +24,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectDisabled.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectDisabled.demo.tsx
@@ -1,6 +1,6 @@
 import {FlatSelectConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <FlatSelectConnected
         id="flat-select-disabled"
         options={[
@@ -20,3 +20,4 @@ export default () => (
         disabled
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectGroup.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectGroup.demo.tsx
@@ -1,6 +1,6 @@
 import {FlatSelectConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <FlatSelectConnected
         id="flat-select-group"
         options={[
@@ -20,3 +20,4 @@ export default () => (
         group
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectIconsOnly.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectIconsOnly.demo.tsx
@@ -1,7 +1,7 @@
 import {FlatSelectConnected} from '@coveord/plasma-react';
 import {Donut64Size24Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <FlatSelectConnected
         id="flat-select-id"
         options={[
@@ -21,3 +21,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectOptionPicker.demo.tsx
+++ b/packages/website/src/examples/legacy/form/FlatSelect/FlatSelectOptionPicker.demo.tsx
@@ -1,6 +1,6 @@
 import {FlatSelectConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <FlatSelectConnected
         id="flat-select-option-picker"
         options={[
@@ -20,3 +20,4 @@ export default () => (
         optionPicker
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/JSONEditor/InError.demo.tsx
+++ b/packages/website/src/examples/legacy/form/JSONEditor/InError.demo.tsx
@@ -2,10 +2,11 @@ import {JSONEditorConnected} from '@coveord/plasma-react';
 
 const invalidJSON = '{hello: world}';
 
-export default () => (
+const Demo = () => (
     <JSONEditorConnected
         id="example-3"
         defaultValue={invalidJSON}
         errorMessage="Custom error message when JSON is invalid"
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/JSONEditor/JSONEditor.demo.tsx
+++ b/packages/website/src/examples/legacy/form/JSONEditor/JSONEditor.demo.tsx
@@ -2,7 +2,8 @@ import {JSONEditorConnected, JSONToString} from '@coveord/plasma-react';
 
 const defaultValue = JSONToString({hello: 'world', thisIsANumber: 42, andThisAMap: {a: 'a', b: 'b'}});
 
-export default () => {
+const Demo = () => {
     const logValue = (value: string) => console.log(value);
     return <JSONEditorConnected id="example-1" defaultValue={defaultValue} onChange={logValue} />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/JSONEditor/ReadOnly.demo.tsx
+++ b/packages/website/src/examples/legacy/form/JSONEditor/ReadOnly.demo.tsx
@@ -2,4 +2,5 @@ import {JSONEditorConnected, JSONToString} from '@coveord/plasma-react';
 
 const defaultValue = JSONToString({hello: 'world', thisIsANumber: 42, andThisAMap: {a: 'a', b: 'b'}});
 
-export default () => <JSONEditorConnected id="example-2" defaultValue={defaultValue} readOnly />;
+const Demo = () => <JSONEditorConnected id="example-2" defaultValue={defaultValue} readOnly />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/JSONEditor/ValueState.demo.tsx
+++ b/packages/website/src/examples/legacy/form/JSONEditor/ValueState.demo.tsx
@@ -3,7 +3,7 @@ import {JSONEditorConnected, JSONToString, JSONEditorSelectors, PlasmaState} fro
 
 const defaultValue = JSONToString({hello: 'world', thisIsANumber: 42, andThisAMap: {a: 'a', b: 'b'}});
 
-export default () => {
+const Demo = () => {
     const content = useSelector((state: PlasmaState) => JSONEditorSelectors.getValue(state, 'example-4'));
     return (
         <>
@@ -12,3 +12,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/MultiSelect/main.demo.tsx
+++ b/packages/website/src/examples/legacy/form/MultiSelect/main.demo.tsx
@@ -1,6 +1,6 @@
 import {MultiSelectConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <MultiSelectConnected
         id="mutli-select-1"
         items={[
@@ -10,3 +10,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/MultiSelect/withFilter.demo.tsx
+++ b/packages/website/src/examples/legacy/form/MultiSelect/withFilter.demo.tsx
@@ -1,6 +1,6 @@
 import {MultiSelectWithFilter} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <MultiSelectWithFilter
         id="mutli-select-2"
         customValues
@@ -11,3 +11,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/MultiSelect/withPredicates.demo.tsx
+++ b/packages/website/src/examples/legacy/form/MultiSelect/withPredicates.demo.tsx
@@ -1,6 +1,6 @@
 import {IItemBoxProps, MultiSelectWithPredicate} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <MultiSelectWithPredicate
         id="multi-select-3"
         items={[
@@ -28,3 +28,4 @@ export default () => (
         }}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/NumericInput/NumericInput.demo.tsx
+++ b/packages/website/src/examples/legacy/form/NumericInput/NumericInput.demo.tsx
@@ -1,6 +1,6 @@
 import {NumericInputConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <NumericInputConnected
         id="numeric-1"
         initialValue={500}
@@ -11,3 +11,4 @@ export default () => (
         invalidMessage="The value must be between 25 and 950."
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/NumericInput/NumericInputDisabled.demo.tsx
+++ b/packages/website/src/examples/legacy/form/NumericInput/NumericInputDisabled.demo.tsx
@@ -1,3 +1,4 @@
 import {NumericInputConnected} from '@coveord/plasma-react';
 
-export default () => <NumericInputConnected id="numeric-2" initialValue={100} disabled />;
+const Demo = () => <NumericInputConnected id="numeric-2" initialValue={100} disabled />;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/RadioButton/main.demo.tsx
+++ b/packages/website/src/examples/legacy/form/RadioButton/main.demo.tsx
@@ -1,6 +1,6 @@
 import {RadioSelectConnected, Radio, Label} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <RadioSelectConnected
         id="radio-select-id"
         valueOnMount="1"
@@ -19,3 +19,4 @@ export default () => (
         </Radio>
     </RadioSelectConnected>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/RadioButton/radioCard.demo.tsx
+++ b/packages/website/src/examples/legacy/form/RadioButton/radioCard.demo.tsx
@@ -1,6 +1,6 @@
 import {RadioSelectConnected, RadioCard, Label} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <RadioSelectConnected
         id="radio-card-select-example"
         valueOnMount="1"
@@ -25,3 +25,4 @@ export default () => (
         </RadioCard>
     </RadioSelectConnected>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/SearchBar/main.demo.tsx
+++ b/packages/website/src/examples/legacy/form/SearchBar/main.demo.tsx
@@ -1,7 +1,7 @@
 import {SearchBar} from '@coveord/plasma-react';
 import {useState} from 'react';
 
-export default () => {
+const Demo = () => {
     const [isSearching, setSearching] = useState(false);
     const [value, setValue] = useState('');
 
@@ -22,3 +22,4 @@ export default () => {
         />
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/SingleSelect/main.demo.tsx
+++ b/packages/website/src/examples/legacy/form/SingleSelect/main.demo.tsx
@@ -1,6 +1,6 @@
 import {SingleSelectConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <SingleSelectConnected
         id="single-select-1"
         items={[
@@ -10,3 +10,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/SingleSelect/withFilter.demo.tsx
+++ b/packages/website/src/examples/legacy/form/SingleSelect/withFilter.demo.tsx
@@ -1,6 +1,6 @@
 import {SingleSelectWithFilter} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <SingleSelectWithFilter
         id="single-select-2"
         items={[
@@ -12,3 +12,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/SingleSelect/withInfiniteScroll.demo.tsx
+++ b/packages/website/src/examples/legacy/form/SingleSelect/withInfiniteScroll.demo.tsx
@@ -16,7 +16,7 @@ const ServerSideSingleSelect: ComponentType<
     React.PropsWithChildren<ISingleSelectOwnProps & SelectWithInfiniteScrollProps>
 > = compose<any>(withServerSideProcessing, selectWithFilter, selectWithInfiniteScroll)(SingleSelectConnected);
 
-export default () => {
+const Demo = () => {
     const filterValue = useSelector((state) => FilterBoxSelectors.getFilterText(state, {id: 'single-select-4'}));
     const [photos, totalEntries, fetchPhotos] = usePhotosAPIMock();
     const [pageNbr, setPage] = useState(1);
@@ -52,6 +52,7 @@ export default () => {
         />
     );
 };
+export default Demo;
 
 export interface PhotoProps {
     albumId: string;

--- a/packages/website/src/examples/legacy/form/SingleSelect/withPredicates.demo.tsx
+++ b/packages/website/src/examples/legacy/form/SingleSelect/withPredicates.demo.tsx
@@ -1,6 +1,6 @@
 import {IItemBoxProps, SingleSelectWithPredicate} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <SingleSelectWithPredicate
         id="single-select-3"
         items={[
@@ -28,3 +28,4 @@ export default () => (
         }}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Slider/Slider.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Slider/Slider.demo.tsx
@@ -1,6 +1,6 @@
 import {Slider} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Slider
         id="🍄"
         hasTooltip
@@ -14,3 +14,4 @@ export default () => (
         appendValueFormatter={(value: number) => `${value}$`}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Slider/SliderAppend.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Slider/SliderAppend.demo.tsx
@@ -8,7 +8,7 @@ const AppendLabel: FunctionComponent<{value: string; label: string}> = ({value, 
     </div>
 );
 
-export default () => {
+const Demo = () => {
     const appendValueFormatter = (value: number, side: string) => {
         let formattedValue = `${value + 50}%`;
         let valueLabel = 'Right Label';
@@ -31,3 +31,4 @@ export default () => {
         />
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Slider/SliderAsymetric.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Slider/SliderAsymetric.demo.tsx
@@ -1,6 +1,6 @@
 import {Slider} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Slider
         id="asymetric-slider"
         min={-2000}
@@ -11,3 +11,4 @@ export default () => (
         appendValue
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/Slider/SliderOnChange.demo.tsx
+++ b/packages/website/src/examples/legacy/form/Slider/SliderOnChange.demo.tsx
@@ -1,7 +1,7 @@
 import {Slider} from '@coveord/plasma-react';
 import {useState} from 'react';
 
-export default () => {
+const Demo = () => {
     const initialValue = 0;
     const [value, setValue] = useState(initialValue);
     return (
@@ -29,3 +29,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/TextArea/main.demo.tsx
+++ b/packages/website/src/examples/legacy/form/TextArea/main.demo.tsx
@@ -1,7 +1,7 @@
 import {Label, TextArea} from '@coveord/plasma-react';
 import {useState} from 'react';
 
-export default () => {
+const Demo = () => {
     const [value, setValue] = useState('');
 
     return (
@@ -20,3 +20,4 @@ export default () => {
         </div>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/TextInput/TextInput.demo.tsx
+++ b/packages/website/src/examples/legacy/form/TextInput/TextInput.demo.tsx
@@ -15,7 +15,7 @@ const nonEmptyValidation: InputValidator = (value: string) => {
     return {status: 'valid'};
 };
 
-export default () => (
+const Demo = () => (
     <FormProvider>
         <TextInput
             required
@@ -30,3 +30,4 @@ export default () => (
         />
     </FormProvider>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/TextInput/useTextInput.demo.tsx
+++ b/packages/website/src/examples/legacy/form/TextInput/useTextInput.demo.tsx
@@ -25,7 +25,7 @@ const InteractiveButtons: FunctionComponent = () => {
     );
 };
 
-export default () => (
+const Demo = () => (
     <FormProvider>
         <TextInput
             id="favorite-dish"
@@ -43,3 +43,4 @@ export default () => (
         <InteractiveButtons />
     </FormProvider>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/button/Button.demo.tsx
+++ b/packages/website/src/examples/legacy/form/button/Button.demo.tsx
@@ -1,3 +1,4 @@
 import {Button} from '@coveord/plasma-react';
 
-export default () => <Button>Hello World!</Button>;
+const Demo = () => <Button>Hello World!</Button>;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/button/Disabled.demo.tsx
+++ b/packages/website/src/examples/legacy/form/button/Disabled.demo.tsx
@@ -1,7 +1,8 @@
 import {Button} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Button primary enabled={false}>
         Hello World!
     </Button>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/button/IconAndLink.demo.tsx
+++ b/packages/website/src/examples/legacy/form/button/IconAndLink.demo.tsx
@@ -1,8 +1,9 @@
 import {Button} from '@coveord/plasma-react';
 import {ZombieSize24Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <Button link="https://www.coveo.com">
         <ZombieSize24Px height={24} aria-label="zombie" />
     </Button>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/button/Loading.demo.tsx
+++ b/packages/website/src/examples/legacy/form/button/Loading.demo.tsx
@@ -1,6 +1,6 @@
 import {Button} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <Button isLoading enabled={false}>
             Disabled
@@ -10,3 +10,4 @@ export default () => (
         </Button>
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/button/Prepend.demo.tsx
+++ b/packages/website/src/examples/legacy/form/button/Prepend.demo.tsx
@@ -1,8 +1,9 @@
 import {Button} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Button classes={['mod-prepend']}>
         <span className="btn-prepend">P</span>
         Hello World!
     </Button>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/button/Primary.demo.tsx
+++ b/packages/website/src/examples/legacy/form/button/Primary.demo.tsx
@@ -1,3 +1,4 @@
 import {Button} from '@coveord/plasma-react';
 
-export default () => <Button primary>Hello World!</Button>;
+const Demo = () => <Button primary>Hello World!</Button>;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/button/Small.demo.tsx
+++ b/packages/website/src/examples/legacy/form/button/Small.demo.tsx
@@ -1,3 +1,4 @@
 import {Button} from '@coveord/plasma-react';
 
-export default () => <Button small>Hello World!</Button>;
+const Demo = () => <Button small>Hello World!</Button>;
+export default Demo;

--- a/packages/website/src/examples/legacy/form/button/WithTooltip.demo.tsx
+++ b/packages/website/src/examples/legacy/form/button/WithTooltip.demo.tsx
@@ -1,7 +1,8 @@
 import {Button, TooltipPlacement} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Button primary tooltip="Hello there!" tooltipPlacement={TooltipPlacement.Top}>
         Hover me!
     </Button>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/diff-viewer/DiffViewer.demo.tsx
+++ b/packages/website/src/examples/legacy/form/diff-viewer/DiffViewer.demo.tsx
@@ -1,6 +1,6 @@
 import {DiffViewer} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const diffText = `
 --- PRIMARY
 +++ CURRENT_STATE
@@ -17,3 +17,4 @@ export default () => {
 
     return <DiffViewer difference={diffText} />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/diff-viewer/ManyChanges.demo.tsx
+++ b/packages/website/src/examples/legacy/form/diff-viewer/ManyChanges.demo.tsx
@@ -1,6 +1,6 @@
 import {DiffViewer} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const diffText = `
 --- PRIMARY
 +++ CURRENT_STATE
@@ -26,3 +26,4 @@ export default () => {
 
     return <DiffViewer difference={diffText} />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/diff-viewer/NoChanges.demo.tsx
+++ b/packages/website/src/examples/legacy/form/diff-viewer/NoChanges.demo.tsx
@@ -1,6 +1,6 @@
 import {DiffViewer} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const diffText = ``;
 
     return (
@@ -11,3 +11,4 @@ export default () => {
         />
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/diff-viewer/SplitView.demo.tsx
+++ b/packages/website/src/examples/legacy/form/diff-viewer/SplitView.demo.tsx
@@ -1,6 +1,6 @@
 import {DiffViewer} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const diffText = `
 --- PRIMARY
 +++ CURRENT_STATE
@@ -17,3 +17,4 @@ export default () => {
 
     return <DiffViewer difference={diffText} splitView />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/form/multiline-box/MultilineBox.demo.tsx
+++ b/packages/website/src/examples/legacy/form/multiline-box/MultilineBox.demo.tsx
@@ -11,7 +11,7 @@ interface MyData {
     name: string;
 }
 
-export default () => (
+const Demo = () => (
     <FormProvider>
         <MultilineBox<MyData>
             id="multiline-box-id"
@@ -38,3 +38,4 @@ export default () => (
         />
     </FormProvider>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/multiline-box/MultilineBoxComplex.demo.tsx
+++ b/packages/website/src/examples/legacy/form/multiline-box/MultilineBoxComplex.demo.tsx
@@ -40,7 +40,7 @@ const ComplexMultilineBox = compose(
     })
 )(MultilineBox);
 
-export default () => (
+const Demo = () => (
     <FormProvider>
         <ComplexMultilineBox
             id="multiline-box-complex-id"
@@ -67,3 +67,4 @@ export default () => (
         />
     </FormProvider>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/multiline-box/MultilineBoxWithContainer.demo.tsx
+++ b/packages/website/src/examples/legacy/form/multiline-box/MultilineBoxWithContainer.demo.tsx
@@ -21,7 +21,7 @@ const containerNode = (child: ReactNode, data: Array<IMultilineSingleBoxProps<My
 
 const MultilineBoxWithContainer = compose(multilineBoxContainer({containerNode}))(MultilineBox);
 
-export default () => (
+const Demo = () => (
     <FormProvider>
         <div className="highlight-padding highlight-margin">
             <MultilineBoxWithContainer
@@ -50,3 +50,4 @@ export default () => (
         </div>
     </FormProvider>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/multiline-box/MultilineBoxWithDragAndDrop.demo.tsx
+++ b/packages/website/src/examples/legacy/form/multiline-box/MultilineBoxWithDragAndDrop.demo.tsx
@@ -15,7 +15,7 @@ interface MyData {
 
 const MultilineBoxWithDragAndDrop = compose(multilineBoxWithDnD())(MultilineBox);
 
-export default () => (
+const Demo = () => (
     <FormProvider>
         <MultilineBoxWithDragAndDrop
             id="multiline-box-dnd-id"
@@ -42,3 +42,4 @@ export default () => (
         />
     </FormProvider>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/form/multiline-box/MultilineBoxWithRemove.demo.tsx
+++ b/packages/website/src/examples/legacy/form/multiline-box/MultilineBoxWithRemove.demo.tsx
@@ -28,7 +28,7 @@ const MultilineBoxWithRemove = compose(
     })
 )(MultilineBox);
 
-export default () => (
+const Demo = () => (
     <FormProvider>
         <MultilineBoxWithRemove
             id="multiline-box-remove-id"
@@ -55,3 +55,4 @@ export default () => (
         />
     </FormProvider>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/foundations/Links/ButtonLink.demo.tsx
+++ b/packages/website/src/examples/legacy/foundations/Links/ButtonLink.demo.tsx
@@ -1,7 +1,8 @@
 import {TargetSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <button className="link" onClick={() => alert('The button was clicked')}>
         Link <TargetSize16Px height={16} />
     </button>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/foundations/Links/Link.demo.tsx
+++ b/packages/website/src/examples/legacy/foundations/Links/Link.demo.tsx
@@ -1,7 +1,8 @@
 import {TargetSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <a className="link" href="/foundations/Links">
         Link <TargetSize16Px height={16} />
     </a>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/foundations/Links/LinkDisabled.demo.tsx
+++ b/packages/website/src/examples/legacy/foundations/Links/LinkDisabled.demo.tsx
@@ -1,7 +1,8 @@
 import {TargetSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <a className="link disabled" href="/foundations/Links">
         Link <TargetSize16Px height={16} />
     </a>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/foundations/Spacing/Spacing.demo.tsx
+++ b/packages/website/src/examples/legacy/foundations/Spacing/Spacing.demo.tsx
@@ -2,8 +2,9 @@
 // blue is padding
 // highlight-padding and highlight-margin classes are only available on the Plasma website
 
-export default () => (
+const Demo = () => (
     <div className="highlight-padding highlight-margin">
         <div className="p2 m2">Content</div>
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/foundations/Typekit/Typekit.demo.tsx
+++ b/packages/website/src/examples/legacy/foundations/Typekit/Typekit.demo.tsx
@@ -1,1 +1,2 @@
-export default () => <h1>Hello World!</h1>;
+const Demo = () => <h1>Hello World!</h1>;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Banner/Banner.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Banner/Banner.demo.tsx
@@ -1,3 +1,4 @@
 import {BannerContainer} from '@coveord/plasma-react';
 
-export default () => <BannerContainer />;
+const Demo = () => <BannerContainer />;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Blankslate/Blankslate.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Blankslate/Blankslate.demo.tsx
@@ -1,7 +1,7 @@
 import {BlankSlate} from '@coveord/plasma-react';
 import {IdeaSize32Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <BlankSlate
         icon={IdeaSize32Px}
         title="Title of the blank slate"
@@ -22,3 +22,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Blankslate/BlankslateInError.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Blankslate/BlankslateInError.demo.tsx
@@ -1,8 +1,9 @@
 import {BlankSlateWithError} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <BlankSlateWithError
         title="Unable to retrieve X"
         description="Super clear error message localized to ensure a good comprehension about the current error"
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Blankslate/BlankslateWithTable.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Blankslate/BlankslateWithTable.demo.tsx
@@ -1,7 +1,7 @@
 import {BlankSlateWithTable} from '@coveord/plasma-react';
 import {IdeaSize32Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <table className="table">
         <thead>
             <tr>
@@ -15,3 +15,4 @@ export default () => (
         </tbody>
     </table>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Blankslate/BlankslateWithTableError.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Blankslate/BlankslateWithTableError.demo.tsx
@@ -1,6 +1,6 @@
 import {BlankSlateWithTableInError, ButtonWithRefreshCallback} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <table className="table">
         <thead>
             <tr>
@@ -34,3 +34,4 @@ export default () => (
         </tbody>
     </table>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/BorderedLine/BorderedLine.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/BorderedLine/BorderedLine.demo.tsx
@@ -1,7 +1,8 @@
 import {BorderedLine} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <BorderedLine className="full-content-x">
         I am a bordered row and you can fill me with whatever you want!
     </BorderedLine>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/BrowserPreview/BrowserPreview.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/BrowserPreview/BrowserPreview.demo.tsx
@@ -1,8 +1,9 @@
 import {BrowserPreview} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <BrowserPreview title={'Custom title! Custom title!'}>
         <h4>Hello World</h4>
         <p>Here's the description</p>
     </BrowserPreview>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/BrowserPreview/BrowserPreviewWithEmptyState.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/BrowserPreview/BrowserPreviewWithEmptyState.demo.tsx
@@ -1,6 +1,6 @@
 import {BrowserPreview, BrowserPreviewEmpty} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <BrowserPreview>
         <BrowserPreviewEmpty onClick={() => alert('Clicked!')}>
             <span>
@@ -10,3 +10,4 @@ export default () => (
         </BrowserPreviewEmpty>
     </BrowserPreview>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/BrowserPreview/BrowserPreviewWithError.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/BrowserPreview/BrowserPreviewWithError.demo.tsx
@@ -1,7 +1,8 @@
 import {BrowserPreview, BrowserPreviewError} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <BrowserPreview>
         <BrowserPreviewError errorMessage="The Query expression within the Reference Cases field is not valid." />
     </BrowserPreview>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Chart/BarChartWithDates.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Chart/BarChartWithDates.demo.tsx
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import {BarSeries, ChartTooltip, ChartContainer, XYAxis, XYChart} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div style={{height: 400}}>
         <ChartContainer
             renderChart={(width, height) => (
@@ -20,6 +20,7 @@ export default () => (
         />
     </div>
 );
+export default Demo;
 
 const dateData = [
     {

--- a/packages/website/src/examples/legacy/layout/Chart/ChartWithInfoLines.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Chart/ChartWithInfoLines.demo.tsx
@@ -1,6 +1,6 @@
 import {LineSeries, InfoLine, ChartContainer, XGrid, YGrid, XYAxis, XYChart} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div style={{height: 400}}>
         <ChartContainer
             renderChart={(width, height) => (
@@ -17,6 +17,7 @@ export default () => (
         />
     </div>
 );
+export default Demo;
 
 const data = [
     {

--- a/packages/website/src/examples/legacy/layout/Chart/ComplexChart.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Chart/ComplexChart.demo.tsx
@@ -9,7 +9,7 @@ import {
     XYPoint,
 } from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div style={{height: 400}}>
         <ChartContainer
             renderChart={(width, height) => (
@@ -34,6 +34,7 @@ export default () => (
         />
     </div>
 );
+export default Demo;
 
 const data = [
     {

--- a/packages/website/src/examples/legacy/layout/Chart/ScatterChart.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Chart/ScatterChart.demo.tsx
@@ -1,6 +1,6 @@
 import {ScatterSeries, ChartContainer, XYChart} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div style={{height: 400}}>
         <ChartContainer
             renderChart={(width, height) => (
@@ -11,6 +11,7 @@ export default () => (
         />
     </div>
 );
+export default Demo;
 
 const data = [
     {

--- a/packages/website/src/examples/legacy/layout/ChildForm/ChildForm.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ChildForm/ChildForm.demo.tsx
@@ -1,8 +1,9 @@
 import {ChildForm} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         Parent
         <ChildForm>Child</ChildForm>
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/ChildForm/ChildFormVertical.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ChildForm/ChildFormVertical.demo.tsx
@@ -1,8 +1,9 @@
 import {ChildForm} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div className="inline-flex center-align">
         Parent
         <ChildForm className="vertical">Child</ChildForm>
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Collapsible/Collapsible.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Collapsible/Collapsible.demo.tsx
@@ -1,6 +1,6 @@
 import {CollapsibleConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <CollapsibleConnected
         id="collapsible-example-1"
         headerContent={<h6 className="p2">Q: Why can't you trust an atom?</h6>}
@@ -8,3 +8,4 @@ export default () => (
         <div className="p2">A: Because they make up everything</div>
     </CollapsibleConnected>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Collapsible/CollapsibleDisabled.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Collapsible/CollapsibleDisabled.demo.tsx
@@ -1,6 +1,6 @@
 import {CollapsibleContainerConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <CollapsibleContainerConnected
         id="collapsible-container-example-3"
         title="Collapsible Container disabled"
@@ -13,3 +13,4 @@ export default () => (
         something!
     </CollapsibleContainerConnected>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Collapsible/CollapsibleExpanded.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Collapsible/CollapsibleExpanded.demo.tsx
@@ -1,6 +1,6 @@
 import {CollapsibleContainerConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <CollapsibleContainerConnected
         id="collapsible-container-example-1"
         title="Collapsible Container expanded on mount"
@@ -13,3 +13,4 @@ export default () => (
         I am expanded on mount!
     </CollapsibleContainerConnected>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Collapsible/CollapsibleInfoBox.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Collapsible/CollapsibleInfoBox.demo.tsx
@@ -1,7 +1,8 @@
 import {CollapsibleInfoBox} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <CollapsibleInfoBox id="collapsible-info-box-example-1" title="Lean more about collapsible info boxes.">
         By default, this component will render with an info icon
     </CollapsibleInfoBox>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Header/loading.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Header/loading.demo.tsx
@@ -1,3 +1,4 @@
 import {BasicHeaderLoading} from '@coveord/plasma-react';
 
-export default () => <BasicHeaderLoading />;
+const Demo = () => <BasicHeaderLoading />;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Header/main.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Header/main.demo.tsx
@@ -1,6 +1,6 @@
 import {BasicHeader} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <BasicHeader
         title={{
             text: 'Charmeleon title',
@@ -13,3 +13,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/IconCard/IconCard.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/IconCard/IconCard.demo.tsx
@@ -1,6 +1,6 @@
 import {IconCard} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <IconCard
         title="Card title"
         icon={<img src="https://placeholder.pics/svg/72x72/DEDEDE/FFFFFF-FFFFFF" />}
@@ -8,3 +8,4 @@ export default () => (
         onClick={() => alert('You clicked the card')}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/IconCard/IconCardDisabled.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/IconCard/IconCardDisabled.demo.tsx
@@ -1,7 +1,7 @@
 import {BadgeIconPlacement, IconCard} from '@coveord/plasma-react';
 import {LockSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <IconCard
         small
         title="Web"
@@ -12,3 +12,4 @@ export default () => (
         style={{width: '368px'}}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/IconCard/IconCardSmall.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/IconCard/IconCardSmall.demo.tsx
@@ -1,7 +1,7 @@
 import {IconCard} from '@coveord/plasma-react';
 import {CloudSize24Px, DatabaseSize24Px, CrawlingBotSize24Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <IconCard
         small
         title="Web"
@@ -15,3 +15,4 @@ export default () => (
         style={{width: '368px'}}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/IconCard/IconCardWithBadges.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/IconCard/IconCardWithBadges.demo.tsx
@@ -1,6 +1,6 @@
 import {IconCard, BadgeType} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <IconCard
         title="Simple builder"
         description="For lightweight usage, prototyping, and testing the search experience. Hosted by Coveo."
@@ -17,3 +17,4 @@ export default () => (
         onClick={() => alert('You clicked the card')}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/IconCard/IconCardWithChoices.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/IconCard/IconCardWithChoices.demo.tsx
@@ -1,7 +1,7 @@
 import {IconCard} from '@coveord/plasma-react';
 import {CloudSize24Px, DatabaseSize24Px, CrawlingBotSize24Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <IconCard
         title="Web"
         description="Enter a starting URL and automatically index all the pages of this site."
@@ -14,3 +14,4 @@ export default () => (
         onClick={(choice) => alert(choice)}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/InfoBox/InfoBox.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/InfoBox/InfoBox.demo.tsx
@@ -1,3 +1,4 @@
 import {InfoBox} from '@coveord/plasma-react';
 
-export default () => <InfoBox>Some contextual information.</InfoBox>;
+const Demo = () => <InfoBox>Some contextual information.</InfoBox>;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/InfoBox/InfoBoxCollapsible.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/InfoBox/InfoBoxCollapsible.demo.tsx
@@ -1,6 +1,6 @@
 import {InfoBox, CollapsibleConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <InfoBox className="py0">
         <CollapsibleConnected
             headerClasses="py2"
@@ -15,3 +15,4 @@ export default () => (
         </CollapsibleConnected>
     </InfoBox>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/InfoBox/InfoBoxWarning.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/InfoBox/InfoBoxWarning.demo.tsx
@@ -1,3 +1,4 @@
 import {InfoBox} from '@coveord/plasma-react';
 
-export default () => <InfoBox className="mod-warning">Be aware that this is a warning.</InfoBox>;
+const Demo = () => <InfoBox className="mod-warning">Be aware that this is a warning.</InfoBox>;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/LabelledValue/LabelledValue.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/LabelledValue/LabelledValue.demo.tsx
@@ -1,3 +1,4 @@
 import {LabeledValue} from '@coveord/plasma-react';
 
-export default () => <LabeledValue label="Super cool label" value="Value under the super cool label" />;
+const Demo = () => <LabeledValue label="Super cool label" value="Value under the super cool label" />;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/LabelledValue/LabelledValueFullRow.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/LabelledValue/LabelledValueFullRow.demo.tsx
@@ -1,9 +1,10 @@
 import {LabeledValue} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <div className="flex flex-wrap">
         <LabeledValue label="Super cool label taking the full row" value="Value under the super cool label" fullRow />
         <LabeledValue label="Too much bubbly debat at the office" value="WE ARE TWO" />
         <LabeledValue label="Buddy" value="TO DANCE" />
     </div>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/LabelledValue/LabelledValueWithInformation.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/LabelledValue/LabelledValueWithInformation.demo.tsx
@@ -1,6 +1,6 @@
 import {LabeledValue, TooltipPlacement} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <LabeledValue
         label="Super cool label"
         value="Value under the super cool label"
@@ -8,3 +8,4 @@ export default () => (
         informationPlacement={TooltipPlacement.Bottom}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Limit/Limit.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Limit/Limit.demo.tsx
@@ -1,3 +1,4 @@
 import {Limit} from '@coveord/plasma-react';
 
-export default () => <Limit id="🥔" title="Limit example" usage={42} limit={100} />;
+const Demo = () => <Limit id="🥔" title="Limit example" usage={42} limit={100} />;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Limit/LimitEditable.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Limit/LimitEditable.demo.tsx
@@ -1,3 +1,4 @@
 import {Limit} from '@coveord/plasma-react';
 
-export default () => <Limit id="💵" title="Supreme leader Snoke" usage={57} isLimitEditable limit={100} />;
+const Demo = () => <Limit id="💵" title="Supreme leader Snoke" usage={57} isLimitEditable limit={100} />;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Limit/LimitWithCustomValue.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Limit/LimitWithCustomValue.demo.tsx
@@ -1,3 +1,4 @@
 import {Limit} from '@coveord/plasma-react';
 
-export default () => <Limit id="👑" title="Patate King" usage={42} limit={130} limitLabel="Throttling limit" />;
+const Demo = () => <Limit id="👑" title="Patate King" usage={42} limit={130} limitLabel="Throttling limit" />;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Limit/LimitWithGoal.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Limit/LimitWithGoal.demo.tsx
@@ -1,3 +1,4 @@
 import {Limit} from '@coveord/plasma-react';
 
-export default () => <Limit id="❗" title="Limit example" usage={100} limit={100} isLimitTheGoalToReach />;
+const Demo = () => <Limit id="❗" title="Limit example" usage={100} limit={100} isLimitTheGoalToReach />;
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Limit/LimitWithHistory.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Limit/LimitWithHistory.demo.tsx
@@ -1,5 +1,6 @@
 import {Limit} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Limit id="🐄" title="Hey" usage={82} isHistoryIncluded limit={100} onHistoryIconClick={() => alert('Patate!')} />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/ModalWindow/ModalLoading.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ModalWindow/ModalLoading.demo.tsx
@@ -1,7 +1,7 @@
 import {useDispatch} from 'react-redux';
 import {Button, IDispatch, openModal, closeModal, ModalLoading} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const dispatch: IDispatch = useDispatch();
     const open = () => dispatch(openModal('loading-modal'));
     const close = () => dispatch(closeModal('loading-modal'));
@@ -12,3 +12,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/ModalWindow/ModalPrompt.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ModalWindow/ModalPrompt.demo.tsx
@@ -1,7 +1,7 @@
 import {useDispatch} from 'react-redux';
 import {Button, IDispatch, openModal, closeModal, ModalCompositeConnected} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const dispatch: IDispatch = useDispatch();
     const open = (id: string) => () => dispatch(openModal(id));
     const close = (id: string) => () => dispatch(closeModal(id));
@@ -69,3 +69,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/ModalWindow/ModalWindow.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ModalWindow/ModalWindow.demo.tsx
@@ -1,7 +1,7 @@
 import {useDispatch} from 'react-redux';
 import {Button, IDispatch, openModal, closeModal, ModalCompositeConnected} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const dispatch: IDispatch = useDispatch();
     const open = () => dispatch(openModal('simple-modal'));
     const close = () => dispatch(closeModal('simple-modal'));
@@ -32,3 +32,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/ModalWindow/ModalWithDirty.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ModalWindow/ModalWithDirty.demo.tsx
@@ -12,7 +12,7 @@ import {
     WithDirtyActions,
 } from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const id = 'ModalWithDirty';
     const isDirty = useSelector((state: PlasmaState) => WithDirtySelectors.getIsDirty(state, {id}));
     const dispatch: IDispatch = useDispatch();
@@ -57,3 +57,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/ModalWindow/ModalWithProps.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ModalWindow/ModalWithProps.demo.tsx
@@ -1,7 +1,7 @@
 import {useDispatch} from 'react-redux';
 import {Button, IDispatch, openModal, closeModal, ModalCompositeConnected} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const dispatch: IDispatch = useDispatch();
     const open = () => dispatch(openModal('additional-props'));
     const close = () => dispatch(closeModal('additional-props'));
@@ -24,3 +24,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/ModalWizard/ModalWizard.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ModalWizard/ModalWizard.demo.tsx
@@ -16,7 +16,7 @@ import {
 
 const containsCoveo = (str: string) => str.trim().toLowerCase().includes('coveo');
 
-export default () => {
+const Demo = () => {
     const selectedPath = useSelector((state: PlasmaState) =>
         RadioSelectSelectors.getValue(state, {id: 'radio-step-1'})
     );
@@ -101,3 +101,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/ModalWizard/ModalWizardWithValidationIds.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/ModalWizard/ModalWizardWithValidationIds.demo.tsx
@@ -16,7 +16,7 @@ import {useDispatch} from 'react-redux';
 const NonEmptyInput = withNonEmptyValueInputValidationHOC(withDirtyInputHOC(InputConnected));
 const NonEmptySelect = withDirtySingleSelectHOC(withNonEmptySingleSelectHOC(SingleSelectConnected));
 
-export default () => {
+const Demo = () => {
     const dispatch: IDispatch = useDispatch();
 
     return (
@@ -56,3 +56,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Section/Section.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Section/Section.demo.tsx
@@ -1,9 +1,10 @@
 import {Section} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <Section title="Section title" description="Section description.">
         <Section level={2} mods={'mod-header-padding'} title="Look at my cool mod">
             <div>Children</div>
         </Section>
     </Section>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Section/SectionLevel.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Section/SectionLevel.demo.tsx
@@ -1,9 +1,10 @@
 import {Section} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <Section title="This is a level 1 section" description="Section description." level={1} />
         <Section title="This is a level 2 section" description="Section description." level={2} />
         <Section title="This is a level 3 section" description="Section description." level={3} />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Section/SectionWithMods.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Section/SectionWithMods.demo.tsx
@@ -1,6 +1,6 @@
 import {Section} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <Section mods={'mod-header-padding'} title="This is a level 1 section" description="Section description." />
         <Section
@@ -11,3 +11,4 @@ export default () => (
         <Section mods={'material-card'} title="This is a level 3 section" description="Section description." />
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/SplitLayout/SplitLayout.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/SplitLayout/SplitLayout.demo.tsx
@@ -1,8 +1,9 @@
 import {SplitLayout} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <SplitLayout
         leftChildren={<p className="p1">Hello from the left!</p>}
         rightChildren={<p className="p1">Hello from the right!</p>}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/SplitLayout/SplitLayoutBorderless.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/SplitLayout/SplitLayoutBorderless.demo.tsx
@@ -1,9 +1,10 @@
 import {SplitLayout, SplitLayoutMods} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <SplitLayout
         mods={SplitLayoutMods.noBorder}
         leftChildren={<p className="p1">Hello from the left!</p>}
         rightChildren={<p className="p1">Hello from the right!</p>}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/StickyFooter/StickyFooter.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/StickyFooter/StickyFooter.demo.tsx
@@ -4,7 +4,7 @@ import {useState} from 'react';
 
 const lorem = loremIpsum({count: 100});
 
-export default () => {
+const Demo = () => {
     const [isOpened, setIsOpened] = useState(false);
     return (
         <>
@@ -21,3 +21,4 @@ export default () => {
         </>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/layout/Table/main.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/main.demo.tsx
@@ -4,7 +4,7 @@ import {loremIpsum} from 'lorem-ipsum';
 
 const TABLE_ID: string = 'mainExampleTableId';
 
-export default () => (
+const Demo = () => (
     <TableHOC
         id={TABLE_ID}
         className="table"
@@ -15,6 +15,7 @@ export default () => (
         showBorderBottom
     />
 );
+export default Demo;
 
 const renderHeader = () => (
     <thead>

--- a/packages/website/src/examples/legacy/layout/Table/withAction.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withAction.demo.tsx
@@ -5,7 +5,7 @@ import {EditSize24Px} from '@coveord/plasma-react-icons';
 
 const TABLE_ID: string = 'withActionsTableId';
 
-export default () => (
+const Demo = () => (
     <TableComposed
         id={TABLE_ID}
         className="table"
@@ -16,6 +16,7 @@ export default () => (
         showBorderBottom
     />
 );
+export default Demo;
 
 const TableComposed = compose<any>(tableWithActions())(TableHOC);
 

--- a/packages/website/src/examples/legacy/layout/Table/withBlankslate.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withBlankslate.demo.tsx
@@ -12,7 +12,8 @@ import {compose} from 'redux';
 
 const TABLE_ID: string = 'withBlankslateTableId';
 
-export default () => <WithBlankSlate />;
+const Demo = () => <WithBlankSlate />;
+export default Demo;
 
 const WithBlankSlate: FunctionComponent = () => (
     <>

--- a/packages/website/src/examples/legacy/layout/Table/withDatePicker.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withDatePicker.demo.tsx
@@ -12,7 +12,7 @@ import {loremIpsum} from 'lorem-ipsum';
 
 const TABLE_ID: string = 'withDatePickerTableId';
 
-export default () => (
+const Demo = () => (
     <TableComposed
         id={TABLE_ID}
         className="table"
@@ -23,6 +23,7 @@ export default () => (
         showBorderBottom
     />
 );
+export default Demo;
 
 const selectionOptions: IDatesSelectionBox[] = [
     {

--- a/packages/website/src/examples/legacy/layout/Table/withFilter.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withFilter.demo.tsx
@@ -4,7 +4,7 @@ import {loremIpsum} from 'lorem-ipsum';
 
 const TABLE_ID: string = 'withFilterTableId';
 
-export default () => (
+const Demo = () => (
     <TableComposed
         id={TABLE_ID}
         className="table"
@@ -15,6 +15,7 @@ export default () => (
         showBorderBottom
     />
 );
+export default Demo;
 
 const TableComposed = compose<any>(
     tableWithFilter({filter: {isAutoFocus: false}}), // using the default matchfilter

--- a/packages/website/src/examples/legacy/layout/Table/withLoading.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withLoading.demo.tsx
@@ -3,7 +3,7 @@ import {CloudSize16Px} from '@coveord/plasma-react-icons';
 
 const TABLE_ID: string = 'withLoadingTableId';
 
-export default () => (
+const Demo = () => (
     <TableHOC
         id={TABLE_ID}
         className="table"
@@ -21,6 +21,7 @@ export default () => (
         }}
     />
 );
+export default Demo;
 
 const renderHeader = () => (
     <thead>

--- a/packages/website/src/examples/legacy/layout/Table/withPagination.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withPagination.demo.tsx
@@ -4,7 +4,7 @@ import {loremIpsum} from 'lorem-ipsum';
 
 const TABLE_ID: string = 'withPaginationTableId';
 
-export default () => (
+const Demo = () => (
     <TableComposed
         id={TABLE_ID}
         className="table"
@@ -15,6 +15,7 @@ export default () => (
         showBorderBottom
     />
 );
+export default Demo;
 
 const TableComposed = compose<any>(tableWithNewPagination({perPageNumbers: [3, 5, 10]}))(TableHOC);
 

--- a/packages/website/src/examples/legacy/layout/Table/withPredicate.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withPredicate.demo.tsx
@@ -4,7 +4,7 @@ import {loremIpsum} from 'lorem-ipsum';
 
 const TABLE_ID: string = 'withPredicateTableId';
 
-export default () => (
+const Demo = () => (
     <TableComposed
         id={TABLE_ID}
         className="table"
@@ -15,6 +15,7 @@ export default () => (
         showBorderBottom
     />
 );
+export default Demo;
 
 const renderHeader = () => (
     <thead>

--- a/packages/website/src/examples/legacy/layout/Table/withServer.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withServer.demo.tsx
@@ -12,7 +12,7 @@ import {compose} from 'redux';
 const TABLE_ID: string = 'withServerTableId';
 const ServerTableComposed = compose<any>(withServerSideProcessing, tableWithUrlState)(TableHOC);
 
-export default () => {
+const Demo = () => {
     const [users, totalEntries, fetchUsers] = useAPIMock();
 
     const updateUrl = (query: string) => {
@@ -37,6 +37,7 @@ export default () => {
         />
     );
 };
+export default Demo;
 
 const clean = <T extends Record<string, unknown>>(object: T) => {
     Object.keys(object).forEach((key) => (object[key] === undefined ? delete object[key] : {}));

--- a/packages/website/src/examples/legacy/layout/Table/withSort.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withSort.demo.tsx
@@ -4,7 +4,7 @@ import {loremIpsum} from 'lorem-ipsum';
 
 const TABLE_ID: string = 'withSortTableId';
 
-export default () => (
+const Demo = () => (
     <TableComposed
         id={TABLE_ID}
         className="table"
@@ -15,6 +15,7 @@ export default () => (
         showBorderBottom
     />
 );
+export default Demo;
 
 const renderHeader = (tableId: string) => (
     <thead>

--- a/packages/website/src/examples/legacy/navigation/Breadcrumbs/complex.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/Breadcrumbs/complex.demo.tsx
@@ -22,7 +22,7 @@ const defaultBreadcrumb: IBreadcrumbProps = {
     ],
 };
 
-export default () => (
+const Demo = () => (
     <BreadcrumbHeader
         breadcrumb={defaultBreadcrumb}
         description="Simple description for the title"
@@ -33,3 +33,4 @@ export default () => (
         ]}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/Breadcrumbs/main.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/Breadcrumbs/main.demo.tsx
@@ -1,6 +1,6 @@
 import {BreadcrumbHeader} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <BreadcrumbHeader
         breadcrumb={{
             title: {
@@ -17,3 +17,4 @@ export default () => (
         hasBorderBottom={false}
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/SideNavigation/collapsible.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/SideNavigation/collapsible.demo.tsx
@@ -2,7 +2,7 @@ import {SideNavigation, SideNavigationItem, SideNavigationMenuSection} from '@co
 import {CoveoIconSize16Px} from '@coveord/plasma-react-icons';
 import {useState} from 'react';
 
-export default () => {
+const Demo = () => {
     const [isExpanded, setIsExpanded] = useState(true);
     return (
         <SideNavigation>
@@ -27,3 +27,4 @@ export default () => {
         </SideNavigation>
     );
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/SideNavigation/loading.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/SideNavigation/loading.demo.tsx
@@ -1,7 +1,7 @@
 import {SideNavigation, SideNavigationLoadingItem, SideNavigationMenuSection} from '@coveord/plasma-react';
 import {CoveoIconSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <SideNavigation>
         <SideNavigationMenuSection title="Loading Section" icon={CoveoIconSize16Px}>
             <SideNavigationLoadingItem className="mod-width-30" />
@@ -10,3 +10,4 @@ export default () => (
         </SideNavigationMenuSection>
     </SideNavigation>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/SideNavigation/main.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/SideNavigation/main.demo.tsx
@@ -1,7 +1,7 @@
 import {SideNavigation, SideNavigationItem, SideNavigationMenuSection} from '@coveord/plasma-react';
 import {CoveoIconSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <SideNavigation>
         <SideNavigationMenuSection title="Regular Section" icon={CoveoIconSize16Px}>
             <SideNavigationItem isActive>
@@ -17,3 +17,4 @@ export default () => (
         </SideNavigationMenuSection>
     </SideNavigation>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/SubNavigation/custom.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/SubNavigation/custom.demo.tsx
@@ -1,7 +1,7 @@
 import {SubNavigationConnected} from '@coveord/plasma-react';
 import {ThumbsDownSize16Px, ThumbsUpSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <SubNavigationConnected
         id="third-sub-nav"
         items={[
@@ -55,3 +55,4 @@ export default () => (
         defaultSelected="titanic"
     />
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/SubNavigation/customWithDesc.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/SubNavigation/customWithDesc.demo.tsx
@@ -1,6 +1,6 @@
 import {SubNavigationConnected} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const exampleItems = [
         {label: <h3>H3 React Node</h3>, id: 'react-node'},
         {
@@ -26,3 +26,4 @@ export default () => {
 
     return <SubNavigationConnected id="first-sub-nav" items={exampleItems} />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/SubNavigation/defaultSelected.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/SubNavigation/defaultSelected.demo.tsx
@@ -1,6 +1,6 @@
 import {SubNavigationConnected} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const exampleItems = [
         {label: 'Avatar', id: 'avatar'},
         {label: 'Titanic', id: 'titanic'},
@@ -11,3 +11,4 @@ export default () => {
 
     return <SubNavigationConnected id="second-sub-nav" items={exampleItems} defaultSelected="star-wars" />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/SubNavigation/main.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/SubNavigation/main.demo.tsx
@@ -1,6 +1,6 @@
 import {SubNavigationConnected} from '@coveord/plasma-react';
 
-export default () => {
+const Demo = () => {
     const exampleItems = [
         {label: 'Avatar', id: 'avatar'},
         {label: 'Titanic', id: 'titanic'},
@@ -10,3 +10,4 @@ export default () => {
 
     return <SubNavigationConnected id="first-sub-nav" items={exampleItems} />;
 };
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/Tabs/Tab.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/Tabs/Tab.demo.tsx
@@ -1,6 +1,6 @@
 import {Badge, BadgeType, TabConnected, TabContent, TabNavigation, TabPaneConnected} from '@coveord/plasma-react';
 
-export default () => (
+const Demo = () => (
     <>
         <TabNavigation>
             <TabConnected groupId="patate" id="tab2" title="Gyarados" tooltip="I have a toolip!" />
@@ -23,3 +23,4 @@ export default () => (
         </TabContent>
     </>
 );
+export default Demo;

--- a/packages/website/src/examples/legacy/navigation/Tabs/TabWithIcon.demo.tsx
+++ b/packages/website/src/examples/legacy/navigation/Tabs/TabWithIcon.demo.tsx
@@ -1,7 +1,7 @@
 import {TabConnected, TabContent, TabNavigation, TabPaneConnected} from '@coveord/plasma-react';
 import {HeartSize16Px, LightningSize16Px, RocketSize16Px} from '@coveord/plasma-react-icons';
 
-export default () => (
+const Demo = () => (
     <>
         <TabNavigation>
             <TabConnected groupId="banane" id="tab5" title="Pikachu" icon={LightningSize16Px} />
@@ -21,3 +21,4 @@ export default () => (
         </TabContent>
     </>
 );
+export default Demo;


### PR DESCRIPTION
### Proposed Changes

I've been having a lot of issues with the codesandbox and code not loading properly so I decided to change the template. The initial load is a bit slower but the experience is better overall

- 1st commit is the change from Create React App to Vite in the codesandbox
- 2nd commit is the change to use named const instead of anonymous function in demos, this allows Vite to enable Hot Module Replacement
- 3rd commit is a quick fix for the demo-loader
- 4th is more changes to use named const

### Potential Breaking Changes

None, only website is affected

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
