### PR TITLE
fix(mantine, table): fix a few bugs when table is disabled by fieldset

### DIFF
--- a/packages/mantine/src/components/table/Table.styles.ts
+++ b/packages/mantine/src/components/table/Table.styles.ts
@@ -54,17 +54,15 @@ const useStyles = createStyles<string, TableStylesParams>((theme, {multiRowSelec
             textAlign: 'right',
             padding: `calc(${theme.spacing.xs}/2) ${theme.spacing.sm} !important`,
 
-            '&:has(button:disabled)': {
-                button: {
-                    pointerEvents: 'auto',
-                    cursor: 'pointer',
-                    backgroundColor: 'transparent',
-                    borderColor: 'transparent',
-                    color: `${theme.colors.gray[6]}`,
+            '& button:disabled': {
+                pointerEvents: 'auto',
+                cursor: 'pointer',
+                backgroundColor: 'transparent',
+                borderColor: 'transparent',
+                color: `${theme.colors.gray[6]}`,
 
-                    '&:hover': {
-                        backgroundColor: `${theme.colors.gray[0]}`,
-                    },
+                '&:hover': {
+                    backgroundColor: `${theme.colors.gray[0]}`,
                 },
             },
         },

--- a/packages/mantine/src/components/table/Table.styles.ts
+++ b/packages/mantine/src/components/table/Table.styles.ts
@@ -53,6 +53,20 @@ const useStyles = createStyles<string, TableStylesParams>((theme, {multiRowSelec
         rowCollapsibleButtonCell: {
             textAlign: 'right',
             padding: `calc(${theme.spacing.xs}/2) ${theme.spacing.sm} !important`,
+
+            '&:has(button:disabled)': {
+                button: {
+                    pointerEvents: 'auto',
+                    cursor: 'pointer',
+                    backgroundColor: 'transparent',
+                    borderColor: 'transparent',
+                    color: `${theme.colors.gray[6]}`,
+
+                    '&:hover': {
+                        backgroundColor: `${theme.colors.gray[0]}`,
+                    },
+                },
+            },
         },
 
         row: {

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -1,18 +1,18 @@
-import {Box, Center, Collapse, Loader, Skeleton, SkeletonProps, Table as MantineTable} from '@mantine/core';
+import {Box, Center, Collapse, Loader, Table as MantineTable, Skeleton, SkeletonProps} from '@mantine/core';
 import {useForm} from '@mantine/form';
 import {useDidUpdate} from '@mantine/hooks';
 import {
     ColumnDef,
+    Row,
+    TableState as TanstackTableState,
     defaultColumnSizing,
     flexRender,
     getCoreRowModel,
-    Row,
-    TableState as TanstackTableState,
     useReactTable,
 } from '@tanstack/react-table';
 import debounce from 'lodash.debounce';
 import defaultsDeep from 'lodash.defaultsdeep';
-import {Children, Dispatch, FC, Fragment, ReactElement, useCallback, useEffect, useState} from 'react';
+import {Children, Dispatch, FC, Fragment, ReactElement, useCallback, useEffect, useRef, useState} from 'react';
 
 import useStyles from './Table.styles';
 import {TableFormType, TableProps, TableState, TableType} from './Table.types';
@@ -101,6 +101,8 @@ export const Table: TableType = <T,>({
         };
     }, []);
 
+    const rowRef = useRef<HTMLTableRowElement>(null);
+
     useDidUpdate(() => {
         triggerChange();
         if (!multiRowSelectionEnabled) {
@@ -128,7 +130,12 @@ export const Table: TableType = <T,>({
         return (
             <Fragment key={row.id}>
                 <tr
-                    onClick={() => row.toggleSelected()}
+                    ref={rowRef}
+                    onClick={() =>
+                        rowRef.current.querySelectorAll('.mantine-Table-root input[type=checkbox]:disabled').length > 0
+                            ? undefined
+                            : row.toggleSelected()
+                    }
                     onDoubleClick={() => doubleClickAction?.(row.original)}
                     className={cx(classes.row, {[classes.rowSelected]: isSelected})}
                     aria-selected={isSelected}


### PR DESCRIPTION
### Proposed Changes
This PR tackles a few bugs that arise when a `Table` component is wrapped inside a `fieldset`. Essentially:
* If a table's rows contain checkboxes, despite being disabled, the checkboxes are still toggable when a user clicks on the row itself:

https://github.com/coveo/plasma/assets/105073504/18479ed5-e014-4c6e-96d0-5edff75c7a86

* Also, after the changes made in this [PR](https://github.com/mantinedev/mantine/pull/4152) in Mantine, when bumping the mantine dependecies to the latest, the collapsible buttons are now disabled and its content becomes inaccessible. This is a bug since we still want users to be able to access the collapsed content.

<img width="1489" alt="Screenshot 2023-05-17 at 11 43 30 AM" src="https://github.com/coveo/plasma/assets/105073504/7c9feb52-b8dd-42f2-8c1d-6b3192cf75dc">


The changes made to fix the bugs are the following:
* Modified the `onClick` method of the rows to take into account if its checkbox is disabled or not. If it is, then `onClick` is undefined;
* Modified the disabled style of the collapsible button to be clickable and to look enabled.
 
**NOTE**: Currently, there is also a bug with the Pagination and the PerPage component that is in a `Table`'s footer. More precisely, these components are disabled and unclickable. This is an issue because users should still be able to view the items inside a table and be able to manipulate these components. This [task](https://coveord.atlassian.net/browse/CTCORE-9247) was created to tackle it.

<!-- Explain what are your changes. -->

### Potential Breaking Changes
None

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
