### PR TITLE
feat(mantine, table): add data-testid attributes on rows and cells

### DIFF
--- a/packages/mantine/src/components/table/layouts/RowLayout.tsx
+++ b/packages/mantine/src/components/table/layouts/RowLayout.tsx
@@ -127,6 +127,7 @@ const RowLayoutBody = <T,>({table, doubleClickAction, getExpandChildren, loading
                         [classes.rowUnselectable]: disableRowSelection,
                     })}
                     aria-selected={isSelected}
+                    data-testid={row.id}
                 >
                     {row.getVisibleCells().map((cell) => {
                         const size = cell.column.getSize();
@@ -140,6 +141,7 @@ const RowLayoutBody = <T,>({table, doubleClickAction, getExpandChildren, loading
                         return (
                             <td
                                 key={cell.id}
+                                data-testid={cell.id}
                                 style={{width}}
                                 className={cx(classes.cell, {
                                     [classes.rowCollapsibleButtonCell]: cell.column.id === TableCollapsibleColumn.id,

--- a/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
@@ -58,6 +58,31 @@ describe('RowLayout', () => {
         expect(screen.getByRole('cell', {name: 'LAST'})).toBeVisible();
     });
 
+    it('adds testid on the data', () => {
+        const customColumns: Array<ColumnDef<RowData>> = [
+            columnHelper.accessor('firstName', {}),
+            columnHelper.accessor('lastName', {}),
+        ];
+        render(
+            <Table
+                getRowId={({id}) => id}
+                data={[
+                    {id: 'ash', firstName: 'Ash', lastName: 'Ketchum'},
+                    {id: 'gary', firstName: 'Gary', lastName: 'Oak'},
+                ]}
+                columns={customColumns}
+            />
+        );
+
+        expect(screen.getByTestId('ash')).toBeVisible();
+        expect(screen.getByTestId('ash_firstName')).toHaveTextContent('Ash');
+        expect(screen.getByTestId('ash_lastName')).toHaveTextContent('Ketchum');
+
+        expect(screen.getByTestId('gary')).toBeVisible();
+        expect(screen.getByTestId('gary_firstName')).toHaveTextContent('Gary');
+        expect(screen.getByTestId('gary_lastName')).toHaveTextContent('Oak');
+    });
+
     it('opens the collapsible rows when the user click on the toggle', async () => {
         const user = userEvent.setup();
         const Fixture: FunctionComponent<{row: RowData}> = ({row}) => <div>Collapsible content: {row.lastName}</div>;


### PR DESCRIPTION
### Proposed Changes

Added data-testid attribute on table rows and cells. It creates a better developper experience because it's easier to access the table data with code

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
