### PR TITLE
feat(mantine): update modal sizes

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -97,11 +97,11 @@ export const plasmaTheme: MantineThemeOverride = {
                         : `0 0 ${getSize({
                               size,
                               sizes: {
-                                  xs: rem(440),
-                                  sm: rem(550),
-                                  md: rem(800),
-                                  lg: rem(1334),
-                                  xl: rem('85%'),
+                                  xs: rem(432),
+                                  sm: rem(664),
+                                  md: rem(896),
+                                  lg: rem(1120),
+                                  xl: rem('88%'),
                               },
                           })}`,
                     overflow: 'auto',

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
@@ -18,7 +18,7 @@ const Demo = () => {
                         <Modal.CloseButton />
                     </Modal.Header>
                     <Tabs defaultValue="tab-1" mih={500}>
-                        <Tabs.List pl="xs">
+                        <Tabs.List pl="lg">
                             <Tabs.Tab value="tab-1">Tab 1</Tabs.Tab>
                             <Tabs.Tab value="tab-2">Tab 2</Tabs.Tab>
                             <Tabs.Tab value="tab-3">Tab 3</Tabs.Tab>


### PR DESCRIPTION
### Proposed Changes

> Deliverables: Based on our 2x grid and Mantine’s modal size presets, update the width values for the following:
> - xs = 432
> - sm = 664
> - md = 896
> - lg = 1120
> - xl = 88%

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
