### PR TITLE
fix(mantine, table): update style of the th elements

### DIFF
--- a/packages/mantine/src/components/table/Th.tsx
+++ b/packages/mantine/src/components/table/Th.tsx
@@ -6,7 +6,6 @@ const useStyles = createStyles((theme) => ({
     th: {
         fontWeight: '400 !important' as any,
         padding: '0 !important',
-        color: theme.black + '!important',
         verticalAlign: 'middle',
     },
 
@@ -14,9 +13,11 @@ const useStyles = createStyles((theme) => ({
         width: '100%',
         padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
         whiteSpace: 'nowrap',
+        backgroundColor: theme.colorScheme === 'dark' ? theme.colors.gray[8] : theme.colors.gray[0],
+        color: theme.colors.gray[6],
 
         '&:hover': {
-            backgroundColor: theme.colorScheme === 'dark' ? theme.colors.gray[6] : theme.colors.gray[2],
+            backgroundColor: theme.colorScheme === 'dark' ? theme.colors.gray[7] : theme.colors.gray[1],
         },
     },
 }));
@@ -49,7 +50,7 @@ export const Th = <T,>({header}: ThProps<T>) => {
     if (!header.column.getCanSort()) {
         return (
             <th className={classes.th} style={{width}}>
-                <Text size="xs" py="xs" px="sm">
+                <Text size="xs" py="xs" px="sm" fw={500}>
                     {flexRender(header.column.columnDef.header, header.getContext())}
                 </Text>
             </th>
@@ -64,7 +65,9 @@ export const Th = <T,>({header}: ThProps<T>) => {
         <th className={classes.th} style={{width}} aria-sort={SortingLabels[sortingOrder]}>
             <UnstyledButton onClick={onSort} className={classes.control}>
                 <Group position="apart" noWrap>
-                    <Text size="xs">{flexRender(header.column.columnDef.header, header.getContext())}</Text>
+                    <Text size="xs" fw={500}>
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                    </Text>
                     <Center>
                         <Icon height={14} />
                     </Center>


### PR DESCRIPTION
### Proposed Changes

Updated the style of the table header (th) elements of the Mantine table

#### Before:

normal:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/260007/236557330-294a0f9e-e048-4790-a6fe-5afb141e0853.png">

hover:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/260007/236557381-e61a1e43-8096-445b-8ebb-9dc5c05e424f.png">

#### After:

normal:
<img width="487" alt="image" src="https://user-images.githubusercontent.com/260007/236557528-ed843ef0-9198-4173-b220-7fb9c6431565.png">

hover:
<img width="515" alt="image" src="https://user-images.githubusercontent.com/260007/236557870-6e5fea20-7d3e-45f5-9ac1-cd40ebadffbc.png">


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
