### PR TITLE
fix(mantine, date picker): change height of preset dropdown

### DIFF
--- a/packages/mantine/src/components/date-range-picker/DateRangePickerPresetSelect.tsx
+++ b/packages/mantine/src/components/date-range-picker/DateRangePickerPresetSelect.tsx
@@ -57,6 +57,7 @@ export const DateRangePickerPresetSelect = <T extends unknown>({
             value={selectedPreset}
             onChange={onChangePreset}
             data={selectData}
+            maxDropdownHeight={240}
         />
     );
 };


### PR DESCRIPTION
### Proposed Changes

Changed the height of the dropdown to make it crop a value in half if there is more than 5 values. Previously it was displaying exactly 5 values which confused some users

| Before | After |
|-------|-------|
| <img width="661" alt="image" src="https://github.com/coveo/plasma/assets/260007/f0214622-bfd1-4aca-a432-e7a6c8630908"> | <img width="661" alt="image" src="https://github.com/coveo/plasma/assets/260007/f8a0cf3e-f47c-45d4-9fb1-4c95e247f54b"> |

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
