### PR TITLE
fix(tokens): add missing exports specifiers for scss, css and icons

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -13,7 +13,11 @@
         ".": {
             "require": "./dist/cjs/index.js",
             "import": "./dist/esm/index.js"
-        }
+        },
+        "./scss": "./scss/index.scss",
+        "./scss/*": "./scss/*",
+        "./css/*": "./css/*",
+        "./icons/*": "./icons/*"
     },
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",


### PR DESCRIPTION
### Proposed Changes

`@covoerd/plasma-tokens` package is missing some exports specifiers for scss, css, and icons entrypoints. I thought it was only necessary to specify javascript entries, but it turns out all entrypoints must be specified, even non .js stuff.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
