### PR TITLE
UI tool 8702 modal header separator line

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -318,6 +318,10 @@ const components: Component[] = [
         packageName: '@coveord/plasma-mantine',
         propsType: 'CopyToClipboardProps',
     },
+    {
+        name: 'Prompt',
+        packageName: '@coveord/plasma-mantine',
+    },
 ];
 
 export default components;

--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -58,7 +58,7 @@ export const Prompt: PromptType = ({children, variant, size, ...otherProps}) => 
     };
 
     return (
-        <Modal padding={0} classNames={classNames} size={defaultVariant ? size : 'sm'} {...otherProps}>
+        <Modal variant="prompt" padding={0} classNames={classNames} size={defaultVariant ? size : 'sm'} {...otherProps}>
             <div className={classes.innerBody}>{otherChildren}</div>
             {footer}
         </Modal>

--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -18,7 +18,6 @@ const useStyles = createStyles((theme) => ({
         fontSize: theme.headings.sizes.h3.fontSize,
         lineHeight: theme.headings.sizes.h3.lineHeight,
     },
-    default: {},
     success: {backgroundColor: theme.colors.lime[6], color: color.primary.pureWhite},
     warning: {backgroundColor: theme.colors.yellow[5], color: color.primary.pureWhite},
     critical: {
@@ -33,7 +32,12 @@ const useStyles = createStyles((theme) => ({
 }));
 
 export interface PromptProps extends ModalProps {
-    variant: 'default' | 'success' | 'warning' | 'critical' | 'info';
+    /**
+     * Controls prompt appearance
+     *
+     * @default "info"
+     */
+    variant?: 'success' | 'warning' | 'critical' | 'info';
     children: ReactNode;
 }
 interface PromptType {
@@ -41,9 +45,8 @@ interface PromptType {
     Footer: typeof PromptFooter;
 }
 
-export const Prompt: PromptType = ({children, variant, size, ...otherProps}) => {
+export const Prompt: PromptType = ({children, variant = 'info', ...otherProps}) => {
     const {classes, cx} = useStyles();
-    const defaultVariant = variant === 'default';
     const convertedChildren = Children.toArray(children) as ReactElement[];
 
     const otherChildren = convertedChildren.filter((child) => child.type !== PromptFooter);
@@ -51,14 +54,14 @@ export const Prompt: PromptType = ({children, variant, size, ...otherProps}) => 
 
     const classNames = {
         header: cx(classes.header, classes[variant]),
-        close: !defaultVariant && classes.whiteClose,
+        close: classes.whiteClose,
         body: classes.body,
-        modal: !defaultVariant && classes.modalType,
+        modal: classes.modalType,
         title: classes.title,
     };
 
     return (
-        <Modal variant="prompt" padding={0} classNames={classNames} size={defaultVariant ? size : 'sm'} {...otherProps}>
+        <Modal variant="prompt" padding={0} classNames={classNames} size={'sm'} {...otherProps}>
             <div className={classes.innerBody}>{otherChildren}</div>
             {footer}
         </Modal>

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -83,7 +83,7 @@ export const plasmaTheme: MantineThemeOverride = {
             },
         },
         Modal: {
-            styles: (theme, {fullScreen}, {size}) => ({
+            styles: (theme, {fullScreen, padding}, {size, variant}) => ({
                 content: {
                     flex: fullScreen
                         ? '0 0 100%'
@@ -104,6 +104,14 @@ export const plasmaTheme: MantineThemeOverride = {
                     fontSize: theme.headings.sizes.h3.fontSize,
                     lineHeight: theme.headings.sizes.h3.lineHeight,
                     fontWeight: 500,
+                },
+                header: {
+                    borderBottom: variant !== 'prompt' ? `1px solid ${color.primary.gray[3]}` : null,
+                },
+                body: {
+                    '&:not(:only-child)': {
+                        paddingTop: variant === 'prompt' ? 0 : getSize({size: padding, sizes: plasmaTheme.spacing}),
+                    },
                 },
             }),
             defaultProps: {

--- a/packages/website/src/SideNavigation.tsx
+++ b/packages/website/src/SideNavigation.tsx
@@ -93,6 +93,7 @@ const CurrentNavigation = () => {
                 <NavLink href="/layout/Table" label="Table" />
                 <NavLink href="/layout/Modal" label="Modal" />
                 <NavLink href="/layout/ModalWizard" label="ModalWizard" />
+                <NavLink href="/layout/Prompt" label="Prompt" />
                 <NavLink href="/layout/StickyFooter" label="Sticky footer" />
             </CollapsibleSideSection>
             <CollapsibleSideSection title="Form">

--- a/packages/website/src/examples/layout/Prompt/Prompt.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/Prompt.demo.tsx
@@ -1,0 +1,22 @@
+import {Button, Prompt} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+const Demo = () => {
+    const [opened, setOpened] = useState(false);
+
+    return (
+        <>
+            <Prompt variant="warning" opened={opened} title={'Prompt title'} onClose={() => setOpened(false)}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
+                sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
+                <Prompt.Footer>
+                    <Button variant="outline" onClick={() => setOpened(false)}>
+                        Close
+                    </Button>
+                </Prompt.Footer>
+            </Prompt>
+            <Button onClick={() => setOpened(true)}>Open Prompt</Button>
+        </>
+    );
+};
+export default Demo;

--- a/packages/website/src/pages/layout/Prompt.tsx
+++ b/packages/website/src/pages/layout/Prompt.tsx
@@ -1,0 +1,16 @@
+import {PromptMetadata} from '@coveord/plasma-components-props-analyzer';
+import PromptDemo from '@examples/layout/Prompt/Prompt.demo?demo';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
+
+export default () => (
+    <PageLayout
+        section="Layout"
+        title="Prompt"
+        sourcePath="/packages/mantine/src/components/prompt/Prompt.tsx"
+        description="A Prompt is a visual communication from the system to the user."
+        id="Prompt"
+        propsMetadata={PromptMetadata}
+        demo={<PromptDemo />}
+    />
+);


### PR DESCRIPTION
### Proposed Changes

Changed the theme style from the Modal component so that it adds a horizontal line separator between the header and the body. Also, I've created a `prompt` variant for the Modal component, because we dont want prompt to have that separator.


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
