### PR TITLE
fix: add word break for header title

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -51,7 +51,7 @@ export const Header: HeaderType = ({description, borderBottom, children, variant
                     <Title
                         order={variant === 'page' ? 1 : 3}
                         color={variant === 'page' ? 'gray.5' : undefined}
-                        style={{wordBreak: 'break-all'}}
+                        sx={{wordBreak: 'break-word'}}
                     >
                         {otherChildren}
                         {docAnchor}

--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -48,7 +48,11 @@ export const Header: HeaderType = ({description, borderBottom, children, variant
             >
                 <Stack spacing={0}>
                     {breadcrumbs}
-                    <Title order={variant === 'page' ? 1 : 3} color={variant === 'page' ? 'gray.5' : undefined}>
+                    <Title
+                        order={variant === 'page' ? 1 : 3}
+                        color={variant === 'page' ? 'gray.5' : undefined}
+                        style={{wordBreak: 'break-all'}}
+                    >
                         {otherChildren}
                         {docAnchor}
                     </Title>

--- a/packages/mantine/src/components/header/__tests__/Header.spec.tsx
+++ b/packages/mantine/src/components/header/__tests__/Header.spec.tsx
@@ -10,7 +10,7 @@ describe('Header', () => {
         const header = screen.getByRole('heading');
         expect(header).toMatchInlineSnapshot(`
           <h1
-            class="mantine-Text-root mantine-Title-root mantine-d1yoif"
+            class="mantine-Text-root mantine-Title-root mantine-m67b81"
           >
             child
           </h1>

--- a/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -38,7 +38,7 @@ exports[`Header > renders the specified breadcrumbs above the title 1`] = `
         </a>
       </div>
       <h1
-        class="mantine-Text-root mantine-Title-root mantine-d1yoif"
+        class="mantine-Text-root mantine-Title-root mantine-m67b81"
       >
         Title
       </h1>


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->
This fix allows the word-break styling to visualize better long field names when a user wants to edit a Field.
(Fixes third bullet point in : https://coveord.atlassian.net/browse/UITOOL-8758)

Located in `Content -> Fields`. Click on a long named Field and then click on "edit". You should see the window in the screenshots below.

**Before :** 
<img width="1488" alt="Screen Shot 2023-05-17 at 2 31 35 PM" src="https://github.com/coveo/plasma/assets/132406739/79e10d89-e6bc-4af1-b551-5c351c36e917">

**After :** 
<img width="1789" alt="long Fields name break-word" src="https://github.com/coveo/plasma/assets/132406739/e0e5b01e-45e5-4ba8-b98d-f461d4f1445a">

### Potential Breaking Changes

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
