### PR TITLE
chore(renovate): update config to group minors and patches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["config:base"],
+    "extends": ["config:base", "group:allNonMajor"],
     "timezone": "America/Montreal",
     "schedule": ["at any time"],
     "semanticCommitScope": "deps",
@@ -15,7 +15,7 @@
         {
             "groupName": "@tanstack table",
             "description": "Group @tanstack table packages together because they need to be updated at the same time",
-            "matchPackageNames": ["@tanstack/react-table", "@tanstack/table-core", "@tanstack/match-sorter-utils"]
+            "matchPackagePrefixes": ["@tanstack/"]
         }
     ],
     "lockFileMaintenance": {


### PR DESCRIPTION
### Proposed Changes

All those renovate PRs are a bit annoying. I added the `allNonMajor` preset to group all the patches and minor together

https://docs.renovatebot.com/presets-group/#groupallnonmajor

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
