### PR TITLE
fix: remove th padding due to word-break

### DIFF
--- a/packages/mantine/src/components/table/Th.tsx
+++ b/packages/mantine/src/components/table/Th.tsx
@@ -7,6 +7,7 @@ const useStyles = createStyles((theme) => ({
         fontWeight: '400 !important' as any,
         padding: '0 !important',
         verticalAlign: 'middle',
+        whiteSpace: 'nowrap',
     },
 
     control: {


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->
This fix resolves the second bullet point in this ticket : https://coveord.atlassian.net/browse/UITOOL-8758
(removes the excessive padding in the table header caused by the th that has a title with a word break)

A `whiteSpace: 'nowrap'` styling was added to the th of the table to make sure it doesn't break on multiple lines when the window size decreases.
before | after
-- | --
<img width="397" alt="before" src="https://github.com/coveo/plasma/assets/132406739/64e613a5-bc92-496c-80e9-13e4ae7b9f55"> | <img width="379" alt="after" src="https://github.com/coveo/plasma/assets/132406739/ee5b448f-68bc-4958-b955-82a037903300">

### How to test
1. Navigate to `Layout -> Table`
2. Inspect this section of the table
<img width="853" alt="Screenshot 2023-05-25 at 2 45 54 PM" src="https://github.com/coveo/plasma/assets/132406739/0e388318-eabf-452a-b4a6-cd62ad8e6248">

3. `Edit as HTML` the concerned tag and add multiple words to the div to have text in the div like this : 
<img width="1155" alt="Screenshot 2023-05-25 at 2 49 01 PM" src="https://github.com/coveo/plasma/assets/132406739/1f30554f-c096-4dea-8d6d-c4f7181bd514">

4. If you decrease the window size, the weird padding from before should not be there (it's easier to visualize when hovering on `Title`. 

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
