### PR TITLE
fix(react-icons): bring back compiled mock

### DIFF
--- a/packages/react-icons/mock/.swcrc
+++ b/packages/react-icons/mock/.swcrc
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json.schemastore.org/swcrc",
+    "module": {
+        "type": "commonjs"
+    },
+    "jsc": {
+        "target": "es2020",
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true,
+            "decorators": false,
+            "dynamicImport": false
+        },
+        "transform": {
+            "react": {
+                "runtime": "automatic"
+            }
+        }
+    },
+    "sourceMaps": "inline"
+}

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -23,16 +23,19 @@
         ".": {
             "require": "./dist/cjs/index.js",
             "import": "./dist/esm/index.js"
+        },
+        "./mock": {
+            "require": "./dist/cjs/mock/index.js"
         }
     },
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",
     "files": [
-        "dist",
-        "mock"
+        "dist/*"
     ],
     "scripts": {
-        "build": "pnpm generate && node ../../scripts/build",
+        "build": "pnpm generate && node ../../scripts/build && pnpm build:mock",
+        "build:mock": "swc ./mock/index.tsx -o ./dist/cjs/mock/index.js --config-file ./mock/.swcrc",
         "clean": "rimraf dist",
         "generate": "node ./bin/index.js"
     },


### PR DESCRIPTION
### Proposed Changes

`@coveord/plasma-react-icons/mock` used to be compiled to `commonjs`. When the transition to ESM package occured, the compiled version of the mock was thrown away, but it needs to remain compiled as `commonjs` otherwise jest cannot use it.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
