### PR TITLE
fix(table): column width

### DIFF
--- a/packages/mantine/src/components/table/Th.tsx
+++ b/packages/mantine/src/components/table/Th.tsx
@@ -2,7 +2,7 @@ import {ArrowDownSize16Px, ArrowUpSize16Px, DoubleArrowHeadVSize16Px} from '@cov
 import {Center, Group, Text, UnstyledButton, createStyles} from '@mantine/core';
 import {Header, defaultColumnSizing, flexRender} from '@tanstack/react-table';
 
-const useStyles = createStyles((theme, width: number) => ({
+const useStyles = createStyles((theme, columnSizing: {size: number; minSize: number; maxSize: number}) => ({
     th: {
         fontWeight: '400 !important' as any,
         padding: '0 !important',
@@ -11,7 +11,9 @@ const useStyles = createStyles((theme, width: number) => ({
         textAlign: 'left',
         color: theme.colors.gray[6],
         backgroundColor: theme.colorScheme === 'dark' ? theme.colors.gray[8] : theme.colors.gray[0],
-        width,
+        width: columnSizing.size,
+        minWidth: columnSizing.minSize,
+        maxWidth: columnSizing.maxSize,
     },
 
     control: {
@@ -43,9 +45,14 @@ const SortingLabels = {
 } as const;
 
 export const Th = <T,>({header}: ThProps<T>) => {
-    const size = header.column.getSize();
-    const width = size !== defaultColumnSizing.size ? size : undefined;
-    const {classes} = useStyles(width);
+    const columnSizing = {
+        ...defaultColumnSizing,
+        size: header.column.columnDef.size,
+        minSize: header.column.columnDef.minSize,
+        maxSize: header.column.columnDef.maxSize,
+    };
+
+    const {classes} = useStyles(columnSizing);
 
     if (header.isPlaceholder) {
         return null;

--- a/packages/mantine/src/components/table/layouts/RowLayout.tsx
+++ b/packages/mantine/src/components/table/layouts/RowLayout.tsx
@@ -130,8 +130,13 @@ const RowLayoutBody = <T,>({table, doubleClickAction, getExpandChildren, loading
                     data-testid={row.id}
                 >
                     {row.getVisibleCells().map((cell) => {
-                        const size = cell.column.getSize();
-                        const width = size !== defaultColumnSizing.size ? size : undefined;
+                        const columnSizing = {
+                            ...defaultColumnSizing,
+                            size: cell.column.columnDef.size,
+                            minSize: cell.column.columnDef.minSize,
+                            maxSize: cell.column.columnDef.maxSize,
+                        };
+
                         const onCollapsibleCellClick = (event: MouseEvent<HTMLTableCellElement>) => {
                             if (cell.column.id === TableSelectableColumn.id && !disableRowSelection) {
                                 event.stopPropagation();
@@ -142,7 +147,11 @@ const RowLayoutBody = <T,>({table, doubleClickAction, getExpandChildren, loading
                             <td
                                 key={cell.id}
                                 data-testid={cell.id}
-                                style={{width}}
+                                style={{
+                                    width: columnSizing.size,
+                                    minWidth: columnSizing.minSize,
+                                    maxWidth: columnSizing.maxSize,
+                                }}
                                 className={cx(classes.cell, {
                                     [classes.rowCollapsibleButtonCell]: cell.column.id === TableCollapsibleColumn.id,
                                 })}


### PR DESCRIPTION
### Proposed Changes

**Problem** 
By using the `getSize` hook to get the size of the column and applying that size to the width css property, we create a confusing situation where setting `minSize` or `maxSize` property on a table column will not respect what we would expect using proper css.

**Solution**
Getting the default sizing or the custom sizing if used, and set those as plain CSS.

**Before the fix**
![image](https://github.com/coveo/plasma/assets/45688129/c9657ffe-66cb-4a9c-beac-56a98b82fa5e)

**After the fix**
![image](https://github.com/coveo/plasma/assets/45688129/14cdaf04-296b-4a45-8b35-6796fd3d63f8)
![image](https://github.com/coveo/plasma/assets/45688129/d329eeee-1ec8-41cc-92de-1432c400da87)



**Disclaimer**
The solution does not change the default column layout of the table, no change will be seen unless custom width has been set on table column width. But if a custom width has been used, the new code will apply that styling to the CSS and this might change the table layout.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
