### PR TITLE
fix: trim whitespaces from filter box input

### DIFF
--- a/packages/react/src/components/filterBox/FilterBoxSelectors.ts
+++ b/packages/react/src/components/filterBox/FilterBoxSelectors.ts
@@ -10,7 +10,7 @@ export interface GetFilterTextProps {
 
 const getFilterText = (state: PlasmaState, props: GetFilterTextProps): string => {
     const filter: IFilterState = _.findWhere(state.filters, {id: props.id});
-    return (filter && filter.filterText) || '';
+    return (filter && filter.filterText.trim()) || '';
 };
 
 export interface GetMatchFilterTextProps {


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->
This PR allows the org picker to be more tolerant with white spaces.
I closed [this PR](https://github.com/coveo/admin-ui/pull/7559) in `admin-ui` and opened this one in `plasma` to allow other `FilterBoxSelectors` to be more tolerant.

`trim()` is used to remove leading and trailing white spaces in the input.

Before | After
-- | --
<img width="407" alt="before" src="https://github.com/coveo/plasma/assets/132406739/d574546e-1d44-4314-863f-c0ca3051dd23"> |  <img width="398" alt="after" src="https://github.com/coveo/plasma/assets/132406739/82aa073c-1f38-4fdd-ba83-30441bf5c107">




### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
