### PR TITLE
fix(mantine): fix table predicate onChange

### DIFF
--- a/packages/mantine/src/components/table/TablePredicate.tsx
+++ b/packages/mantine/src/components/table/TablePredicate.tsx
@@ -39,11 +39,10 @@ export const TablePredicate: FunctionComponent<TablePredicateProps> = ({
     ...others
 }) => {
     const {classes} = useStyles(null, {name: 'TablePredicate', classNames, styles, unstyled});
-    const {onChange, form} = useTable();
+    const {form} = useTable();
 
     const onUpdate = (newValue: string) => {
         form.setFieldValue('predicates', {...form.values.predicates, [id]: newValue});
-        onChange?.();
     };
 
     return (

--- a/packages/mantine/src/components/table/__tests__/TablePredicate.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TablePredicate.spec.tsx
@@ -1,5 +1,5 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
-import {render, screen, userEvent, waitFor} from '@test-utils';
+import {act, render, screen, userEvent, waitFor} from '@test-utils';
 
 import {Table} from '../Table';
 
@@ -75,7 +75,7 @@ describe('Table.Predicate', () => {
     });
 
     it('calls onChange when changing the predicate', async () => {
-        const user = userEvent.setup({delay: null});
+        const user = userEvent.setup({advanceTimers: vi.advanceTimersByTime});
         const onChange = vi.fn();
         render(
             <Table
@@ -96,33 +96,18 @@ describe('Table.Predicate', () => {
             </Table>
         );
 
-        await waitFor(() => {
-            expect(
-                screen.getByRole('searchbox', {
-                    name: 'rank',
-                })
-            ).toHaveValue('Second');
+        expect(screen.getByRole('searchbox', {name: 'rank'})).toHaveValue('Second');
+
+        await user.click(screen.getByRole('searchbox', {name: 'rank'}));
+
+        await user.click(screen.getByRole('option', {name: 'First'}));
+
+        expect(screen.getByRole('searchbox', {name: 'rank'})).toHaveValue('First');
+        act(() => {
+            vi.advanceTimersByTime(500);
         });
 
-        await user.click(
-            screen.getByRole('searchbox', {
-                name: 'rank',
-            })
-        );
-
-        await user.click(
-            screen.getByRole('option', {
-                name: 'First',
-            })
-        );
-
-        expect(
-            screen.getByRole('searchbox', {
-                name: 'rank',
-            })
-        ).toHaveValue('First');
-        vi.advanceTimersByTime(500);
-
+        expect(onChange).toHaveBeenCalledTimes(1);
         expect(onChange).toHaveBeenCalledWith(expect.objectContaining({predicates: {rank: 'first'}}));
     });
 });


### PR DESCRIPTION
### Proposed Changes

When using a Table.Predicate component within a Table, changing the predicate value would call the `onChange` prop twice. The fix of this PR is to make sure `onChange` prop gets called only once when selecting a new predicate value.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
