### PR TITLE
fix(react-icons,tokens): add missing swc/helpers dependency

### DIFF
--- a/packages/react-icons/.gitignore
+++ b/packages/react-icons/.gitignore
@@ -1,3 +1,4 @@
 **/generated
 node_modules
 dist
+mock/index.js

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -25,7 +25,7 @@
             "import": "./dist/esm/index.js"
         },
         "./mock": {
-            "require": "./dist/cjs/mock/index.js"
+            "require": "./mock/index.js"
         }
     },
     "main": "./dist/cjs/index.js",
@@ -36,7 +36,7 @@
     ],
     "scripts": {
         "build": "pnpm generate && node ../../scripts/build && pnpm build:mock",
-        "build:mock": "swc ./mock/index.tsx -o ./dist/cjs/mock/index.js --config-file ./mock/.swcrc && cp ./dist/cjs/mock/index.js ./mock/index.js",
+        "build:mock": "swc ./mock/index.tsx -o ./mock/index.js --config-file ./mock/.swcrc",
         "clean": "rimraf dist",
         "generate": "node ./bin/index.js"
     },

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -31,11 +31,12 @@
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",
     "files": [
-        "dist/*"
+        "dist/*",
+        "mock/index.js"
     ],
     "scripts": {
         "build": "pnpm generate && node ../../scripts/build && pnpm build:mock",
-        "build:mock": "swc ./mock/index.tsx -o ./dist/cjs/mock/index.js --config-file ./mock/.swcrc",
+        "build:mock": "swc ./mock/index.tsx -o ./dist/cjs/mock/index.js --config-file ./mock/.swcrc && cp ./dist/cjs/mock/index.js ./mock/index.js",
         "clean": "rimraf dist",
         "generate": "node ./bin/index.js"
     },

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -29,6 +29,9 @@
         "tokens:fetch": "ts-node -r dotenv-safe/config --project ./bin/tsconfig.json ./bin/fetch.ts",
         "tokens:lint": "prettier --write \"{src,scss,data}/*.{css,scss,ts,tsx,json}\""
     },
+    "dependencies": {
+        "@swc/helpers": "0.5.1"
+    },
     "devDependencies": {
         "@swc/cli": "0.1.62",
         "@swc/core": "1.3.53",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,13 +760,17 @@ importers:
         version: 4.3.3(@types/node@16.18.25)(sass@1.62.1)
 
   packages/tokens:
+    dependencies:
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@swc/cli':
         specifier: 0.1.62
         version: 0.1.62(@swc/core@1.3.53)
       '@swc/core':
         specifier: 1.3.53
-        version: 1.3.53
+        version: 1.3.53(@swc/helpers@0.5.1)
       '@types/chroma-js':
         specifier: 2.4.0
         version: 2.4.0
@@ -3174,7 +3178,7 @@ packages:
         optional: true
     dependencies:
       '@mole-inc/bin-wrapper': 8.0.1
-      '@swc/core': 1.3.53
+      '@swc/core': 1.3.53(@swc/helpers@0.5.1)
       commander: 7.2.0
       fast-glob: 3.2.12
       semver: 7.3.8
@@ -3382,7 +3386,7 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core@1.3.53:
+  /@swc/core@1.3.53(@swc/helpers@0.5.1):
     resolution: {integrity: sha512-OM5nCfKDZXr1HjxD072Jlx5463tPX7xeY7NDSRE3X4KFlkRDFdyMWAyV3pet1oouOfUNrzzoVTAR4XSU8ytO6Q==}
     engines: {node: '>=10'}
     requiresBuild: true
@@ -3391,6 +3395,8 @@ packages:
     peerDependenciesMeta:
       '@swc/helpers':
         optional: true
+    dependencies:
+      '@swc/helpers': 0.5.1
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.3.53
       '@swc/core-darwin-x64': 1.3.53
@@ -16420,7 +16426,7 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.3.53
+      '@swc/core': 1.3.53(@swc/helpers@0.5.1)
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3


### PR DESCRIPTION
### Proposed Changes

Forgot two things:
- `@coveord/plasma-tokens` package needs `@swc/helpers` in its depencencies
- `@coveord/plasma-react-icons/mock` was not properly understood by jest just by using package.json exports field.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
