### PR TITLE
feat(mantine, table): improve the style and UX

### DIFF
--- a/packages/mantine/src/components/table/Table.styles.ts
+++ b/packages/mantine/src/components/table/Table.styles.ts
@@ -3,15 +3,6 @@ import {createStyles} from '@mantine/core';
 const useStyles = createStyles<string>((theme) => ({
     table: {
         width: '100%',
-        '& thead tr th': {
-            borderBottom: 'none',
-        },
-        '& td:first-of-type': {
-            paddingLeft: theme.spacing.xl,
-        },
-        '& tbody td': {
-            verticalAlign: 'top',
-        },
     },
 
     header: {

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -4,8 +4,9 @@ import {useDidUpdate} from '@mantine/hooks';
 import {ColumnDef, Row, TableState as TanstackTableState, getCoreRowModel, useReactTable} from '@tanstack/react-table';
 import debounce from 'lodash.debounce';
 import defaultsDeep from 'lodash.defaultsdeep';
-import {Children, Dispatch, ReactElement, useCallback, useEffect, useState} from 'react';
+import {Children, cloneElement, Dispatch, ReactElement, useCallback, useEffect, useState} from 'react';
 
+import {TableLayouts} from './layouts/TableLayouts';
 import useStyles from './Table.styles';
 import {TableFormType, TableProps, TableState, TableType} from './Table.types';
 import {TableActions} from './TableActions';
@@ -16,13 +17,13 @@ import {TableDateRangePicker} from './TableDateRangePicker';
 import {TableFilter} from './TableFilter';
 import {TableFooter} from './TableFooter';
 import {TableHeader} from './TableHeader';
+import {TableLastUpdated} from './TableLastUpdated';
+import {TableLoading} from './TableLoading';
 import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
 import {TableSelectableColumn} from './TableSelectableColumn';
 import {useRowSelection} from './useRowSelection';
-import {TableLoading} from './TableLoading';
-import {TableLayouts} from './layouts/TableLayouts';
 
 export const Table: TableType = <T,>({
     data,
@@ -46,6 +47,7 @@ export const Table: TableType = <T,>({
     const header = convertedChildren.find((child) => child.type === TableHeader);
     const footer = convertedChildren.find((child) => child.type === TableFooter);
     const consumer = convertedChildren.find((child) => child.type === TableConsumer);
+    const lastUpdated = convertedChildren.find((child) => child.type === TableLastUpdated);
 
     const {predicates, dateRange, ...initialStateWithoutForm} = initialState;
     const form = useForm<TableFormType>({
@@ -187,6 +189,11 @@ export const Table: TableType = <T,>({
                             </tbody>
                         </MantineTable>
                         {footer}
+                        {lastUpdated
+                            ? cloneElement(lastUpdated, {
+                                  dependencies: [data, ...(lastUpdated.props.dependencies ?? [])],
+                              })
+                            : null}
                     </>
                 )}
             </TableContext.Provider>
@@ -198,6 +205,7 @@ Table.Actions = TableActions;
 Table.Filter = TableFilter;
 Table.Footer = TableFooter;
 Table.Header = TableHeader;
+Table.LastUpdated = TableLastUpdated;
 Table.Pagination = TablePagination;
 Table.Predicate = TablePredicate;
 Table.PerPage = TablePerPage;

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -1,7 +1,7 @@
-import {Box, Center, Loader, Table as MantineTable} from '@mantine/core';
+import {Box, Center, Loader} from '@mantine/core';
 import {useForm} from '@mantine/form';
 import {useDidUpdate} from '@mantine/hooks';
-import {ColumnDef, Row, TableState as TanstackTableState, getCoreRowModel, useReactTable} from '@tanstack/react-table';
+import {ColumnDef, getCoreRowModel, Row, TableState as TanstackTableState, useReactTable} from '@tanstack/react-table';
 import debounce from 'lodash.debounce';
 import defaultsDeep from 'lodash.defaultsdeep';
 import {Children, cloneElement, Dispatch, ReactElement, useCallback, useEffect, useState} from 'react';
@@ -151,15 +151,11 @@ export const Table: TableType = <T,>({
                     noDataChildren
                 ) : (
                     <>
-                        <MantineTable className={classes.table} horizontalSpacing="sm" verticalSpacing="xs" pb="sm">
+                        <Box component="table" className={classes.table} pb="sm">
                             <thead className={classes.header}>
                                 {!!header ? (
                                     <tr>
-                                        <th
-                                            // need to use inline style because Mantine define style on `.mantine-{id} thead tr th`
-                                            style={{padding: 0, fontWeight: 'unset'}}
-                                            colSpan={table.getAllColumns().length}
-                                        >
+                                        <th style={{padding: 0}} colSpan={table.getAllColumns().length}>
                                             {header}
                                         </th>
                                     </tr>
@@ -187,7 +183,7 @@ export const Table: TableType = <T,>({
                                     </tr>
                                 )}
                             </tbody>
-                        </MantineTable>
+                        </Box>
                         {footer}
                         {lastUpdated
                             ? cloneElement(lastUpdated, {

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -1,16 +1,17 @@
+import {Icon} from '@coveord/plasma-react-icons';
 import {UseFormReturnType} from '@mantine/form';
 import {
     ColumnDef,
     CoreOptions,
+    InitialTableState as TanstackInitialTableState,
     Table,
     TableOptions,
-    InitialTableState as TanstackInitialTableState,
     TableState as TanstackTableState,
 } from '@tanstack/table-core';
 import {Dispatch, ReactElement, ReactNode, RefObject} from 'react';
 
-import {Icon} from '@coveord/plasma-react-icons';
 import {DateRangePickerValue} from '../date-range-picker/DateRangePickerInlineCalendar';
+import {TableLayouts} from './layouts/TableLayouts';
 import {TableActions} from './TableActions';
 import {TableAccordionColumn, TableCollapsibleColumn} from './TableCollapsibleColumn';
 import {TableConsumer} from './TableConsumer';
@@ -18,11 +19,11 @@ import {TableDateRangePicker} from './TableDateRangePicker';
 import {TableFilter} from './TableFilter';
 import {TableFooter} from './TableFooter';
 import {TableHeader} from './TableHeader';
+import {TableLastUpdated} from './TableLastUpdated';
 import {TableLoading} from './TableLoading';
 import {TablePagination} from './TablePagination';
 import {TablePerPage} from './TablePerPage';
 import {TablePredicate} from './TablePredicate';
-import {TableLayouts} from './layouts/TableLayouts';
 
 export type RowSelectionWithData<TData> = Record<string, TData>;
 export interface RowSelectionState<TData> {
@@ -268,6 +269,7 @@ export interface TableType {
     Filter: typeof TableFilter;
     Footer: typeof TableFooter;
     Header: typeof TableHeader;
+    LastUpdated: typeof TableLastUpdated;
     Pagination: typeof TablePagination;
     PerPage: typeof TablePerPage;
     Predicate: typeof TablePredicate;

--- a/packages/mantine/src/components/table/TableFooter.tsx
+++ b/packages/mantine/src/components/table/TableFooter.tsx
@@ -5,7 +5,7 @@ interface TableFooterProps extends DefaultProps {
     children?: ReactNode;
 }
 export const TableFooter: FunctionComponent<TableFooterProps> = ({children, ...others}) => (
-    <Group position="apart" px="md" py="sm" {...others}>
+    <Group position="apart" px="xl" py="md" {...others}>
         {children}
     </Group>
 );

--- a/packages/mantine/src/components/table/TableHeader.tsx
+++ b/packages/mantine/src/components/table/TableHeader.tsx
@@ -15,7 +15,7 @@ const useStyles = createStyles((theme) => ({
         borderBottom: `1px solid ${theme.colors.gray[3]}`,
     },
     multiSelectInfo: {
-        justifySelf: 'flex-start',
+        display: 'flex',
     },
 }));
 

--- a/packages/mantine/src/components/table/TableLastUpdated.tsx
+++ b/packages/mantine/src/components/table/TableLastUpdated.tsx
@@ -1,0 +1,51 @@
+import {createStyles, DefaultProps, Group, Selectors, Text} from '@mantine/core';
+import {useDidUpdate} from '@mantine/hooks';
+import dayjs from 'dayjs';
+import {FunctionComponent, useState} from 'react';
+import {useTable} from './TableContext';
+
+const useStyles = createStyles((theme) => ({
+    root: {
+        minHeight: '98px',
+    },
+    label: {
+        color: theme.colors.gray[6],
+    },
+}));
+
+type TableLastUpdatedStylesNames = Selectors<typeof useStyles>;
+
+interface TableLastUpdatedProps extends DefaultProps<TableLastUpdatedStylesNames> {
+    /**
+     * Label to contextualize the date
+     *
+     * @default "Last update:"
+     */
+    label?: string;
+}
+
+export const TableLastUpdated: FunctionComponent<TableLastUpdatedProps & {dependencies?: never}> = ({
+    label = 'Last update:',
+    dependencies,
+    classNames,
+    styles,
+    unstyled,
+    ...others
+}) => {
+    const {classes} = useStyles(null, {name: 'TableLastUpdated', classNames, styles, unstyled});
+    const {state} = useTable();
+    const [time, setTime] = useState(new Date());
+
+    useDidUpdate(() => {
+        setTime(new Date());
+    }, [state, ...dependencies]);
+
+    return (
+        <Group className={classes.root} px="xl" position="right">
+            <Text size="xs" className={classes.label} {...others}>
+                {label}
+                <span role="timer">{dayjs(time).format('h:mm:ss A')}</span>
+            </Text>
+        </Group>
+    );
+};

--- a/packages/mantine/src/components/table/TablePagination.tsx
+++ b/packages/mantine/src/components/table/TablePagination.tsx
@@ -29,6 +29,7 @@ export const TablePagination: FunctionComponent<TablePaginationProps> = ({totalP
             total={total}
             boundaries={0}
             size="md"
+            spacing="xs"
             getControlProps={(control) => {
                 switch (control) {
                     case 'previous':

--- a/packages/mantine/src/components/table/TablePerPage.tsx
+++ b/packages/mantine/src/components/table/TablePerPage.tsx
@@ -32,14 +32,14 @@ export const TablePerPage: FunctionComponent<TablePerPageProps> & {DEFAULT_SIZE:
     };
 
     return (
-        <Group>
-            <Text>{label}</Text>
+        <Group spacing="sm">
+            <Text fw={500}>{label}</Text>
             <SegmentedControl
                 value={state.pagination.pageSize.toString() ?? values?.[1].toString()}
                 onChange={updatePerPage}
                 data={values.map((value) => value.toString())}
                 color="action"
-                size="md"
+                size="sm"
             />
         </Group>
     );

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -1,9 +1,9 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
-import {render, screen, userEvent, waitFor} from '@test-utils';
+import {render, screen, userEvent, waitFor, within} from '@test-utils';
 
 import {Table} from '../Table';
-import {useTable} from '../TableContext';
 import {TableLayout} from '../Table.types';
+import {useTable} from '../TableContext';
 
 type RowData = {id: string; firstName: string; lastName?: string};
 
@@ -243,13 +243,13 @@ describe('Table', () => {
                     onRowSelectionChange={onRowSelectionChangeSpy}
                 />
             );
-            await user.click(screen.getByRole('row', {name: /jane doe/i}));
+            await user.click(within(screen.getByRole('row', {name: /jane doe/i})).getByRole('checkbox'));
             expect(onRowSelectionChangeSpy).toHaveBeenCalledTimes(1);
             expect(onRowSelectionChangeSpy).toHaveBeenCalledWith([{id: '🆔-2', firstName: 'Jane', lastName: 'Doe'}]);
 
             onRowSelectionChangeSpy.mockClear();
 
-            await user.click(screen.getByRole('row', {name: /john smith/i}));
+            await user.click(within(screen.getByRole('row', {name: /john smith/i})).getByRole('checkbox'));
             expect(onRowSelectionChangeSpy).toHaveBeenCalledTimes(1);
             expect(onRowSelectionChangeSpy).toHaveBeenCalledWith([
                 {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
@@ -284,7 +284,7 @@ describe('Table', () => {
 
             expect(row).toBeInTheDocument();
 
-            await user.click(row);
+            await user.click(within(row).getByRole('checkbox'));
 
             expect(screen.getByRole('row', {name: /patate king/i, selected: true})).toBeInTheDocument();
 

--- a/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
@@ -1,5 +1,5 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
-import {render, screen, userEvent} from '@test-utils';
+import {render, screen, userEvent, within} from '@test-utils';
 
 import {Button} from '../../button';
 import {Table} from '../Table';
@@ -57,6 +57,7 @@ describe('Table.Actions', () => {
             const renderSpy = vi.fn().mockImplementation(() => <div />);
             render(
                 <Table<RowData>
+                    getRowId={(row) => row.name}
                     data={[{name: 'fruit'}, {name: 'vegetable'}, {name: 'bread'}]}
                     columns={columns}
                     multiRowSelectionEnabled
@@ -66,8 +67,8 @@ describe('Table.Actions', () => {
                     </Table.Header>
                 </Table>
             );
-            await user.click(screen.getByRole('cell', {name: 'fruit'}));
-            await user.click(screen.getByRole('cell', {name: 'vegetable'}));
+            await user.click(within(screen.getByRole('row', {name: /fruit/})).getByRole('checkbox'));
+            await user.click(within(screen.getByRole('row', {name: /vegetable/})).getByRole('checkbox'));
             expect(renderSpy).toHaveBeenCalledWith([{name: 'fruit'}, {name: 'vegetable'}]);
         });
     });

--- a/packages/mantine/src/components/table/__tests__/TableLastUpdated.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableLastUpdated.spec.tsx
@@ -1,0 +1,97 @@
+import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
+import {render, screen, userEvent} from '@test-utils';
+import {useState} from 'react';
+
+import {Table} from '../Table';
+
+type RowData = {name: string};
+
+const columnHelper = createColumnHelper<RowData>();
+const columns: Array<ColumnDef<RowData>> = [columnHelper.accessor('name', {enableSorting: false})];
+
+describe('Table.LastUpdated', () => {
+    beforeEach(() => {
+        vi.useFakeTimers().setSystemTime(new Date(2022, 0, 15, 13, 5, 50));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('displays the label and time', () => {
+        const {rerender} = render(
+            <Table data={[{name: 'fruit'}]} columns={columns}>
+                <Table.LastUpdated />
+            </Table>
+        );
+
+        expect(screen.getByText('Last update:')).toBeVisible();
+        expect(screen.getByRole('timer')).toHaveTextContent('1:05:50 PM');
+
+        rerender(
+            <Table data={[{name: 'fruit'}]} columns={columns}>
+                <Table.LastUpdated label="CUSTOM label:" />
+            </Table>
+        );
+
+        expect(screen.queryByText('Last update:')).not.toBeInTheDocument();
+        expect(screen.getByText('CUSTOM label:')).toBeVisible();
+        expect(screen.getByRole('timer')).toHaveTextContent('1:05:50 PM');
+    });
+
+    it('updates the time when a dependency changes', async () => {
+        const user = userEvent.setup({delay: null});
+
+        // Using a fixture to have a button that will trigger a change of a dependency
+        const Fixture = () => {
+            const [isClicked, setIsClicked] = useState(false);
+            return (
+                <>
+                    <button onClick={() => setIsClicked(true)}>Click me</button>
+                    <Table data={[{name: 'fruit'}]} columns={columns}>
+                        <Table.LastUpdated dependencies={[isClicked]} />
+                    </Table>
+                </>
+            );
+        };
+        render(<Fixture />);
+
+        expect(screen.getByText('Last update:')).toBeVisible();
+        expect(screen.getByRole('timer')).toHaveTextContent('1:05:50 PM');
+
+        vi.setSystemTime(new Date(2022, 0, 15, 14, 11, 22));
+
+        // the date changed but the dependency didn't change yet, so the timer is still the same
+        expect(screen.getByRole('timer')).toHaveTextContent('1:05:50 PM');
+
+        // When we click on the button the isClicked switch from false to true which triggers an update
+        await user.click(screen.getByRole('button', {name: 'Click me'}));
+        expect(screen.getByRole('timer')).toHaveTextContent('2:11:22 PM');
+    });
+
+    it('updates the time when the data changes', async () => {
+        const user = userEvent.setup({delay: null});
+        const Fixture = () => {
+            const [data, setData] = useState([{name: 'fruit'}]);
+            return (
+                <>
+                    <button onClick={() => setData([{name: 'vegetable'}])}>Click me</button>
+                    <Table data={data} columns={columns}>
+                        <Table.LastUpdated />
+                    </Table>
+                </>
+            );
+        };
+        render(<Fixture />);
+
+        expect(screen.getByRole('timer')).toHaveTextContent('1:05:50 PM');
+
+        vi.setSystemTime(new Date(2022, 0, 15, 14, 11, 22));
+
+        expect(screen.getByRole('timer')).toHaveTextContent('1:05:50 PM');
+
+        await user.click(screen.getByRole('button', {name: 'Click me'}));
+
+        expect(screen.getByRole('timer')).toHaveTextContent('2:11:22 PM');
+    });
+});

--- a/packages/website/src/examples/layout/Table/TableConsumer.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableConsumer.demo.tsx
@@ -52,6 +52,7 @@ const Demo = () => {
                 {/* Refresh the component every 10s, look at your network tab to validate it works */}
                 <IntervalRefresh every={10 * 1000} />
             </Table.Consumer>
+            <Table.LastUpdated />
         </Table>
     );
 };


### PR DESCRIPTION
### Proposed Changes

Updated the look of the table to match UX requirements. There are a few behaviour changes on row click:
- Display the actions
- If row is collapsible, row expand as user clicks anywhere on the row or on the cell containing the chevron
- If multiRowSelectionEnabled, checkbox is only ticked if the user clicks on the cell containing the checkbox or within the checkbox itself instead of anywhere on the row

I replaced the Table from Mantine with a `<Box component="table">` and a bit of style since we were fighting it and not really benefiting from the implementation

### Potential Breaking Changes

See behaviour change above

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
