### PR TITLE
fix(mantine): remove table pagination when there are no pages

### DIFF
--- a/packages/mantine/src/components/table/TablePerPage.tsx
+++ b/packages/mantine/src/components/table/TablePerPage.tsx
@@ -29,7 +29,7 @@ export const TablePerPage: FunctionComponent<TablePerPageProps> & {DEFAULT_SIZE:
     values = [25, 50, 100],
     onPerPageChange,
 }) => {
-    const {state, setState} = useTable();
+    const {state, setState, getPageCount} = useTable();
 
     const updatePerPage = (newPerPage: string) => {
         onPerPageChange?.(Number(newPerPage));
@@ -39,7 +39,7 @@ export const TablePerPage: FunctionComponent<TablePerPageProps> & {DEFAULT_SIZE:
         }));
     };
 
-    return (
+    return getPageCount() > 0 ? (
         <Group spacing="sm">
             <Text fw={500}>{label}</Text>
             <SegmentedControl
@@ -50,7 +50,7 @@ export const TablePerPage: FunctionComponent<TablePerPageProps> & {DEFAULT_SIZE:
                 size="sm"
             />
         </Group>
-    );
+    ) : null;
 };
 
 TablePerPage.DEFAULT_SIZE = 50;

--- a/packages/mantine/src/components/table/__tests__/TablePagination.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TablePagination.spec.tsx
@@ -123,4 +123,15 @@ describe('Table.Pagination', () => {
             expect(onChangePage).toHaveBeenCalledWith(1);
         });
     });
+
+    it('renders nothing when there are no pages to show', () => {
+        render(
+            <Table data={[]} columns={columns} initialState={{globalFilter: 'filter'}}>
+                <Table.Footer data-testid="table-footer">
+                    <Table.Pagination totalPages={0} />
+                </Table.Footer>
+            </Table>
+        );
+        expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
+    });
 });

--- a/packages/mantine/src/components/table/__tests__/TablePerPage.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TablePerPage.spec.tsx
@@ -134,4 +134,15 @@ describe('Table.PerPage', () => {
             expect(onPerPageChange).toHaveBeenCalledWith(100);
         });
     });
+
+    it('renders nothing when there are no pages to show', () => {
+        render(
+            <Table data={[]} columns={columns} initialState={{globalFilter: 'filter'}}>
+                <Table.Footer data-testid="table-footer">
+                    <Table.PerPage />
+                </Table.Footer>
+            </Table>
+        );
+        expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
+    });
 });


### PR DESCRIPTION
### Proposed Changes

When a table has no data, the pagination controls should not be rendered because they serve no purpose. This PR fixes that.

You can test it out in the demo by going in the "Table" section, if you scroll down to the empty state example, you should see no pagination controls.

Before

<img width="1142" alt="image" src="https://github.com/coveo/plasma/assets/35579930/5d8574ae-042c-4246-9243-9c1c35359dd0">

After

<img width="1139" alt="image" src="https://github.com/coveo/plasma/assets/35579930/880f138c-473a-46aa-9f3d-5100770f2cac">


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
