### PR TITLE
feat(table clear filters): clearing the date range

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -16,13 +16,13 @@ import {TableDateRangePicker} from './TableDateRangePicker';
 import {TableFilter} from './TableFilter';
 import {TableFooter} from './TableFooter';
 import {TableHeader} from './TableHeader';
+import {TableLoading} from './TableLoading';
 import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
 import {TableSelectableColumn} from './TableSelectableColumn';
-import {useRowSelection} from './useRowSelection';
-import {TableLoading} from './TableLoading';
 import {TableLayouts} from './layouts/TableLayouts';
+import {useRowSelection} from './useRowSelection';
 
 export const Table: TableType = <T,>({
     data,
@@ -86,7 +86,9 @@ export const Table: TableType = <T,>({
         !!form.values.dateRange?.[0] ||
         !!form.values.dateRange?.[1];
 
-    const triggerChange = debounce(() => onChange?.({...state, ...form.values}), 500);
+    const triggerChange = debounce(() => {
+        onChange?.({...state, ...form.values});
+    }, 500);
 
     useEffect(() => {
         onMount?.({...state, ...form.values});
@@ -110,6 +112,7 @@ export const Table: TableType = <T,>({
 
     const clearFilters = useCallback(() => {
         form.setFieldValue('predicates', initialState.predicates ?? {});
+        form.setFieldValue('dateRange', initialState.dateRange ?? [null, null]);
         setState((prevState) => ({...prevState, globalFilter: ''}));
     }, []);
 


### PR DESCRIPTION
### Proposed Changes

**scope:** The Mantine Table clearFilters functionnality

If the table uses a date picker, the `clearFilters` function returned from the `useTable` hook will now reset the dateRange of the table to its initial state or set it to null if there was not date initial state.

### How to test it

Go to the generated demo in the table panel. You can modify the date range of the first table there, but since the dateRange will not affect the result per say (beside refetching), you can apply `pwell pwell` in the classic filter to trigger the empty state with the clear filter button.  If you click on the button you will see that the dateRange will be reset to its original state.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests **(The behavior can be tested through the DEMO page easily, beside that I would have to test the implementation to make sure it works. I could do it, but right now there is no such test for any other hook.)**
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
