### PR TITLE
fix(react): type issue in component constructor

### DIFF
--- a/packages/react/src/components/dropdownSearch/DropdownSearchAutoInfiniteScroll.tsx
+++ b/packages/react/src/components/dropdownSearch/DropdownSearchAutoInfiniteScroll.tsx
@@ -26,7 +26,7 @@ export class DropdownSearchAutoInfiniteScroll extends Component<
     IDropdownSearchAutoInfiniteScrollProps,
     IDropdownSearchAutoInfiniteScrollState
 > {
-    constructor(props: IDropdownSearchAutoInfiniteScrollProps, state: IDropdownSearchAutoInfiniteScrollState) {
+    constructor(props: IDropdownSearchAutoInfiniteScrollProps) {
         super(props);
         this.state = {
             activeOptions: props.options.slice(0, props.optionsPerPage),

--- a/packages/react/src/components/input/Input.tsx
+++ b/packages/react/src/components/input/Input.tsx
@@ -15,7 +15,6 @@ import {IClassName} from '../../utils/ClassNameUtils';
 import {PropsToOmitUtils} from '../../utils/PropsToOmitUtils';
 import {TooltipPlacement} from '../../utils/TooltipUtils';
 import {Tooltip} from '../tooltip/Tooltip';
-import {IInputState} from './InputReducers';
 import {ILabelProps, Label} from './Label';
 import {PlasmaState} from '../../PlasmaState';
 import {InputSelectors} from './InputSelectors';
@@ -124,8 +123,8 @@ export class Input extends Component<IInputProps, IInputComponentState> {
         isReadOnly: false,
     };
 
-    constructor(props: IInputProps, state: IInputState) {
-        super(props, state);
+    constructor(props: IInputProps) {
+        super(props);
         this.state = {
             valid: this.props.valid,
         };

--- a/packages/react/src/components/multilineBox/MultilineBox.tsx
+++ b/packages/react/src/components/multilineBox/MultilineBox.tsx
@@ -133,8 +133,8 @@ class MultilineBoxDisconnected<T> extends PureComponent<IMultilineBoxProps<T>> {
         defaultProps: {},
     };
 
-    constructor(props: IMultilineBoxProps<T>, state: any) {
-        super(props, state);
+    constructor(props: IMultilineBoxProps<T>) {
+        super(props);
 
         this.initialData = this.getInitialDataMappedWithBoxIDs();
     }

--- a/packages/react/src/components/multilineInput/SplitMultilineInput.tsx
+++ b/packages/react/src/components/multilineInput/SplitMultilineInput.tsx
@@ -36,8 +36,8 @@ export interface ISplitMultilineInputState {
 export class SplitMultilineInput extends PureComponent<ISplitMultilineInputProps, ISplitMultilineInputState> {
     static inputLineClass: string = 'flex space-between relative pb1';
 
-    constructor(props: ISplitMultilineInputProps, state: ISplitMultilineInputState) {
-        super(props, state);
+    constructor(props: ISplitMultilineInputProps) {
+        super(props);
         this.state = {
             values: this.props.defaultValues,
         };

--- a/packages/react/src/components/popover/Popover.tsx
+++ b/packages/react/src/components/popover/Popover.tsx
@@ -65,8 +65,8 @@ export class Popover extends Component<IPopoverProps, IPopoverState> {
     private tetherToggle: RefObject<HTMLDivElement>;
     private tetherElement: RefObject<HTMLDivElement>;
 
-    constructor(props: IPopoverProps, state: IPopoverState) {
-        super(props, state);
+    constructor(props: IPopoverProps) {
+        super(props);
 
         this.tetherToggle = createRef();
         this.tetherElement = createRef();


### PR DESCRIPTION
### Proposed Changes

While bumping to the most recent version of plasma-react I got a few type errors with some components. E.g.,:

```
error TS2786: 'Input' cannot be used as a JSX component.
  Its type 'typeof Input' is not a valid JSX element type.
    Type 'typeof Input' is not assignable to type 'new (props: any) => Component<any, any, any>'.
      Types of construct signatures are incompatible.
        Type 'new (props: IInputProps, state: IInputState) => Input' is not assignable to type 'new (props: any) => Component<any, any, any>'.
          Target signature provides too few arguments. Expected 2 or more, but got 1.
```

I verified [React's doc](https://react.dev/reference/react/Component#constructor) and we don't have to add the state to the constructor arguments

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
