### PR TITLE
feat(mantine): enable table to have multiple layouts

### DIFF
--- a/packages/mantine/src/components/table/Table.styles.ts
+++ b/packages/mantine/src/components/table/Table.styles.ts
@@ -1,99 +1,44 @@
 import {createStyles} from '@mantine/core';
 
-interface TableStylesParams {
-    multiRowSelectionEnabled: boolean;
-    disableRowSelection: boolean;
-}
-
-const useStyles = createStyles<string, TableStylesParams>((theme, {multiRowSelectionEnabled, disableRowSelection}) => {
-    const rowBackgroundColor =
-        theme.colorScheme === 'dark'
-            ? theme.fn.rgba(theme.colors[theme.primaryColor][7], 0.2)
-            : theme.colors[theme.primaryColor][0];
-    return {
-        table: {
-            width: '100%',
-            '& thead tr th': {
-                borderBottom: 'none',
-            },
-            '& td:first-of-type': {
-                paddingLeft: theme.spacing.xl,
-            },
-            '& tbody td': {
-                verticalAlign: 'top',
-            },
+const useStyles = createStyles<string>((theme) => ({
+    table: {
+        width: '100%',
+        '& thead tr th': {
+            borderBottom: 'none',
         },
-
-        header: {
-            position: 'sticky',
-            top: 0,
-            backgroundColor: theme.colorScheme === 'dark' ? theme.black : theme.white,
-            transition: 'box-shadow 150ms ease',
-            zIndex: 1,
-
-            '&::after': {
-                content: '""',
-                position: 'absolute',
-                left: 0,
-                right: 0,
-                bottom: 0,
-                borderBottom: `1px solid ${theme.colors.gray[3]}`,
-            },
+        '& td:first-of-type': {
+            paddingLeft: theme.spacing.xl,
         },
-
-        headerColumns: {
-            '& th:first-of-type > *': {
-                paddingLeft: theme.spacing.xl,
-            },
-
-            '& input[type=checkbox]': {
-                backgroundColor: disableRowSelection ? `${theme.colors.gray[2]}` : undefined,
-                borderColor: disableRowSelection ? `${theme.colors.gray[3]}` : `${theme.colors.gray[4]}`,
-                pointerEvents: disableRowSelection ? 'none' : 'auto',
-                cursor: disableRowSelection ? 'not-allowed' : 'default',
-
-                '& + svg': {
-                    color: disableRowSelection ? `${theme.colors.gray[5]}` : 'inherit',
-                },
-            },
+        '& tbody td': {
+            verticalAlign: 'top',
         },
+    },
 
-        rowSelected: {
-            backgroundColor: multiRowSelectionEnabled ? undefined : rowBackgroundColor,
+    header: {
+        position: 'sticky',
+        top: 0,
+        backgroundColor: theme.colorScheme === 'dark' ? theme.black : theme.white,
+        transition: 'box-shadow 150ms ease',
+        zIndex: 1,
+
+        '&::after': {
+            content: '""',
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            bottom: 0,
+            borderBottom: `1px solid ${theme.colors.gray[3]}`,
         },
-
-        rowUnselectable: {
-            '& input[type=checkbox]': {
-                backgroundColor: `${theme.colors.gray[2]}`,
-                borderColor: `${theme.colors.gray[3]}`,
-                pointerEvents: 'none',
-                cursor: 'not-allowed',
-
-                '&:checked + svg': {
-                    color: `${theme.colors.gray[5]}`,
-                },
-            },
-        },
-
-        rowCollapsibleButtonCell: {
-            textAlign: 'right',
-            padding: `calc(${theme.spacing.xs}/2) ${theme.spacing.sm} !important`,
-        },
-
-        row: {
-            '&:hover': {
-                backgroundColor: rowBackgroundColor,
-            },
-        },
-    };
-});
+    },
+}));
 
 export const TableComponentsOrder = {
-    MultiSelectInfo: 5,
-    Actions: 4,
-    Predicate: 3,
-    Filter: 2,
-    DateRangePicker: 1,
+    MultiSelectInfo: 6,
+    Actions: 5,
+    Predicate: 4,
+    Filter: 3,
+    DateRangePicker: 2,
+    LayoutControl: 1,
 };
 
 export default useStyles;

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -52,7 +52,7 @@ export const Table: TableType = <T,>({
         initialValues: {
             predicates: initialState?.predicates ?? {},
             dateRange: initialState?.dateRange ?? [null, null],
-            layout: layouts[0].name,
+            layout: initialState?.layout ?? layouts[0].name,
         },
     });
     const {classes} = useStyles();
@@ -207,3 +207,4 @@ Table.AccordionColumn = TableAccordionColumn;
 Table.DateRangePicker = TableDateRangePicker;
 Table.Consumer = TableConsumer;
 Table.Loading = TableLoading;
+Table.Layouts = TableLayouts;

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -1,18 +1,10 @@
-import {Box, Center, Collapse, Loader, Table as MantineTable, Skeleton, SkeletonProps} from '@mantine/core';
+import {Box, Center, Loader, Table as MantineTable} from '@mantine/core';
 import {useForm} from '@mantine/form';
 import {useDidUpdate} from '@mantine/hooks';
-import {
-    ColumnDef,
-    Row,
-    TableState as TanstackTableState,
-    defaultColumnSizing,
-    flexRender,
-    getCoreRowModel,
-    useReactTable,
-} from '@tanstack/react-table';
+import {ColumnDef, Row, TableState as TanstackTableState, getCoreRowModel, useReactTable} from '@tanstack/react-table';
 import debounce from 'lodash.debounce';
 import defaultsDeep from 'lodash.defaultsdeep';
-import {Children, Dispatch, FC, Fragment, ReactElement, useCallback, useEffect, useState} from 'react';
+import {Children, Dispatch, ReactElement, useCallback, useEffect, useState} from 'react';
 
 import useStyles from './Table.styles';
 import {TableFormType, TableProps, TableState, TableType} from './Table.types';
@@ -28,14 +20,9 @@ import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
 import {TableSelectableColumn} from './TableSelectableColumn';
-import {Th} from './Th';
 import {useRowSelection} from './useRowSelection';
-
-const LoadingSkeleton: FC<SkeletonProps> = (props) => (
-    <Skeleton style={{display: 'inline-block'}} {...props} sx={!props.visible ? {borderRadius: 0} : undefined}>
-        {props.children}
-    </Skeleton>
-);
+import {TableLoading} from './TableLoading';
+import {TableLayouts} from './layouts/TableLayouts';
 
 export const Table: TableType = <T,>({
     data,
@@ -44,6 +31,7 @@ export const Table: TableType = <T,>({
     getExpandChildren,
     initialState = {},
     columns,
+    layouts = [TableLayouts.Rows],
     onMount,
     onChange,
     children,
@@ -61,9 +49,13 @@ export const Table: TableType = <T,>({
 
     const {predicates, dateRange, ...initialStateWithoutForm} = initialState;
     const form = useForm<TableFormType>({
-        initialValues: {predicates: initialState?.predicates ?? {}, dateRange: initialState?.dateRange ?? [null, null]},
+        initialValues: {
+            predicates: initialState?.predicates ?? {},
+            dateRange: initialState?.dateRange ?? [null, null],
+            layout: layouts[0].name,
+        },
     });
-    const {cx, classes} = useStyles({multiRowSelectionEnabled, disableRowSelection});
+    const {classes} = useStyles();
 
     const table = useReactTable({
         initialState: defaultsDeep(initialStateWithoutForm, {pagination: {pageSize: TablePerPage.DEFAULT_SIZE}}),
@@ -108,7 +100,13 @@ export const Table: TableType = <T,>({
         if (!multiRowSelectionEnabled) {
             clearSelection();
         }
-    }, [state.globalFilter, state.pagination, state.sorting, form.values]);
+    }, [
+        state.globalFilter,
+        state.pagination,
+        state.sorting,
+        JSON.stringify(form.values.dateRange),
+        JSON.stringify(form.values.predicates),
+    ]);
 
     const clearFilters = useCallback(() => {
         form.setFieldValue('predicates', initialState.predicates ?? {});
@@ -123,60 +121,8 @@ export const Table: TableType = <T,>({
         );
     }
 
-    const rows = table.getRowModel().rows.map((row) => {
-        const rowChildren = getExpandChildren?.(row.original) ?? null;
-        const isSelected = !!row.getIsSelected();
-
-        return (
-            <Fragment key={row.id}>
-                <tr
-                    onClick={() => (disableRowSelection ? undefined : row.toggleSelected())}
-                    onDoubleClick={() => doubleClickAction?.(row.original)}
-                    className={cx(classes.row, {
-                        [classes.rowSelected]: isSelected,
-                        [classes.rowUnselectable]: disableRowSelection,
-                    })}
-                    aria-selected={isSelected}
-                >
-                    {row.getVisibleCells().map((cell) => {
-                        const size = cell.column.getSize();
-                        const width = size !== defaultColumnSizing.size ? size : undefined;
-                        return (
-                            <td
-                                key={cell.id}
-                                style={{width}}
-                                className={cx({
-                                    [classes.rowCollapsibleButtonCell]: cell.column.id === TableCollapsibleColumn.id,
-                                })}
-                            >
-                                <LoadingSkeleton visible={loading}>
-                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                </LoadingSkeleton>
-                            </td>
-                        );
-                    })}
-                </tr>
-                {rowChildren ? (
-                    <tr>
-                        <td
-                            colSpan={table.getAllColumns().length}
-                            style={{
-                                padding: 0,
-                                borderTop: row.getIsExpanded() ? undefined : 'none',
-                                borderBottom: row.getIsExpanded() ? undefined : 'none',
-                            }}
-                        >
-                            <Collapse in={row.getIsExpanded()}>
-                                <Box px="sm" py="xs">
-                                    {rowChildren}
-                                </Box>
-                            </Collapse>
-                        </td>
-                    </tr>
-                ) : null}
-            </Fragment>
-        );
-    });
+    const Layout = layouts.find(({name}) => name === form.values.layout);
+    const hasRows = table.getRowModel().rows.length > 0;
 
     return (
         <Box ref={outsideClickRef}>
@@ -195,10 +141,11 @@ export const Table: TableType = <T,>({
                     multiRowSelectionEnabled,
                     getPageCount: table.getPageCount,
                     disableRowSelection,
+                    layouts,
                 }}
             >
                 {consumer}
-                {!rows.length && !isFiltered && !loading ? (
+                {!hasRows && !isFiltered && !loading ? (
                     noDataChildren
                 ) : (
                     <>
@@ -215,21 +162,25 @@ export const Table: TableType = <T,>({
                                         </th>
                                     </tr>
                                 ) : null}
-                                {table.getHeaderGroups().map((headerGroup) => (
-                                    <tr key={headerGroup.id} className={classes.headerColumns}>
-                                        {headerGroup.headers.map((columnHeader) => (
-                                            <Th key={columnHeader.id} header={columnHeader} />
-                                        ))}
-                                    </tr>
-                                ))}
+                                <Layout.Header
+                                    table={table}
+                                    doubleClickAction={doubleClickAction}
+                                    getExpandChildren={getExpandChildren}
+                                    loading={loading}
+                                />
                             </thead>
                             <tbody>
-                                {rows.length ? (
-                                    rows
+                                {hasRows ? (
+                                    <Layout.Body
+                                        table={table}
+                                        doubleClickAction={doubleClickAction}
+                                        getExpandChildren={getExpandChildren}
+                                        loading={loading}
+                                    />
                                 ) : (
                                     <tr>
                                         <td colSpan={table.getAllColumns().length}>
-                                            <LoadingSkeleton visible={loading}>{noDataChildren}</LoadingSkeleton>
+                                            <TableLoading visible={loading}>{noDataChildren}</TableLoading>
                                         </td>
                                     </tr>
                                 )}
@@ -255,3 +206,4 @@ Table.CollapsibleColumn = TableCollapsibleColumn;
 Table.AccordionColumn = TableAccordionColumn;
 Table.DateRangePicker = TableDateRangePicker;
 Table.Consumer = TableConsumer;
+Table.Loading = TableLoading;

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -2,12 +2,14 @@ import {UseFormReturnType} from '@mantine/form';
 import {
     ColumnDef,
     CoreOptions,
+    Table,
     TableOptions,
     InitialTableState as TanstackInitialTableState,
     TableState as TanstackTableState,
 } from '@tanstack/table-core';
 import {Dispatch, ReactElement, ReactNode, RefObject} from 'react';
 
+import {Icon} from '@coveord/plasma-react-icons';
 import {DateRangePickerValue} from '../date-range-picker/DateRangePickerInlineCalendar';
 import {TableActions} from './TableActions';
 import {TableAccordionColumn, TableCollapsibleColumn} from './TableCollapsibleColumn';
@@ -16,6 +18,7 @@ import {TableDateRangePicker} from './TableDateRangePicker';
 import {TableFilter} from './TableFilter';
 import {TableFooter} from './TableFooter';
 import {TableHeader} from './TableHeader';
+import {TableLoading} from './TableLoading';
 import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
@@ -34,6 +37,45 @@ export interface InitialTableState<TData>
 
 export type onTableChangeEvent<TData> = (params: TableState<TData> & TableFormType) => void;
 
+export interface TableLayout {
+    /**
+     * Name of the layout.
+     * Will be displayed in the layout control
+     */
+    name: string;
+    /**
+     * Icon illustrating the layout.
+     * Will be displayed in the layout control
+     */
+    icon?: Icon;
+    /**
+     * Header portion of the table.
+     * In the standard row layout that is where column headers would be displayed.
+     */
+    Header: <T>(props: TableLayoutProps<T>) => ReactElement;
+    /**
+     * Body portion of the table.
+     * In the standard row layout that is where the rows would be displayed.
+     */
+    Body: <T>(props: TableLayoutProps<T>) => ReactElement;
+}
+
+export interface TableLayoutProps<T = unknown> {
+    table: Table<T>;
+    loading?: boolean;
+    /**
+     * Action passed when user double clicks on a row
+     */
+    doubleClickAction?: (datum: T) => void;
+    /**
+     * Function that generates the expandable content of a row
+     * Return null for rows that don't need to be expandable
+     *
+     * @param datum the row for which the children should be generated.
+     */
+    getExpandChildren?: (datum: T) => ReactNode;
+}
+
 export type TableFormType = {
     /**
      * Object containing the table predicates and their selected values
@@ -47,6 +89,10 @@ export type TableFormType = {
      * @example [new Date(2022, 0, 1), new Date(2022, 0, 31)]
      */
     dateRange: DateRangePickerValue;
+    /**
+     * Selected layout name
+     */
+    layout: TableLayout['name'];
 };
 
 export type TableContextType<TData> = {
@@ -105,6 +151,10 @@ export type TableContextType<TData> = {
      * Function that returns the number of pages
      */
     getPageCount: () => number;
+    /**
+     * Available layouts. When more than one layout is provided, it will display a layout control to switch between them.
+     */
+    layouts: TableLayout[];
 };
 
 export interface TableProps<T> {
@@ -122,6 +172,12 @@ export interface TableProps<T> {
      * @see https://tanstack.com/table/v8/docs/guide/column-defs
      */
     columns: Array<ColumnDef<T>>;
+    /**
+     * Available layouts
+     *
+     * @default [TableLayout.Rows]
+     */
+    layouts?: TableLayout[];
     /**
      * Function called when the table mounts
      *
@@ -218,4 +274,5 @@ export interface TableType {
     CollapsibleColumn: typeof TableCollapsibleColumn;
     AccordionColumn: typeof TableAccordionColumn;
     Consumer: typeof TableConsumer;
+    Loading: typeof TableLoading;
 }

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -22,6 +22,7 @@ import {TableLoading} from './TableLoading';
 import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
+import {TableLayouts} from './layouts/TableLayouts';
 
 export type RowSelectionWithData<TData> = Record<string, TData>;
 export interface RowSelectionState<TData> {
@@ -175,7 +176,7 @@ export interface TableProps<T> {
     /**
      * Available layouts
      *
-     * @default [TableLayout.Rows]
+     * @default [Table.Layouts.Rows]
      */
     layouts?: TableLayout[];
     /**
@@ -275,4 +276,5 @@ export interface TableType {
     AccordionColumn: typeof TableAccordionColumn;
     Consumer: typeof TableConsumer;
     Loading: typeof TableLoading;
+    Layouts: typeof TableLayouts;
 }

--- a/packages/mantine/src/components/table/TableHeader.tsx
+++ b/packages/mantine/src/components/table/TableHeader.tsx
@@ -5,6 +5,7 @@ import {FunctionComponent, ReactNode} from 'react';
 import {Button} from '../button';
 import {TableComponentsOrder} from './Table.styles';
 import {useTable} from './TableContext';
+import {TableLayoutControl} from './TableLayoutControl';
 
 const useStyles = createStyles((theme) => ({
     root: {
@@ -66,6 +67,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
                 </Grid.Col>
             ) : null}
             {children}
+            <TableLayoutControl />
         </Grid>
     );
 };

--- a/packages/mantine/src/components/table/TableLayoutControl.tsx
+++ b/packages/mantine/src/components/table/TableLayoutControl.tsx
@@ -1,0 +1,29 @@
+import {Box, Center, Grid, SegmentedControl, Space} from '@mantine/core';
+import {TableComponentsOrder} from './Table.styles';
+import {useTable} from './TableContext';
+
+export const TableLayoutControl = () => {
+    const {form, layouts} = useTable();
+    return layouts.length > 1 ? (
+        <Grid.Col order={TableComponentsOrder.LayoutControl} span="content">
+            <SegmentedControl
+                color="action"
+                data={layouts.map(({name, icon: Icon}) => ({
+                    value: name,
+                    label: (
+                        <Center>
+                            {Icon ? (
+                                <>
+                                    <Icon height={16} />
+                                    <Space w="xs" />
+                                </>
+                            ) : null}
+                            <Box>{name}</Box>
+                        </Center>
+                    ),
+                }))}
+                {...form.getInputProps('layout')}
+            />
+        </Grid.Col>
+    ) : null;
+};

--- a/packages/mantine/src/components/table/TableLoading.tsx
+++ b/packages/mantine/src/components/table/TableLoading.tsx
@@ -1,0 +1,8 @@
+import {Skeleton, SkeletonProps} from '@mantine/core';
+import {FunctionComponent} from 'react';
+
+export const TableLoading: FunctionComponent<SkeletonProps> = (props) => (
+    <Skeleton style={{display: 'inline-block'}} {...props} sx={!props.visible ? {borderRadius: 0} : undefined}>
+        {props.children}
+    </Skeleton>
+);

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -3,6 +3,7 @@ import {render, screen, userEvent, waitFor} from '@test-utils';
 
 import {Table} from '../Table';
 import {useTable} from '../TableContext';
+import {TableLayout} from '../Table.types';
 
 type RowData = {id: string; firstName: string; lastName?: string};
 
@@ -141,6 +142,19 @@ describe('Table', () => {
     });
 
     describe('with multiple layouts', () => {
+        const layouts: TableLayout[] = [
+            {
+                name: 'Layout 1',
+                Header: () => <tr data-testid="layout1-header" />,
+                Body: () => <tr data-testid="layout1-body" />,
+            },
+            {
+                name: 'Layout 2',
+                Header: () => <tr data-testid="layout2-header" />,
+                Body: () => <tr data-testid="layout2-body" />,
+            },
+        ];
+
         it('handles switching layout', async () => {
             const user = userEvent.setup();
             render(
@@ -148,18 +162,7 @@ describe('Table', () => {
                     getRowId={({id}) => id}
                     data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
                     columns={columns}
-                    layouts={[
-                        {
-                            name: 'Layout 1',
-                            Header: () => <tr data-testid="layout1-header" />,
-                            Body: () => <tr data-testid="layout1-body" />,
-                        },
-                        {
-                            name: 'Layout 2',
-                            Header: () => <tr data-testid="layout2-header" />,
-                            Body: () => <tr data-testid="layout2-body" />,
-                        },
-                    ]}
+                    layouts={layouts}
                 >
                     <Table.Header data-testid="table-header" />
                 </Table>
@@ -191,18 +194,7 @@ describe('Table', () => {
                     columns={columns}
                     onMount={fetchDataSpy}
                     onChange={fetchDataSpy}
-                    layouts={[
-                        {
-                            name: 'Layout 1',
-                            Header: () => <tr data-testid="layout1-header" />,
-                            Body: () => <tr data-testid="layout1-body" />,
-                        },
-                        {
-                            name: 'Layout 2',
-                            Header: () => <tr data-testid="layout2-header" />,
-                            Body: () => <tr data-testid="layout2-body" />,
-                        },
-                    ]}
+                    layouts={layouts}
                 >
                     <Table.Header data-testid="table-header" />
                 </Table>
@@ -211,6 +203,27 @@ describe('Table', () => {
             await user.click(screen.getByRole('radio', {name: /layout 2/i}));
             await user.click(screen.getByRole('radio', {name: /layout 1/i}));
             expect(fetchDataSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('renders the layout specified in the initialState', () => {
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
+                    columns={columns}
+                    layouts={layouts}
+                    initialState={{layout: 'Layout 2'}}
+                >
+                    <Table.Header data-testid="table-header" />
+                </Table>
+            );
+
+            expect(screen.getByRole('radio', {name: /layout 2/i})).toBeChecked();
+            expect(screen.getByTestId('layout2-header')).toBeInTheDocument();
+            expect(screen.getByTestId('layout2-body')).toBeInTheDocument();
+            expect(screen.getByRole('radio', {name: /layout 1/i})).not.toBeChecked();
+            expect(screen.queryByTestId('layout1-header')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('layout1-body')).not.toBeInTheDocument();
         });
     });
 

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -1,9 +1,7 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
-import {render, screen, userEvent, waitFor, within} from '@test-utils';
-import {FunctionComponent} from 'react';
+import {render, screen, userEvent, waitFor} from '@test-utils';
 
 import {Table} from '../Table';
-import {TableProps} from '../Table.types';
 import {useTable} from '../TableContext';
 
 type RowData = {id: string; firstName: string; lastName?: string};
@@ -14,127 +12,44 @@ const columns: Array<ColumnDef<RowData>> = [
     columnHelper.accessor('lastName', {enableSorting: false}),
 ];
 
+const EmptyState = () => {
+    const {isFiltered} = useTable();
+    return isFiltered ? <span data-testid="filtered-empty-state" /> : <span data-testid="empty-state" />;
+};
+
 describe('Table', () => {
-    it('renders the data', () => {
-        render(
-            <Table
-                getRowId={({id}) => id}
-                data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
-                columns={columns}
-            />
-        );
+    describe('when it has no data', () => {
+        it('hides the footer and header if the table is not filtered', () => {
+            render(
+                <Table data={[]} columns={columns} noDataChildren={<EmptyState />}>
+                    <Table.Header data-testid="table-header">header</Table.Header>
+                    <Table.Footer data-testid="table-footer">footer</Table.Footer>
+                </Table>
+            );
 
-        expect(screen.getByRole('columnheader', {name: 'firstName'})).toBeVisible();
-        expect(screen.getByRole('columnheader', {name: 'lastName'})).toBeVisible();
+            expect(screen.queryByTestId('table-header')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('table-footer')).not.toBeInTheDocument();
+            expect(screen.getByTestId('empty-state')).toBeVisible();
+        });
 
-        expect(
-            screen.getByRole('cell', {
-                name: /first/i,
-            })
-        ).toBeVisible();
-        expect(
-            screen.getByRole('cell', {
-                name: /last/i,
-            })
-        ).toBeVisible();
-    });
+        it('does not hide the footer and header if the table is filtered', () => {
+            render(
+                <Table
+                    data={[]}
+                    columns={columns}
+                    noDataChildren={<EmptyState />}
+                    initialState={{globalFilter: 'something'}}
+                >
+                    <Table.Header data-testid="table-header">header</Table.Header>
+                    <Table.Footer data-testid="table-footer">footer</Table.Footer>
+                </Table>
+            );
 
-    it('formats the data', () => {
-        const customColumns: Array<ColumnDef<RowData>> = [
-            columnHelper.accessor('firstName', {
-                header: () => 'First Name',
-                cell: (info) => info.getValue().toUpperCase(),
-                enableSorting: false,
-            }),
-            columnHelper.accessor('lastName', {
-                header: () => 'Last Name',
-                cell: (info) => info.getValue().toUpperCase(),
-                enableSorting: false,
-            }),
-        ];
-        render(<Table data={[{id: '🆔', firstName: 'first', lastName: 'last'}]} columns={customColumns} />);
-
-        expect(screen.getByRole('columnheader', {name: 'First Name'})).toBeVisible();
-        expect(screen.getByRole('columnheader', {name: 'Last Name'})).toBeVisible();
-
-        expect(
-            screen.getByRole('cell', {
-                name: 'FIRST',
-            })
-        ).toBeVisible();
-        expect(
-            screen.getByRole('cell', {
-                name: 'LAST',
-            })
-        ).toBeVisible();
-    });
-
-    it('renders the noDataChildren when the table is empty', () => {
-        const Fixture: FunctionComponent = () => <button>Hello</button>;
-        render(<Table data={[]} noDataChildren={<Fixture />} columns={columns} />);
-
-        expect(screen.getByRole('button', {name: 'Hello'})).toBeVisible();
-    });
-
-    it('hides the footer and header when the table is empty and not filtered', () => {
-        const NoData = () => <span data-testid="empty-state" />;
-        const customColumns: Array<ColumnDef<RowData>> = [
-            columnHelper.accessor('firstName', {
-                header: () => 'First Name',
-                cell: (info) => info.getValue().toUpperCase(),
-                enableSorting: false,
-            }),
-            columnHelper.accessor('lastName', {
-                header: () => 'Last Name',
-                cell: (info) => info.getValue().toUpperCase(),
-                enableSorting: false,
-            }),
-        ];
-        render(
-            <Table data={[]} columns={customColumns} noDataChildren={<NoData />}>
-                <Table.Header data-testid="table-header">header</Table.Header>
-                <Table.Footer data-testid="table-footer">footer</Table.Footer>
-            </Table>
-        );
-
-        expect(screen.queryByTestId('table-header')).not.toBeInTheDocument();
-        expect(screen.queryByTestId('table-footer')).not.toBeInTheDocument();
-        expect(screen.getByTestId('empty-state')).toBeInTheDocument();
-    });
-
-    it('does not hide the footer and header when the table is empty and filtered', () => {
-        const NoData = () => {
-            const {isFiltered} = useTable();
-            return isFiltered ? <span data-testid="filtered-empty-state" /> : <span data-testid="empty-state" />;
-        };
-        const customColumns: Array<ColumnDef<RowData>> = [
-            columnHelper.accessor('firstName', {
-                header: () => 'First Name',
-                cell: (info) => info.getValue().toUpperCase(),
-                enableSorting: false,
-            }),
-            columnHelper.accessor('lastName', {
-                header: () => 'Last Name',
-                cell: (info) => info.getValue().toUpperCase(),
-                enableSorting: false,
-            }),
-        ];
-        render(
-            <Table
-                data={[]}
-                columns={customColumns}
-                noDataChildren={<NoData />}
-                initialState={{globalFilter: 'something'}}
-            >
-                <Table.Header data-testid="table-header">header</Table.Header>
-                <Table.Footer data-testid="table-footer">footer</Table.Footer>
-            </Table>
-        );
-
-        expect(screen.getByTestId('table-header')).toBeInTheDocument();
-        expect(screen.getByTestId('table-footer')).toBeInTheDocument();
-        expect(screen.getByTestId('filtered-empty-state')).toBeInTheDocument();
-        expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+            expect(screen.getByTestId('table-header')).toBeVisible();
+            expect(screen.getByTestId('table-footer')).toBeVisible();
+            expect(screen.getByTestId('filtered-empty-state')).toBeVisible();
+            expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+        });
     });
 
     it('updates the table when a component in Table.Consumer triggers a change', async () => {
@@ -162,176 +77,42 @@ describe('Table', () => {
         });
     });
 
-    describe('shows a loading animation', () => {
-        const doRender = (props: Omit<TableProps<RowData>, 'columns'>) => {
-            const NoData = () => {
-                const {isFiltered, clearFilters} = useTable();
-                return isFiltered ? (
-                    <button data-testid="filtered-empty-state" onClick={clearFilters}></button>
-                ) : (
-                    <span data-testid="empty-state" />
-                );
-            };
-
-            const customColumns: Array<ColumnDef<RowData>> = [
-                columnHelper.accessor('firstName', {
-                    header: () => 'First Name',
-                    cell: (info) => info.getValue().toUpperCase(),
-                    enableSorting: false,
-                }),
-                columnHelper.accessor('lastName', {
-                    header: () => 'Last Name',
-                    cell: (info) => info.getValue().toUpperCase(),
-                    enableSorting: false,
-                }),
-            ];
+    describe('when it is loading', () => {
+        it('shows a loading animation over the no data children (filtered)', () => {
             render(
-                <Table columns={customColumns} noDataChildren={<NoData />} {...props}>
+                <Table
+                    loading
+                    data={[]}
+                    columns={columns}
+                    noDataChildren={<EmptyState />}
+                    initialState={{globalFilter: 'something'}}
+                >
                     <Table.Header>
                         <Table.Filter data-testid="table-filter" />
                     </Table.Header>
                 </Table>
             );
-        };
-
-        it('when the table filtered, empty and loading', () => {
-            doRender({loading: true, data: [], initialState: {globalFilter: 'something'}});
             expect(screen.getByTestId('filtered-empty-state').parentElement).toHaveClass(
                 'mantine-Skeleton-root mantine-Skeleton-visible'
             );
         });
 
-        it('when the table not filtered, empty and loading', () => {
-            doRender({data: [], loading: true});
+        it('shows a loading animation over the no data children (unfiltered)', () => {
+            render(
+                <Table loading data={[]} columns={columns} noDataChildren={<EmptyState />}>
+                    <Table.Header>
+                        <Table.Filter data-testid="table-filter" />
+                    </Table.Header>
+                </Table>
+            );
             expect(screen.getByTestId('empty-state').parentElement).toHaveClass(
                 'mantine-Skeleton-root mantine-Skeleton-visible'
             );
         });
     });
 
-    it('opens the collapsible rows when the user click on the toggle', async () => {
-        const user = userEvent.setup({delay: null});
-        const Fixture: FunctionComponent<{row: RowData}> = ({row}) => <div>Collapsible content: {row.lastName}</div>;
-        const customColumns: Array<ColumnDef<RowData>> = [
-            columnHelper.accessor('firstName', {
-                enableSorting: false,
-            }),
-            Table.CollapsibleColumn as ColumnDef<RowData>,
-        ];
-        render(
-            <Table
-                getRowId={({id}) => id}
-                data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
-                getExpandChildren={(row: RowData) => <Fixture row={row} />}
-                columns={customColumns}
-            />
-        );
-
-        // wait for the collapsible icon to show
-        await screen.findByRole('button', {name: 'arrowHeadDown'});
-
-        expect(screen.queryByText('Collapsible content: last')).not.toBeVisible();
-
-        await user.click(screen.getByRole('button', {name: 'arrowHeadDown'}));
-        await waitFor(() => {
-            expect(screen.queryByText('Collapsible content: last')).toBeVisible();
-        });
-    });
-
-    it('renders the collapsible button only for rows that can be expanded', async () => {
-        const Fixture: FunctionComponent<{row: RowData}> = ({row}) => (
-            <div>
-                Collapsible content: {row.firstName} {row.lastName}
-            </div>
-        );
-        const customColumns: Array<ColumnDef<RowData>> = [
-            columnHelper.accessor('firstName', {
-                enableSorting: false,
-            }),
-            Table.CollapsibleColumn as ColumnDef<RowData>,
-        ];
-        render(
-            <Table
-                getRowId={({id}) => id}
-                data={[
-                    {id: '🆔-1', firstName: 'Luke', lastName: 'Skywalker'},
-                    {id: '🆔-2', firstName: 'Lea', lastName: 'Skywalker'},
-                    {id: '🆔-3', firstName: 'Han', lastName: 'Solo'},
-                ]}
-                getExpandChildren={(row: RowData) => (row.lastName === 'Skywalker' ? <Fixture row={row} /> : null)}
-                columns={customColumns}
-            />
-        );
-
-        // wait for the collapsible icon to show
-        await screen.findAllByRole('button', {name: 'arrowHeadDown'});
-
-        const allRows = screen.getAllByRole('button', {name: 'arrowHeadDown'});
-        expect(allRows).toHaveLength(2);
-    });
-
-    it('closes the opened collapsible when using the accordion column and the user expand a different row', async () => {
-        const user = userEvent.setup({delay: null});
-        const Fixture: FunctionComponent<{row: RowData}> = ({row}) => <div>Collapsible content: {row.lastName}</div>;
-        const customColumns: Array<ColumnDef<RowData>> = [
-            columnHelper.accessor('firstName', {
-                enableSorting: false,
-            }),
-            Table.AccordionColumn as ColumnDef<RowData>,
-        ];
-        render(
-            <Table
-                getRowId={({id}) => id}
-                data={[
-                    {id: '🆔-1', firstName: 'Jack', lastName: 'Russel'},
-                    {id: '🆔-2', firstName: 'Golden', lastName: 'Retriever'},
-                ]}
-                getExpandChildren={(row: RowData) => <Fixture row={row} />}
-                columns={customColumns}
-            />
-        );
-
-        // wait for the collapsible icon to show
-        await screen.findAllByRole('button', {name: 'arrowHeadDown'});
-
-        expect(screen.queryByText('Collapsible content: Russel')).not.toBeVisible();
-        expect(screen.queryByText('Collapsible content: Retriever')).not.toBeVisible();
-
-        await user.click(within(screen.getAllByRole('row')[1]).getByRole('button', {name: 'arrowHeadDown'}));
-        await waitFor(() => {
-            expect(screen.queryByText('Collapsible content: Russel')).toBeVisible();
-        });
-        expect(screen.queryByText('Collapsible content: Retriever')).not.toBeVisible();
-
-        await user.click(within(screen.getAllByRole('row')[3]).getByRole('button', {name: 'arrowHeadDown'}));
-
-        await waitFor(() => {
-            expect(screen.queryByText('Collapsible content: Retriever')).toBeVisible();
-        });
-        expect(screen.queryByText('Collapsible content: Russel')).not.toBeVisible();
-    });
-
-    it('calls an action when user double clicks on a row', async () => {
-        const user = userEvent.setup();
-        const doubleClickSpy = vi.fn();
-        render(
-            <Table<RowData>
-                getRowId={({id}) => id}
-                data={[
-                    {id: '🆔-1', firstName: 'Mario'},
-                    {id: '🆔-2', firstName: 'Luigi'},
-                ]}
-                columns={columns}
-                doubleClickAction={doubleClickSpy}
-            ></Table>
-        );
-        await user.dblClick(screen.getByRole('cell', {name: 'Mario'}));
-        expect(doubleClickSpy).toHaveBeenCalledTimes(1);
-        expect(doubleClickSpy).toHaveBeenCalledWith({id: '🆔-1', firstName: 'Mario'});
-    });
-
     it('reset row selection when user click outside the table', async () => {
-        const user = userEvent.setup({delay: null});
+        const user = userEvent.setup();
         render(
             <div>
                 <div>I'm a header</div>
@@ -359,73 +140,84 @@ describe('Table', () => {
         expect(screen.getByRole('row', {name: 'patate king', selected: false})).toBeInTheDocument();
     });
 
+    describe('with multiple layouts', () => {
+        it('handles switching layout', async () => {
+            const user = userEvent.setup();
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
+                    columns={columns}
+                    layouts={[
+                        {
+                            name: 'Layout 1',
+                            Header: () => <tr data-testid="layout1-header" />,
+                            Body: () => <tr data-testid="layout1-body" />,
+                        },
+                        {
+                            name: 'Layout 2',
+                            Header: () => <tr data-testid="layout2-header" />,
+                            Body: () => <tr data-testid="layout2-body" />,
+                        },
+                    ]}
+                >
+                    <Table.Header data-testid="table-header" />
+                </Table>
+            );
+            expect(screen.getByRole('radio', {name: /layout 1/i})).toBeChecked();
+            expect(screen.getByTestId('layout1-header')).toBeInTheDocument();
+            expect(screen.getByTestId('layout1-body')).toBeInTheDocument();
+            expect(screen.getByRole('radio', {name: /layout 2/i})).not.toBeChecked();
+            expect(screen.queryByTestId('layout2-header')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('layout2-body')).not.toBeInTheDocument();
+
+            await user.click(screen.getByRole('radio', {name: /layout 2/i}));
+
+            expect(screen.getByRole('radio', {name: /layout 2/i})).toBeChecked();
+            expect(screen.getByTestId('layout2-header')).toBeInTheDocument();
+            expect(screen.getByTestId('layout2-body')).toBeInTheDocument();
+            expect(screen.getByRole('radio', {name: /layout 1/i})).not.toBeChecked();
+            expect(screen.queryByTestId('layout1-header')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('layout1-body')).not.toBeInTheDocument();
+        });
+
+        it('does not refetch data when switching layout', async () => {
+            const user = userEvent.setup();
+            const fetchDataSpy = vi.fn();
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
+                    columns={columns}
+                    onMount={fetchDataSpy}
+                    onChange={fetchDataSpy}
+                    layouts={[
+                        {
+                            name: 'Layout 1',
+                            Header: () => <tr data-testid="layout1-header" />,
+                            Body: () => <tr data-testid="layout1-body" />,
+                        },
+                        {
+                            name: 'Layout 2',
+                            Header: () => <tr data-testid="layout2-header" />,
+                            Body: () => <tr data-testid="layout2-body" />,
+                        },
+                    ]}
+                >
+                    <Table.Header data-testid="table-header" />
+                </Table>
+            );
+
+            await user.click(screen.getByRole('radio', {name: /layout 2/i}));
+            await user.click(screen.getByRole('radio', {name: /layout 1/i}));
+            expect(fetchDataSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('when multi row selection is enabled', () => {
-        it('displays a checkbox as the first cell of each row', () => {
-            render(
-                <Table
-                    getRowId={({id}) => id}
-                    data={[
-                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
-                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
-                    ]}
-                    columns={columns}
-                    multiRowSelectionEnabled
-                />
-            );
-
-            expect(screen.getByRole('columnheader', {name: /select all from this page/i})).toBeInTheDocument();
-
-            const rows = screen.getAllByRole('row');
-            rows.forEach((row) => {
-                expect(within(row).getByRole('checkbox', {name: /select/i})).toBeInTheDocument();
-            });
-        });
-
-        it('selects the rows specified in the initial state on mount', () => {
-            render(
-                <Table
-                    getRowId={({id}) => id}
-                    data={[
-                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
-                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
-                    ]}
-                    columns={columns}
-                    multiRowSelectionEnabled
-                    initialState={{
-                        rowSelection: {'🆔-2': {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'}},
-                    }}
-                />
-            );
-
-            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
-        });
-
-        it('selects all rows of the current page when clicking on the checkbox that is in the column header', async () => {
-            const user = userEvent.setup({delay: null});
-            render(
-                <Table
-                    getRowId={({id}) => id}
-                    data={[
-                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
-                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
-                    ]}
-                    columns={columns}
-                    multiRowSelectionEnabled
-                />
-            );
-
-            const selectAll = screen.getByRole('checkbox', {name: /select all from this page/i});
-            await user.click(selectAll);
-
-            expect(screen.getAllByRole('row', {selected: true})).toHaveLength(2);
-            await user.click(selectAll);
-
-            expect(screen.queryAllByRole('row', {selected: true})).toEqual([]);
-        });
-
         it('calls the onRowSelectionChange prop when the row selection changes', async () => {
             const onRowSelectionChangeSpy = vi.fn();
-            const user = userEvent.setup({delay: null});
+            const user = userEvent.setup();
             render(
                 <Table
                     getRowId={({id}) => id}
@@ -459,7 +251,7 @@ describe('Table', () => {
         });
 
         it('does not clear the row selection when clicking outside the table', async () => {
-            const user = userEvent.setup({delay: null});
+            const user = userEvent.setup();
             render(
                 <div>
                     <div>I'm a header</div>
@@ -489,7 +281,7 @@ describe('Table', () => {
         });
 
         it('unselects all the selected rows when clicking on the the unselect button from the table header', async () => {
-            const user = userEvent.setup({delay: null});
+            const user = userEvent.setup();
             render(
                 <Table
                     getRowId={({id}) => id}
@@ -509,58 +301,6 @@ describe('Table', () => {
             expect(screen.queryAllByRole('row', {selected: true})).toEqual([]);
         });
 
-        it('prevents row selection if disableRowSelection is true', async () => {
-            const user = userEvent.setup({delay: null});
-
-            render(
-                <div>
-                    <Table
-                        getRowId={({id}) => id}
-                        data={[
-                            {id: '🆔-1', firstName: 'first', lastName: 'last'},
-                            {id: '🆔-2', firstName: 'patate', lastName: 'king'},
-                        ]}
-                        columns={columns}
-                        multiRowSelectionEnabled
-                        disableRowSelection
-                    />
-                </div>
-            );
-
-            await user.click(screen.getByRole('row', {name: /patate king/i}));
-            expect(screen.getByRole('row', {name: /patate king/i, selected: false})).toBeInTheDocument();
-            expect(screen.queryByRole('row', {name: /patate king/i, selected: true})).not.toBeInTheDocument();
-
-            await user.click(screen.getByRole('row', {name: /first last/i}));
-            expect(screen.getByRole('row', {name: /first last/i, selected: false})).toBeInTheDocument();
-            expect(screen.queryByRole('row', {name: /first last/i, selected: true})).not.toBeInTheDocument();
-        });
-
-        it('prevents click on checkboxes if disableRowSelection is true', async () => {
-            const user = userEvent.setup({delay: null});
-
-            render(
-                <Table
-                    getRowId={({id}) => id}
-                    data={[
-                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
-                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
-                    ]}
-                    columns={columns}
-                    multiRowSelectionEnabled
-                    disableRowSelection
-                />
-            );
-
-            expect(screen.getByRole('checkbox', {name: /select all/i})).toHaveStyle('pointerEvents: none');
-
-            const rows = screen.getAllByRole('row');
-            rows.forEach(async (row) => {
-                const checkbox = within(row).getByRole('checkbox', {name: /select/i});
-                expect(checkbox).toHaveStyle('pointerEvents: none');
-            });
-        });
-
         it('does not display number of selected rows if disableRowSelection is true', async () => {
             render(
                 <Table
@@ -577,7 +317,6 @@ describe('Table', () => {
                 />
             );
 
-            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
             expect(screen.queryByRole('button', {name: /1 selected/i})).not.toBeInTheDocument();
         });
     });

--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -1,3 +1,4 @@
 export * from './Table';
 export {useTable} from './TableContext';
 export {type onTableChangeEvent, type InitialTableState, type TableState, type TableProps} from './Table.types';
+export {TableLayouts} from './layouts/TableLayouts';

--- a/packages/mantine/src/components/table/layouts/RowLayout.tsx
+++ b/packages/mantine/src/components/table/layouts/RowLayout.tsx
@@ -1,0 +1,150 @@
+import {ListSize16Px} from '@coveord/plasma-react-icons';
+import {Box, Collapse, createStyles} from '@mantine/core';
+import {flexRender} from '@tanstack/react-table';
+import {defaultColumnSizing} from '@tanstack/table-core';
+import {Fragment} from 'react';
+import {TableLayout, TableLayoutProps} from '../Table.types';
+import {TableCollapsibleColumn} from '../TableCollapsibleColumn';
+import {useTable} from '../TableContext';
+import {TableLoading} from '../TableLoading';
+import {Th} from '../Th';
+
+interface TableStylesParams {
+    multiRowSelectionEnabled: boolean;
+    disableRowSelection: boolean;
+}
+
+const useStyles = createStyles<string, TableStylesParams>((theme, {multiRowSelectionEnabled, disableRowSelection}) => {
+    const rowBackgroundColor =
+        theme.colorScheme === 'dark'
+            ? theme.fn.rgba(theme.colors[theme.primaryColor][7], 0.2)
+            : theme.colors[theme.primaryColor][0];
+    return {
+        headerColumns: {
+            '& th:first-of-type > *': {
+                paddingLeft: theme.spacing.xl,
+            },
+
+            '& input[type=checkbox]': {
+                backgroundColor: disableRowSelection ? `${theme.colors.gray[2]}` : undefined,
+                borderColor: disableRowSelection ? `${theme.colors.gray[3]}` : `${theme.colors.gray[4]}`,
+                pointerEvents: disableRowSelection ? 'none' : 'auto',
+                cursor: disableRowSelection ? 'not-allowed' : 'default',
+
+                '& + svg': {
+                    color: disableRowSelection ? `${theme.colors.gray[5]}` : 'inherit',
+                },
+            },
+        },
+
+        rowSelected: {
+            backgroundColor: multiRowSelectionEnabled ? undefined : rowBackgroundColor,
+        },
+
+        rowUnselectable: {
+            '& input[type=checkbox]': {
+                backgroundColor: `${theme.colors.gray[2]}`,
+                borderColor: `${theme.colors.gray[3]}`,
+                pointerEvents: 'none',
+                cursor: 'not-allowed',
+
+                '&:checked + svg': {
+                    color: `${theme.colors.gray[5]}`,
+                },
+            },
+        },
+
+        rowCollapsibleButtonCell: {
+            textAlign: 'right',
+            padding: `calc(${theme.spacing.xs}/2) ${theme.spacing.sm} !important`,
+        },
+
+        row: {
+            '&:hover': {
+                backgroundColor: rowBackgroundColor,
+            },
+        },
+    };
+});
+
+const RowLayoutHeader = <T,>({table}: TableLayoutProps<T>) => {
+    const {multiRowSelectionEnabled, disableRowSelection} = useTable();
+    const {classes} = useStyles({disableRowSelection, multiRowSelectionEnabled});
+    const headers = table.getHeaderGroups().map((headerGroup) => (
+        <tr key={headerGroup.id} className={classes.headerColumns}>
+            {headerGroup.headers.map((columnHeader) => (
+                <Th key={columnHeader.id} header={columnHeader} />
+            ))}
+        </tr>
+    ));
+    return <>{headers}</>;
+};
+
+const RowLayoutBody = <T,>({table, doubleClickAction, getExpandChildren, loading}: TableLayoutProps<T>) => {
+    const {multiRowSelectionEnabled, disableRowSelection} = useTable();
+    const {classes, cx} = useStyles({disableRowSelection, multiRowSelectionEnabled});
+
+    const rows = table.getRowModel().rows.map((row) => {
+        const rowChildren = getExpandChildren?.(row.original) ?? null;
+        const isSelected = !!row.getIsSelected();
+
+        return (
+            <Fragment key={row.id}>
+                <tr
+                    onClick={() => (disableRowSelection ? undefined : row.toggleSelected())}
+                    onDoubleClick={() => doubleClickAction?.(row.original)}
+                    className={cx(classes.row, {
+                        [classes.rowSelected]: isSelected,
+                        [classes.rowUnselectable]: disableRowSelection,
+                    })}
+                    aria-selected={isSelected}
+                >
+                    {row.getVisibleCells().map((cell) => {
+                        const size = cell.column.getSize();
+                        const width = size !== defaultColumnSizing.size ? size : undefined;
+                        return (
+                            <td
+                                key={cell.id}
+                                style={{width}}
+                                className={cx({
+                                    [classes.rowCollapsibleButtonCell]: cell.column.id === TableCollapsibleColumn.id,
+                                })}
+                            >
+                                <TableLoading visible={loading}>
+                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                </TableLoading>
+                            </td>
+                        );
+                    })}
+                </tr>
+                {rowChildren ? (
+                    <tr>
+                        <td
+                            colSpan={table.getAllColumns().length}
+                            style={{
+                                padding: 0,
+                                borderTop: row.getIsExpanded() ? undefined : 'none',
+                                borderBottom: row.getIsExpanded() ? undefined : 'none',
+                            }}
+                        >
+                            <Collapse in={row.getIsExpanded()}>
+                                <Box px="sm" py="xs">
+                                    {rowChildren}
+                                </Box>
+                            </Collapse>
+                        </td>
+                    </tr>
+                ) : null}
+            </Fragment>
+        );
+    });
+
+    return <>{rows}</>;
+};
+
+export const RowLayout: TableLayout = {
+    name: 'Rows',
+    icon: ListSize16Px,
+    Header: RowLayoutHeader,
+    Body: RowLayoutBody,
+};

--- a/packages/mantine/src/components/table/layouts/TableLayouts.tsx
+++ b/packages/mantine/src/components/table/layouts/TableLayouts.tsx
@@ -1,0 +1,5 @@
+import {RowLayout} from './RowLayout';
+
+export const TableLayouts = {
+    Rows: RowLayout,
+};

--- a/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
@@ -1,0 +1,296 @@
+import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
+import {render, screen, userEvent, waitFor, within} from '@test-utils';
+import {FunctionComponent} from 'react';
+import {Table} from '../../Table';
+
+describe('RowLayout', () => {
+    type RowData = {id: string; firstName: string; lastName?: string};
+
+    const columnHelper = createColumnHelper<RowData>();
+    const columns: Array<ColumnDef<RowData>> = [
+        columnHelper.accessor('firstName', {enableSorting: false}),
+        columnHelper.accessor('lastName', {enableSorting: false}),
+    ];
+
+    it('renders the data using the RowLayout by default', () => {
+        render(
+            <Table
+                getRowId={({id}) => id}
+                data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
+                columns={columns}
+            />
+        );
+
+        expect(screen.getByRole('columnheader', {name: 'firstName'})).toBeVisible();
+        expect(screen.getByRole('columnheader', {name: 'lastName'})).toBeVisible();
+
+        expect(
+            screen.getByRole('cell', {
+                name: /first/i,
+            })
+        ).toBeVisible();
+        expect(
+            screen.getByRole('cell', {
+                name: /last/i,
+            })
+        ).toBeVisible();
+    });
+
+    it('formats the data', () => {
+        const customColumns: Array<ColumnDef<RowData>> = [
+            columnHelper.accessor('firstName', {
+                header: () => 'First Name',
+                cell: (info) => info.getValue().toUpperCase(),
+                enableSorting: false,
+            }),
+            columnHelper.accessor('lastName', {
+                header: () => 'Last Name',
+                cell: (info) => info.getValue().toUpperCase(),
+                enableSorting: false,
+            }),
+        ];
+        render(<Table data={[{id: '🆔', firstName: 'first', lastName: 'last'}]} columns={customColumns} />);
+
+        expect(screen.getByRole('columnheader', {name: 'First Name'})).toBeVisible();
+        expect(screen.getByRole('columnheader', {name: 'Last Name'})).toBeVisible();
+
+        expect(screen.getByRole('cell', {name: 'FIRST'})).toBeVisible();
+        expect(screen.getByRole('cell', {name: 'LAST'})).toBeVisible();
+    });
+
+    it('opens the collapsible rows when the user click on the toggle', async () => {
+        const user = userEvent.setup();
+        const Fixture: FunctionComponent<{row: RowData}> = ({row}) => <div>Collapsible content: {row.lastName}</div>;
+        const customColumns: Array<ColumnDef<RowData>> = [
+            columnHelper.accessor('firstName', {
+                enableSorting: false,
+            }),
+            Table.CollapsibleColumn as ColumnDef<RowData>,
+        ];
+        render(
+            <Table
+                getRowId={({id}) => id}
+                data={[{id: '🆔', firstName: 'first', lastName: 'last'}]}
+                getExpandChildren={(row: RowData) => <Fixture row={row} />}
+                columns={customColumns}
+            />
+        );
+
+        // wait for the collapsible icon to show
+        await screen.findByRole('button', {name: 'arrowHeadDown'});
+
+        expect(screen.queryByText('Collapsible content: last')).not.toBeVisible();
+
+        await user.click(screen.getByRole('button', {name: 'arrowHeadDown'}));
+        await waitFor(() => {
+            expect(screen.queryByText('Collapsible content: last')).toBeVisible();
+        });
+    });
+
+    it('renders the collapsible button only for rows that can be expanded', async () => {
+        const Fixture: FunctionComponent<{row: RowData}> = ({row}) => (
+            <div>
+                Collapsible content: {row.firstName} {row.lastName}
+            </div>
+        );
+        const customColumns: Array<ColumnDef<RowData>> = [
+            columnHelper.accessor('firstName', {
+                enableSorting: false,
+            }),
+            Table.CollapsibleColumn as ColumnDef<RowData>,
+        ];
+        render(
+            <Table
+                getRowId={({id}) => id}
+                data={[
+                    {id: '🆔-1', firstName: 'Luke', lastName: 'Skywalker'},
+                    {id: '🆔-2', firstName: 'Lea', lastName: 'Skywalker'},
+                    {id: '🆔-3', firstName: 'Han', lastName: 'Solo'},
+                ]}
+                getExpandChildren={(row: RowData) => (row.lastName === 'Skywalker' ? <Fixture row={row} /> : null)}
+                columns={customColumns}
+            />
+        );
+
+        // wait for the collapsible icon to show
+        await screen.findAllByRole('button', {name: 'arrowHeadDown'});
+
+        const allRows = screen.getAllByRole('button', {name: 'arrowHeadDown'});
+        expect(allRows).toHaveLength(2);
+    });
+
+    it('closes the opened collapsible when using the accordion column and the user expand a different row', async () => {
+        const user = userEvent.setup();
+        const Fixture: FunctionComponent<{row: RowData}> = ({row}) => <div>Collapsible content: {row.lastName}</div>;
+        const customColumns: Array<ColumnDef<RowData>> = [
+            columnHelper.accessor('firstName', {
+                enableSorting: false,
+            }),
+            Table.AccordionColumn as ColumnDef<RowData>,
+        ];
+        render(
+            <Table
+                getRowId={({id}) => id}
+                data={[
+                    {id: '🆔-1', firstName: 'Jack', lastName: 'Russel'},
+                    {id: '🆔-2', firstName: 'Golden', lastName: 'Retriever'},
+                ]}
+                getExpandChildren={(row: RowData) => <Fixture row={row} />}
+                columns={customColumns}
+            />
+        );
+
+        // wait for the collapsible icon to show
+        await screen.findAllByRole('button', {name: 'arrowHeadDown'});
+
+        expect(screen.queryByText('Collapsible content: Russel')).not.toBeVisible();
+        expect(screen.queryByText('Collapsible content: Retriever')).not.toBeVisible();
+
+        await user.click(within(screen.getAllByRole('row')[1]).getByRole('button', {name: 'arrowHeadDown'}));
+        await waitFor(() => {
+            expect(screen.queryByText('Collapsible content: Russel')).toBeVisible();
+        });
+        expect(screen.queryByText('Collapsible content: Retriever')).not.toBeVisible();
+
+        await user.click(within(screen.getAllByRole('row')[3]).getByRole('button', {name: 'arrowHeadDown'}));
+
+        await waitFor(() => {
+            expect(screen.queryByText('Collapsible content: Retriever')).toBeVisible();
+        });
+        expect(screen.queryByText('Collapsible content: Russel')).not.toBeVisible();
+    });
+
+    it('calls an action when user double clicks on a row', async () => {
+        const user = userEvent.setup();
+        const doubleClickSpy = vi.fn();
+        render(
+            <Table<RowData>
+                getRowId={({id}) => id}
+                data={[
+                    {id: '🆔-1', firstName: 'Mario'},
+                    {id: '🆔-2', firstName: 'Luigi'},
+                ]}
+                columns={columns}
+                doubleClickAction={doubleClickSpy}
+            ></Table>
+        );
+        await user.dblClick(screen.getByRole('cell', {name: 'Mario'}));
+        expect(doubleClickSpy).toHaveBeenCalledTimes(1);
+        expect(doubleClickSpy).toHaveBeenCalledWith({id: '🆔-1', firstName: 'Mario'});
+    });
+
+    describe('when multi row selection is enabled', () => {
+        it('displays a checkbox as the first cell of each row', () => {
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                    ]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                />
+            );
+
+            expect(screen.getByRole('columnheader', {name: /select all from this page/i})).toBeInTheDocument();
+
+            const rows = screen.getAllByRole('row');
+            rows.forEach((row) => {
+                expect(within(row).getByRole('checkbox', {name: /select/i})).toBeInTheDocument();
+            });
+        });
+
+        it('selects the rows specified in the initial state on mount', () => {
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                    ]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                    initialState={{
+                        rowSelection: {'🆔-2': {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'}},
+                    }}
+                />
+            );
+
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
+        });
+
+        it('selects all rows of the current page when clicking on the checkbox that is in the column header', async () => {
+            const user = userEvent.setup();
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                    ]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                />
+            );
+
+            const selectAll = screen.getByRole('checkbox', {name: /select all from this page/i});
+            await user.click(selectAll);
+
+            expect(screen.getAllByRole('row', {selected: true})).toHaveLength(2);
+            await user.click(selectAll);
+
+            expect(screen.queryAllByRole('row', {selected: true})).toEqual([]);
+        });
+
+        it('prevents row selection if disableRowSelection is true', async () => {
+            const user = userEvent.setup();
+
+            render(
+                <div>
+                    <Table
+                        getRowId={({id}) => id}
+                        data={[
+                            {id: '🆔-1', firstName: 'first', lastName: 'last'},
+                            {id: '🆔-2', firstName: 'patate', lastName: 'king'},
+                        ]}
+                        columns={columns}
+                        multiRowSelectionEnabled
+                        disableRowSelection
+                    />
+                </div>
+            );
+
+            await user.click(screen.getByRole('row', {name: /patate king/i}));
+            expect(screen.getByRole('row', {name: /patate king/i, selected: false})).toBeInTheDocument();
+            expect(screen.queryByRole('row', {name: /patate king/i, selected: true})).not.toBeInTheDocument();
+
+            await user.click(screen.getByRole('row', {name: /first last/i}));
+            expect(screen.getByRole('row', {name: /first last/i, selected: false})).toBeInTheDocument();
+            expect(screen.queryByRole('row', {name: /first last/i, selected: true})).not.toBeInTheDocument();
+        });
+
+        it('prevents click on checkboxes if disableRowSelection is true', async () => {
+            render(
+                <Table
+                    getRowId={({id}) => id}
+                    data={[
+                        {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                        {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+                    ]}
+                    columns={columns}
+                    multiRowSelectionEnabled
+                    disableRowSelection
+                />
+            );
+
+            expect(screen.getByRole('checkbox', {name: /select all/i})).toHaveStyle('pointerEvents: none');
+
+            const rows = screen.getAllByRole('row');
+            rows.forEach(async (row) => {
+                const checkbox = within(row).getByRole('checkbox', {name: /select/i});
+                expect(checkbox).toHaveStyle('pointerEvents: none');
+            });
+        });
+    });
+});

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -276,12 +276,12 @@ export const plasmaTheme: MantineThemeOverride = {
                 },
             },
         },
-        Segmented: {
-            styles: {
-                control: {
-                    zIndex: 'unset',
+        SegmentedControl: {
+            styles: (theme) => ({
+                root: {
+                    backgroundColor: theme.colors.gray[2],
                 },
-            },
+            }),
         },
         Stepper: {
             defaultProps: {

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -1,10 +1,10 @@
 import {TableMetadata} from '@coveord/plasma-components-props-analyzer';
 import TableDemo from '@examples/layout/Table/Table.demo?demo';
-// import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo?demo';
-// import TableConsumerDemo from '@examples/layout/Table/TableConsumer.demo?demo';
-// import TableDisableRowSelection from '@examples/layout/Table/TableDisabledRowSelection.demo?demo';
-// import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo?demo';
-// import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
+import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo?demo';
+import TableConsumerDemo from '@examples/layout/Table/TableConsumer.demo?demo';
+import TableDisableRowSelection from '@examples/layout/Table/TableDisabledRowSelection.demo?demo';
+import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo?demo';
+import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -17,15 +17,15 @@ const DemoPage = () => (
         id="Table"
         propsMetadata={TableMetadata}
         demo={<TableDemo noPadding layout="vertical" />}
-        // examples={{
-        //     multiSelect: <TableMultiSelectionDemo noPadding title="Table with bulk selection of rows" />,
-        //     disableRowSelection: <TableDisableRowSelection noPadding title="Table with disabled row selection" />,
-        //     clientSide: (
-        //         <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
-        //     ),
-        //     emptyState: <TableEmptyStateDemo noPadding title="Table with empty states" />,
-        //     consumer: <TableConsumerDemo noPadding title="Table with a child component using the hook to re-fetch" />,
-        // }}
+        examples={{
+            multiSelect: <TableMultiSelectionDemo noPadding title="Table with bulk selection of rows" />,
+            disableRowSelection: <TableDisableRowSelection noPadding title="Table with disabled row selection" />,
+            clientSide: (
+                <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
+            ),
+            emptyState: <TableEmptyStateDemo noPadding title="Table with empty states" />,
+            consumer: <TableConsumerDemo noPadding title="Table with a child component using the hook to re-fetch" />,
+        }}
     />
 );
 

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -1,10 +1,10 @@
 import {TableMetadata} from '@coveord/plasma-components-props-analyzer';
 import TableDemo from '@examples/layout/Table/Table.demo?demo';
-import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo?demo';
-import TableConsumerDemo from '@examples/layout/Table/TableConsumer.demo?demo';
-import TableDisableRowSelection from '@examples/layout/Table/TableDisabledRowSelection.demo?demo';
-import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo?demo';
-import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
+// import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo?demo';
+// import TableConsumerDemo from '@examples/layout/Table/TableConsumer.demo?demo';
+// import TableDisableRowSelection from '@examples/layout/Table/TableDisabledRowSelection.demo?demo';
+// import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo?demo';
+// import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -17,15 +17,15 @@ const DemoPage = () => (
         id="Table"
         propsMetadata={TableMetadata}
         demo={<TableDemo noPadding layout="vertical" />}
-        examples={{
-            multiSelect: <TableMultiSelectionDemo noPadding title="Table with bulk selection of rows" />,
-            disableRowSelection: <TableDisableRowSelection noPadding title="Table with disabled row selection" />,
-            clientSide: (
-                <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
-            ),
-            emptyState: <TableEmptyStateDemo noPadding title="Table with empty states" />,
-            consumer: <TableConsumerDemo noPadding title="Table with a child component using the hook to re-fetch" />,
-        }}
+        // examples={{
+        //     multiSelect: <TableMultiSelectionDemo noPadding title="Table with bulk selection of rows" />,
+        //     disableRowSelection: <TableDisableRowSelection noPadding title="Table with disabled row selection" />,
+        //     clientSide: (
+        //         <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
+        //     ),
+        //     emptyState: <TableEmptyStateDemo noPadding title="Table with empty states" />,
+        //     consumer: <TableConsumerDemo noPadding title="Table with a child component using the hook to re-fetch" />,
+        // }}
     />
 );
 


### PR DESCRIPTION
### Proposed Changes

Enabling the `<Table>` component to offer multiple layouts to the user.

In this PR, I extracted the existing logic to render rows into a `RowLayout` and exposed a new `layouts` prop on the Table component. The default value of this prop is an array containing only the row layout, so this change is not breaking.

When providing more than one layout, a layout toggle appears and let the user switch between layouts.


https://github.com/coveo/plasma/assets/35579930/97506783-989e-4901-8c0d-9c45f1697f85



### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
