### PR TITLE
feat(mantine, table): add disableRowSelection property

### DIFF
--- a/packages/mantine/src/components/table/Table.styles.ts
+++ b/packages/mantine/src/components/table/Table.styles.ts
@@ -2,9 +2,10 @@ import {createStyles} from '@mantine/core';
 
 interface TableStylesParams {
     multiRowSelectionEnabled: boolean;
+    disableRowSelection: boolean;
 }
 
-const useStyles = createStyles<string, TableStylesParams>((theme, {multiRowSelectionEnabled}) => {
+const useStyles = createStyles<string, TableStylesParams>((theme, {multiRowSelectionEnabled, disableRowSelection}) => {
     const rowBackgroundColor =
         theme.colorScheme === 'dark'
             ? theme.fn.rgba(theme.colors[theme.primaryColor][7], 0.2)
@@ -44,10 +45,34 @@ const useStyles = createStyles<string, TableStylesParams>((theme, {multiRowSelec
             '& th:first-of-type > *': {
                 paddingLeft: theme.spacing.xl,
             },
+
+            '& input[type=checkbox]': {
+                backgroundColor: disableRowSelection ? `${theme.colors.gray[2]}` : undefined,
+                borderColor: disableRowSelection ? `${theme.colors.gray[3]}` : `${theme.colors.gray[4]}`,
+                pointerEvents: disableRowSelection ? 'none' : 'auto',
+                cursor: disableRowSelection ? 'not-allowed' : 'default',
+
+                '& + svg': {
+                    color: disableRowSelection ? `${theme.colors.gray[5]}` : 'inherit',
+                },
+            },
         },
 
         rowSelected: {
             backgroundColor: multiRowSelectionEnabled ? undefined : rowBackgroundColor,
+        },
+
+        rowUnselectable: {
+            '& input[type=checkbox]': {
+                backgroundColor: `${theme.colors.gray[2]}`,
+                borderColor: `${theme.colors.gray[3]}`,
+                pointerEvents: 'none',
+                cursor: 'not-allowed',
+
+                '&:checked + svg': {
+                    color: `${theme.colors.gray[5]}`,
+                },
+            },
         },
 
         rowCollapsibleButtonCell: {

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -1,13 +1,13 @@
-import {Box, Center, Collapse, Loader, Skeleton, SkeletonProps, Table as MantineTable} from '@mantine/core';
+import {Box, Center, Collapse, Loader, Table as MantineTable, Skeleton, SkeletonProps} from '@mantine/core';
 import {useForm} from '@mantine/form';
 import {useDidUpdate} from '@mantine/hooks';
 import {
     ColumnDef,
+    Row,
+    TableState as TanstackTableState,
     defaultColumnSizing,
     flexRender,
     getCoreRowModel,
-    Row,
-    TableState as TanstackTableState,
     useReactTable,
 } from '@tanstack/react-table';
 import debounce from 'lodash.debounce';
@@ -50,6 +50,7 @@ export const Table: TableType = <T,>({
     loading = false,
     doubleClickAction,
     multiRowSelectionEnabled,
+    disableRowSelection,
     onRowSelectionChange,
     options = {},
 }: TableProps<T>) => {
@@ -62,7 +63,7 @@ export const Table: TableType = <T,>({
     const form = useForm<TableFormType>({
         initialValues: {predicates: initialState?.predicates ?? {}, dateRange: initialState?.dateRange ?? [null, null]},
     });
-    const {cx, classes} = useStyles({multiRowSelectionEnabled});
+    const {cx, classes} = useStyles({multiRowSelectionEnabled, disableRowSelection});
 
     const table = useReactTable({
         initialState: defaultsDeep(initialStateWithoutForm, {pagination: {pageSize: TablePerPage.DEFAULT_SIZE}}),
@@ -76,6 +77,7 @@ export const Table: TableType = <T,>({
         enableRowSelection: !loading,
         ...options,
     });
+
     const [state, setState] = useState<TableState<T>>(table.initialState as TableState<T>);
     table.setOptions((prev) => ({
         ...prev,
@@ -128,9 +130,12 @@ export const Table: TableType = <T,>({
         return (
             <Fragment key={row.id}>
                 <tr
-                    onClick={() => row.toggleSelected()}
+                    onClick={() => (disableRowSelection ? undefined : row.toggleSelected())}
                     onDoubleClick={() => doubleClickAction?.(row.original)}
-                    className={cx(classes.row, {[classes.rowSelected]: isSelected})}
+                    className={cx(classes.row, {
+                        [classes.rowSelected]: isSelected,
+                        [classes.rowUnselectable]: disableRowSelection,
+                    })}
                     aria-selected={isSelected}
                 >
                     {row.getVisibleCells().map((cell) => {
@@ -189,6 +194,7 @@ export const Table: TableType = <T,>({
                     containerRef: outsideClickRef,
                     multiRowSelectionEnabled,
                     getPageCount: table.getPageCount,
+                    disableRowSelection,
                 }}
             >
                 {consumer}

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -2,8 +2,8 @@ import {UseFormReturnType} from '@mantine/form';
 import {
     ColumnDef,
     CoreOptions,
-    InitialTableState as TanstackInitialTableState,
     TableOptions,
+    InitialTableState as TanstackInitialTableState,
     TableState as TanstackTableState,
 } from '@tanstack/table-core';
 import {Dispatch, ReactElement, ReactNode, RefObject} from 'react';
@@ -11,6 +11,7 @@ import {Dispatch, ReactElement, ReactNode, RefObject} from 'react';
 import {DateRangePickerValue} from '../date-range-picker/DateRangePickerInlineCalendar';
 import {TableActions} from './TableActions';
 import {TableAccordionColumn, TableCollapsibleColumn} from './TableCollapsibleColumn';
+import {TableConsumer} from './TableConsumer';
 import {TableDateRangePicker} from './TableDateRangePicker';
 import {TableFilter} from './TableFilter';
 import {TableFooter} from './TableFooter';
@@ -18,7 +19,6 @@ import {TableHeader} from './TableHeader';
 import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
-import {TableConsumer} from './TableConsumer';
 
 export type RowSelectionWithData<TData> = Record<string, TData>;
 export interface RowSelectionState<TData> {
@@ -97,6 +97,11 @@ export type TableContextType<TData> = {
      * Whether multi row selection is activated
      */
     multiRowSelectionEnabled: boolean;
+    /**
+     * Whether row selection is enabled or not
+     *
+     */
+    disableRowSelection: boolean;
     /**
      * Function that returns the number of pages
      */
@@ -178,6 +183,12 @@ export interface TableProps<T> {
      * @default false
      */
     multiRowSelectionEnabled?: boolean;
+    /**
+     * Whether row selection is enabled or not
+     *
+     * @default false
+     */
+    disableRowSelection?: boolean;
     /**
      * Additional options that can be passed to the table
      */

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -99,7 +99,6 @@ export type TableContextType<TData> = {
     multiRowSelectionEnabled: boolean;
     /**
      * Whether row selection is enabled or not
-     *
      */
     disableRowSelection: boolean;
     /**

--- a/packages/mantine/src/components/table/TableHeader.tsx
+++ b/packages/mantine/src/components/table/TableHeader.tsx
@@ -30,7 +30,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
     children,
     ...others
 }) => {
-    const {getSelectedRows, multiRowSelectionEnabled, clearSelection} = useTable();
+    const {getSelectedRows, multiRowSelectionEnabled, clearSelection, disableRowSelection} = useTable();
     const {classes} = useStyles(null, {name: 'TableHeader', classNames, styles, unstyled});
     const selectedRows = getSelectedRows();
     return (
@@ -45,7 +45,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
             className={classes.root}
             {...others}
         >
-            {multiRowSelectionEnabled && selectedRows.length > 0 ? (
+            {multiRowSelectionEnabled && !disableRowSelection && selectedRows.length > 0 ? (
                 <Grid.Col
                     span="auto"
                     py="sm"

--- a/packages/mantine/src/components/table/TableHeader.tsx
+++ b/packages/mantine/src/components/table/TableHeader.tsx
@@ -33,6 +33,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
     const {getSelectedRows, multiRowSelectionEnabled, clearSelection, disableRowSelection} = useTable();
     const {classes} = useStyles(null, {name: 'TableHeader', classNames, styles, unstyled});
     const selectedRows = getSelectedRows();
+
     return (
         <Grid
             justify="flex-start"
@@ -45,7 +46,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
             className={classes.root}
             {...others}
         >
-            {multiRowSelectionEnabled && !disableRowSelection && selectedRows.length > 0 ? (
+            {multiRowSelectionEnabled && selectedRows.length > 0 ? (
                 <Grid.Col
                     span="auto"
                     py="sm"
@@ -53,7 +54,12 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
                     order={TableComponentsOrder.MultiSelectInfo}
                 >
                     <Tooltip label="Unselect all">
-                        <Button onClick={clearSelection} variant="subtle" leftIcon={<CrossSize16Px height={16} />}>
+                        <Button
+                            onClick={clearSelection}
+                            variant="subtle"
+                            disabled={disableRowSelection}
+                            leftIcon={<CrossSize16Px height={16} />}
+                        >
                             {selectedRows.length} selected
                         </Button>
                     </Tooltip>

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -508,5 +508,78 @@ describe('Table', () => {
             await user.click(screen.getByRole('button', {name: /2 selected/i}));
             expect(screen.queryAllByRole('row', {selected: true})).toEqual([]);
         });
+
+        it('prevents row selection if disableRowSelection is true', async () => {
+            const user = userEvent.setup({delay: null});
+
+            render(
+                <div>
+                    <div>I'm a header</div>
+                    <Table
+                        getRowId={({id}) => id}
+                        data={[
+                            {id: '🆔-1', firstName: 'first', lastName: 'last'},
+                            {id: '🆔-2', firstName: 'patate', lastName: 'king'},
+                        ]}
+                        columns={columns}
+                        multiRowSelectionEnabled
+                        disableRowSelection
+                    />
+                </div>
+            );
+
+            await user.click(screen.getByRole('row', {name: /patate king/i}));
+            expect(screen.getByRole('row', {name: /patate king/i, selected: false})).toBeInTheDocument();
+            expect(screen.queryByRole('row', {name: /patate king/i, selected: true})).not.toBeInTheDocument();
+
+            await user.click(screen.getByRole('row', {name: /first last/i}));
+            expect(screen.getByRole('row', {name: /first last/i, selected: false})).toBeInTheDocument();
+            expect(screen.queryByRole('row', {name: /first last/i, selected: true})).not.toBeInTheDocument();
+        });
+
+        it('prevents click on checkboxes if disableRowSelection is true', async () => {
+            const user = userEvent.setup({delay: null});
+
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                    ]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                    disableRowSelection
+                />
+            );
+
+            expect(screen.getByRole('checkbox', {name: /select all/i})).toHaveStyle('pointerEvents: none');
+
+            const rows = screen.getAllByRole('row');
+            rows.forEach(async (row) => {
+                const checkbox = within(row).getByRole('checkbox', {name: /select/i});
+                expect(checkbox).toHaveStyle('pointerEvents: none');
+            });
+        });
+
+        it('does not display number of selected rows if disableRowSelection is true', async () => {
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                    ]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                    initialState={{
+                        rowSelection: {'🆔-2': {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'}},
+                    }}
+                />
+            );
+
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
+            expect(screen.queryByRole('button', {name: /1 selected/i})).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -514,7 +514,6 @@ describe('Table', () => {
 
             render(
                 <div>
-                    <div>I'm a header</div>
                     <Table
                         getRowId={({id}) => id}
                         data={[

--- a/packages/website/src/examples/layout/Table/TableDisabledRowSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableDisabledRowSelection.demo.tsx
@@ -1,0 +1,117 @@
+import {
+    BlankSlate,
+    Button,
+    ColumnDef,
+    createColumnHelper,
+    onTableChangeEvent,
+    Table,
+    Title,
+    useTable,
+} from '@coveord/plasma-mantine';
+import {FunctionComponent, useState} from 'react';
+
+interface IExampleRowData {
+    userId: number;
+    id: number;
+    title: string;
+    body: string;
+}
+
+const columnHelper = createColumnHelper<IExampleRowData>();
+const columns: Array<ColumnDef<IExampleRowData>> = [
+    columnHelper.accessor('userId', {
+        header: 'User ID',
+        cell: (info) => info.row.original.userId,
+        enableSorting: false,
+    }),
+    columnHelper.accessor('title', {
+        header: 'Title',
+        cell: (info) => info.row.original.title,
+        enableSorting: false,
+    }),
+];
+
+const Demo = () => {
+    const [data, setData] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [pages, setPages] = useState(1);
+
+    const fetchData: onTableChangeEvent<IExampleRowData> = async (state) => {
+        setLoading(true);
+        const searchParams = new URLSearchParams({
+            _page: (state.pagination.pageIndex + 1).toString(),
+            _limit: state.pagination.pageSize.toString(),
+            title_like: state.globalFilter,
+        });
+        if (!state.globalFilter) {
+            searchParams.delete('title_like');
+        }
+        try {
+            const response = await fetch(`https://jsonplaceholder.typicode.com/posts?${searchParams.toString()}`);
+            const body = await response.json();
+            setData(body);
+            setPages(Math.ceil(Number(response.headers.get('x-total-count')) / state.pagination?.pageSize));
+        } catch (e) {
+            console.error(e);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <Table<IExampleRowData>
+            data={data}
+            getRowId={({id}) => id.toString()}
+            columns={columns}
+            noDataChildren={<NoData />}
+            onMount={fetchData}
+            onChange={fetchData}
+            loading={loading}
+            onRowSelectionChange={(selectedRows) =>
+                console.info(`Row selection changed, selected rows: ${selectedRows.map(({id}) => id).join(', ')}`)
+            }
+            multiRowSelectionEnabled
+            disableRowSelection
+            initialState={{
+                rowSelection: {
+                    '1': {
+                        userId: 1,
+                        id: 1,
+                        title: 'sunt aut facere repellat provident occaecati excepturi optio reprehenderit',
+                        body: 'quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto',
+                    },
+                    '2': {
+                        userId: 1,
+                        id: 2,
+                        title: 'qui est esse',
+                        body: 'est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla',
+                    },
+                },
+            }}
+        >
+            <Table.Header>
+                <Table.Filter placeholder="Search posts by title" />
+            </Table.Header>
+            <Table.Footer>
+                <Table.PerPage />
+                <Table.Pagination totalPages={pages} />
+            </Table.Footer>
+        </Table>
+    );
+};
+export default Demo;
+
+const NoData: FunctionComponent = () => {
+    const {isFiltered, clearFilters} = useTable();
+
+    return isFiltered ? (
+        <BlankSlate>
+            <Title order={4}>No data found for those filters</Title>
+            <Button onClick={clearFilters}>Clear filters</Button>
+        </BlankSlate>
+    ) : (
+        <BlankSlate>
+            <Title order={4}>No Data</Title>
+        </BlankSlate>
+    );
+};

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -1,9 +1,10 @@
 import {TableMetadata} from '@coveord/plasma-components-props-analyzer';
 import TableDemo from '@examples/layout/Table/Table.demo?demo';
-import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
 import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo?demo';
-import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo?demo';
 import TableConsumerDemo from '@examples/layout/Table/TableConsumer.demo?demo';
+import TableDisableRowSelection from '@examples/layout/Table/TableDisabledRowSelection.demo?demo';
+import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo?demo';
+import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -18,6 +19,7 @@ const DemoPage = () => (
         demo={<TableDemo noPadding layout="vertical" />}
         examples={{
             multiSelect: <TableMultiSelectionDemo noPadding title="Table with bulk selection of rows" />,
+            disableRowSelection: <TableDisableRowSelection noPadding title="Table with disabled row selection" />,
             clientSide: (
                 <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
             ),


### PR DESCRIPTION
### Proposed Changes
* Added a `disableRowSelection` property to prevent row selection.

Essentially, enabling this property will **disable row selection** and **prevent clicks on the checkboxes** present on the table's rows. The purpose of this property is to be able to present the data in the table but to disallow users from modifying the rows that have been selected.

This property could be used for a table that's part of a form and the selected row are saved in it. When the form is disabled, we do not want users to be able to change the selected row in the table. In cases like these, we want to retrieve and save the information from the table, and not perform actions on its items. Hence, table and row actions are not relevant here.

<!-- Explain what are your changes. -->

### Potential Breaking Changes
None

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
