### PR TITLE
fix(mantine, table): style of components shown in Table.Header

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -200,7 +200,11 @@ export const Table: TableType = <T,>({
                             <thead className={classes.header}>
                                 {!!header ? (
                                     <tr>
-                                        <th style={{padding: 0}} colSpan={table.getAllColumns().length}>
+                                        <th
+                                            // need to use inline style because Mantine define style on `.mantine-{id} thead tr th`
+                                            style={{padding: 0, fontWeight: 'unset'}}
+                                            colSpan={table.getAllColumns().length}
+                                        >
                                             {header}
                                         </th>
                                     </tr>

--- a/packages/mantine/src/components/table/TableDateRangePicker.tsx
+++ b/packages/mantine/src/components/table/TableDateRangePicker.tsx
@@ -51,7 +51,7 @@ export const TableDateRangePicker: FunctionComponent<TableDateRangePickerProps> 
         <Grid.Col span="content" order={TableComponentsOrder.DateRangePicker} py="sm">
             <Group spacing="xs">
                 <Text span>{formatedRange}</Text>
-                <Popover opened={opened} onChange={setOpened}>
+                <Popover opened={opened} onChange={setOpened} withinPortal>
                     <Popover.Target>
                         <Button variant="outline" color="gray" onClick={() => setOpened(true)} px="xs">
                             <CalendarSize24Px width={24} height={24} />


### PR DESCRIPTION
### Proposed Changes

Previously the components shown in Table.Header were outside of the table, preventing style clashing. But since we moved the Table.Header inside the table this is not the case anymore.

Before:
<img width="649" alt="image" src="https://user-images.githubusercontent.com/260007/234666838-8d01e0b0-5643-4000-b261-ffaa84e7b9d2.png">
<img width="843" alt="image" src="https://user-images.githubusercontent.com/260007/234666781-62e19a51-bb51-4da2-bcaa-b4d2e0bee594.png">


After:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/260007/234666618-13383592-f60f-478b-869b-f0f0f0b3a1aa.png">
<img width="760" alt="image" src="https://user-images.githubusercontent.com/260007/234666668-0a864df9-fbad-45a3-bcb9-c4dc323a3093.png">


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
