### PR TITLE
chore(deps): run renovate more often

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
     "extends": ["config:base"],
     "timezone": "America/Montreal",
-    "schedule": ["after 8pm every weekday", "before 6am every weekday", "every weekend"],
-    "updateNotScheduled": false,
+    "schedule": ["at any time"],
     "semanticCommitScope": "deps",
     "commitBody": "UITOOL-284",
     "packageRules": [
@@ -11,7 +10,6 @@
             "updateTypes": ["minor", "patch"],
             "automerge": true,
             "semanticCommitType": "chore",
-            "stabilityDays": 7,
             "internalChecksFilter": "strict"
         },
         {


### PR DESCRIPTION
### Proposed Changes

Currently we merge one or two Renovate PR per day because they have conflicts in the pnpm-lock and it only get resolved at night. To get through the list of dependencies to bump it would be better to let it run at any time

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
