### PR TITLE
feat(mantine, table): improve click outside table row selection

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -41,6 +41,7 @@ export const Table: TableType = <T,>({
     multiRowSelectionEnabled,
     disableRowSelection,
     onRowSelectionChange,
+    additionalRootNodes,
     options = {},
 }: TableProps<T>) => {
     const convertedChildren = Children.toArray(children) as ReactElement[];
@@ -84,6 +85,7 @@ export const Table: TableType = <T,>({
     const {clearSelection, getSelectedRow, getSelectedRows, outsideClickRef} = useRowSelection(table, {
         multiRowSelectionEnabled,
         onRowSelectionChange,
+        additionalRootNodes,
     });
     const isFiltered =
         !!state.globalFilter ||

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -247,6 +247,15 @@ export interface TableProps<T> {
      */
     disableRowSelection?: boolean;
     /**
+     * Nodes that are considered inside the table.
+     *
+     * Rows normally get unselected when clicking outside the table, but sometimes it has difficulties guessing what is inside or outside, for example when using modals.
+     * You can use this prop to force the table to consider some nodes to be inside the table.
+     *
+     * @see https://mantine.dev/hooks/use-click-outside/#multiple-nodes
+     */
+    additionalRootNodes?: HTMLElement[];
+    /**
      * Additional options that can be passed to the table
      */
     options?: Omit<

--- a/packages/mantine/src/components/table/useRowSelection.ts
+++ b/packages/mantine/src/components/table/useRowSelection.ts
@@ -2,6 +2,7 @@ import {useClickOutside} from '@mantine/hooks';
 import {functionalUpdate, RowSelectionState, Table} from '@tanstack/table-core';
 import isEqual from 'fast-deep-equal';
 
+import {useRef} from 'react';
 import {RowSelectionWithData, TableProps, TableState} from './Table.types';
 
 export const useRowSelection = <T>(
@@ -9,13 +10,19 @@ export const useRowSelection = <T>(
     {
         onRowSelectionChange,
         multiRowSelectionEnabled,
-    }: Pick<TableProps<T>, 'onRowSelectionChange' | 'multiRowSelectionEnabled'>
+        additionalRootNodes = [],
+    }: Pick<TableProps<T>, 'onRowSelectionChange' | 'multiRowSelectionEnabled' | 'additionalRootNodes'>
 ) => {
-    const outsideClickRef = useClickOutside(() => {
-        if (!multiRowSelectionEnabled) {
-            clearSelection();
-        }
-    });
+    const outsideClickRef = useRef<HTMLDivElement>();
+    useClickOutside(
+        () => {
+            if (!multiRowSelectionEnabled) {
+                clearSelection();
+            }
+        },
+        null,
+        [outsideClickRef.current, ...additionalRootNodes]
+    );
 
     table.setOptions((prev) => ({
         ...prev,


### PR DESCRIPTION
### Proposed Changes

Allow having elements outside the table that won't unselect rows when clicking on them.

There is no demo for it in the actual website, but I added a unit test for it and here's how it looks in a real use case.

Before

https://github.com/coveo/plasma/assets/35579930/2cad5e26-3a77-449b-ab90-8f3de4373625

After

https://github.com/coveo/plasma/assets/35579930/d4f48194-5079-4efb-9647-f47bcf60e089


### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
