### PR TITLE
fix: order date range picker buttons

### DIFF
--- a/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
+++ b/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
@@ -108,11 +108,11 @@ export const DateRangePickerInlineCalendar = ({
                     borderTop: `1px solid ${theme.colors.gray[2]}`,
                 })}
             >
-                <Button size="xs" onClick={onCalendarApply}>
-                    Apply
-                </Button>
                 <Button variant="outline" size="xs" onClick={onCancel}>
                     Cancel
+                </Button>
+                <Button size="xs" onClick={onCalendarApply}>
+                    Apply
                 </Button>
             </Group>
         </>


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->
This fix allows to invert the order of the buttons `Apply` and `Cancel` in the Date Picker in `Layout -> Table` of Plasma. The `Cancel` button needs to be on the left of the `Apply` button, as shown in the right side of the table below.

Before | After
-- | --
<img width="833" alt="Screen Shot 2023-05-18 at 1 53 02 PM" src="https://github.com/coveo/plasma/assets/132406739/fe405399-83f2-40e8-9564-2878c912b3c3"> | <img width="664" alt="Screen Shot 2023-05-18 at 1 47 55 PM" src="https://github.com/coveo/plasma/assets/132406739/38ba525a-be3d-4043-a149-7ddced043208">

Link to ticket here : https://coveord.atlassian.net/jira/software/c/projects/UITOOL/boards/926?modal=detail&selectedIssue=UITOOL-8809 

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
