### PR TITLE
fix(mantine): avoid CodeEditor errors onFocus

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -193,7 +193,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                 onMount={(editor, monaco) => {
                     editorRef.current = editor;
                     registerLanguages(monaco);
-                    editor.onDidFocusEditorText(onFocus);
+                    editor.onDidFocusEditorText(() => onFocus?.());
                     editor.onDidBlurEditorText(async () => {
                         await editor.getAction('editor.action.formatDocument').run();
                     });


### PR DESCRIPTION
### Proposed Changes

When `onFocus` prop isn't specified on the `CodeEditor` component, it sets `undefined` as callback to the focus event, which leads to this error being printed in the console whenever you focus in the code editor. 

```console
errors.js:15 Uncaught Error: Cannot read properties of undefined (reading 'call')

TypeError: Cannot read properties of undefined (reading 'call')
    at Listener.invoke (event.js:648:23)
    at EventDeliveryQueue.deliver (event.js:829:34)
    at Emitter.fire (event.js:794:33)
    at BooleanEventEmitter.setValue (codeEditorWidget.js:1379:37)
    at codeEditorWidget.js:1140:43
    at Listener.invoke (event.js:648:23)
    at PrivateEventDeliveryQueue.deliver (event.js:829:34)
    at Emitter.fire (event.js:794:33)
    at ViewModelEventDispatcher._emitOutgoingEvents (viewModelEventDispatcher.js:44:27)
    at ViewModelEventDispatcher.emitOutgoingEvent (viewModelEventDispatcher.js:21:14)
    at errors.js:15:27
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
