### PR TITLE
fix(mantine): export table layout types

### DIFF
--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -8,3 +8,4 @@ export {
     type TableLayout,
     type TableLayoutProps,
 } from './Table.types';
+export {flexRender as renderTableCell} from '@tanstack/react-table';

--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -1,4 +1,10 @@
 export * from './Table';
 export {useTable} from './TableContext';
-export {type onTableChangeEvent, type InitialTableState, type TableState, type TableProps} from './Table.types';
-export {TableLayouts} from './layouts/TableLayouts';
+export {
+    type onTableChangeEvent,
+    type InitialTableState,
+    type TableState,
+    type TableProps,
+    type TableLayout,
+    type TableLayoutProps,
+} from './Table.types';


### PR DESCRIPTION
### Proposed Changes

These types should be exported to make it easier to build a custom table layout.

### Potential Breaking Changes

TableLayouts isn't exported directly anymore. It is accessible through Table.Layouts. Not marking the commit as breaking though since this was never intended and released very recently.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
