### PR TITLE
ci: accelerate CI by not building before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,14 @@ jobs:
               with:
                   WORKFLOW: 'ci'
     test:
-        name: Build and Test
+        name: Test
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
             - uses: ./.github/actions/setup
-            - uses: ./.github/actions/build
             - uses: ./.github/actions/test
     demo:
-        name: Deploy Demo
+        name: Build & Deploy Demo
         runs-on: ubuntu-latest
         permissions:
             pull-requests: write

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
             "outputMode": "new-only"
         },
         "test": {
-            "dependsOn": ["build"],
+            "dependsOn": ["^build"],
             "outputs": [],
             "inputs": ["src/**/*.spec.*"],
             "outputMode": "new-only"


### PR DESCRIPTION
### Proposed Changes

We were `build`ing the app before running the tests which is unnecessary, because we already build during the demo deployment job. The `test` command builds the necessary dependencies for the test execution thanks to the `turbo` configuration. The `Test` check should be 2-3 minutes faster now, because building the website took a lot of time and we won't have to do that anymore.

| Before | After |
| --- | --- |
| ![image](https://github.com/coveo/plasma/assets/35579930/6e78aea6-7ba7-4bf6-b8a9-faa65f571eb9) | ![image](https://github.com/coveo/plasma/assets/35579930/56646506-407f-438f-85b7-6dcef2ba7efd) |

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
