### PR TITLE
fix(plasma-style): fix rgb function misusage

### DIFF
--- a/packages/react/src/components/tooltip/Tooltip.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.tsx
@@ -123,6 +123,7 @@ export class Tooltip extends Component<ITooltipProps> {
                 id={id}
                 {..._.omit(this.props, TOOLTIP_PROPS_TO_OMIT)}
                 {...injectedProps}
+                style={{...injectedProps.style, margin: 0}}
                 className="react-vapor-tooltip"
             >
                 {this.props.title}

--- a/packages/style/scss/colors.scss
+++ b/packages/style/scss/colors.scss
@@ -165,7 +165,7 @@ $deprecated: (
 );
 
 @function toRGB($color) {
-    @return red($color), green($color), blue($color);
+    @return red($color) green($color) blue($color);
 }
 
 @mixin spreadPalette($palette) {

--- a/packages/style/scss/components/banner.scss
+++ b/packages/style/scss/components/banner.scss
@@ -63,7 +63,7 @@
 }
 
 .banner-right {
-    color: rgb(var(--white-rgb) $transparency-2);
+    color: rgb(var(--white-rgb) / $transparency-2);
     font-size: var(--default-font-size);
 }
 

--- a/packages/style/scss/components/blankslate.scss
+++ b/packages/style/scss/components/blankslate.scss
@@ -38,7 +38,7 @@
 
     // deprecated use .mod-error instead
     &.mod-danger {
-        background-color: rgb(var(--deprecated-red-rgb) $transparency-5);
+        background-color: rgb(var(--deprecated-red-rgb) / $transparency-5);
         border-color: var(--critical-70);
 
         h1,
@@ -48,7 +48,7 @@
     }
 
     &.mod-error {
-        background-color: rgb(var(--deprecated-tango-rgb) $transparency-5);
+        background-color: rgb(var(--deprecated-tango-rgb) / $transparency-5);
         border-color: var(--deprecated-red);
 
         h1 {

--- a/packages/style/scss/components/card.scss
+++ b/packages/style/scss/components/card.scss
@@ -1,4 +1,4 @@
-$card-container-box-shadow: 0 2px 8px 0 rgb(var(--black-rgb) $transparency-4);
+$card-container-box-shadow: 0 2px 8px 0 rgb(var(--black-rgb) / $transparency-4);
 $card-hover-box-shadow: -5px 0 5px var(--deprecated-light-grey);
 
 // Status Cards

--- a/packages/style/scss/components/facet.scss
+++ b/packages/style/scss/components/facet.scss
@@ -12,7 +12,7 @@
     margin: $facet-margin-y 0;
     padding-bottom: $facet-spacing;
     background: var(--white);
-    border: 1px solid rgb(var(--deprecated-heather-rgb) 0.3);
+    border: 1px solid rgb(var(--deprecated-heather-rgb) / 30%);
     border-radius: $big-border-radius;
     box-shadow: 0 2px 10px 0 rgb(0 0 0 / 10%);
 }
@@ -239,7 +239,7 @@
     overflow-y: auto;
     list-style: none;
     background-color: var(--white);
-    border: 1px solid rgb(var(--deprecated-heather-rgb) 0.3);
+    border: 1px solid rgb(var(--deprecated-heather-rgb) / 30%);
     border-radius: $big-border-radius;
 
     @include slim-scroll(var(--deprecated-light-grey), var(--deprecated-medium-grey));

--- a/packages/style/scss/components/home-card.scss
+++ b/packages/style/scss/components/home-card.scss
@@ -16,7 +16,7 @@
     margin-bottom: $home-card-margin;
     padding: 2 * $spacing;
     background: var(--white);
-    border: 1px solid rgb(var(--deprecated-heather-rgb) 0.3);
+    border: 1px solid rgb(var(--deprecated-heather-rgb) / 30%);
     border-radius: $home-card-radius;
     box-shadow: $material-card-shadow;
 }

--- a/packages/style/scss/components/material-card.scss
+++ b/packages/style/scss/components/material-card.scss
@@ -1,7 +1,7 @@
 .material-card {
     padding: 2 * $spacing;
     background-color: var(--white);
-    border: 1px solid rgb(var(--deprecated-heather-rgb) 0.3);
+    border: 1px solid rgb(var(--deprecated-heather-rgb) / 30%);
     border-radius: $border-radius;
     box-shadow: $material-card-shadow;
     transition: box-shadow 0.1s ease-out;

--- a/packages/style/scss/components/modal.scss
+++ b/packages/style/scss/components/modal.scss
@@ -42,7 +42,7 @@ $icon-size: 24px;
 
 .modal-backdrop {
     z-index: $base-backdrop-z-index;
-    background: rgb(var(--deprecated-purple-blue-rgb) $transparency-1);
+    background: rgb(var(--deprecated-purple-blue-rgb) / $transparency-1);
     opacity: 1;
     transition: all 0.3s;
 

--- a/packages/style/scss/components/popover.scss
+++ b/packages/style/scss/components/popover.scss
@@ -3,7 +3,7 @@
     background-color: var(--white);
     border: $default-border;
     border-radius: $border-radius;
-    box-shadow: 0 2px 4px rgb(var(--deprecated-stratos-rgb) 0.4);
+    box-shadow: 0 2px 4px rgb(var(--deprecated-stratos-rgb) / 40%);
 }
 
 .popover-body {

--- a/packages/style/scss/components/tooltip.scss
+++ b/packages/style/scss/components/tooltip.scss
@@ -1,5 +1,5 @@
 .tooltip {
-    --tooltip-color: rgb(var(--navy-blue-60-rgb) 0.94);
+    --tooltip-color: rgb(var(--navy-blue-60-rgb) / 94%);
     --arrow-size: 4px;
     --tooltip-gap: 8px;
 
@@ -91,7 +91,7 @@
         background-color: var(--tooltip-color);
         border-color: var(--tooltip-color);
         border-radius: 8px;
-        filter: drop-shadow(0 8px 24px rgb(var(--navy-blue-70-rgb) 0.53));
+        filter: drop-shadow(0 8px 24px rgb(var(--navy-blue-70-rgb) / 53%));
         backdrop-filter: blur(2px);
     }
 }
@@ -108,7 +108,7 @@ $chart-tooltip-content-size: 3px;
     font-size: $small-font-size;
     background-color: var(--white);
     border: $default-border;
-    box-shadow: 0 0 $chart-tooltip-content-size 0 rgb(var(--black-rgb) $transparency-4);
+    box-shadow: 0 0 $chart-tooltip-content-size 0 rgb(var(--black-rgb) / $transparency-4);
 }
 
 .chart-tooltip-color {

--- a/packages/style/scss/controls/filtering/multi-filter-picker.scss
+++ b/packages/style/scss/controls/filtering/multi-filter-picker.scss
@@ -13,7 +13,7 @@
 
         .add-container {
             overflow: auto;
-            background-color: rgb(var(--deprecated-white-rgb) 0.4);
+            background-color: rgb(var(--deprecated-white-rgb) / 40%);
 
             .add {
                 padding: $multi-filterpickerbox-add-padding;

--- a/packages/style/scss/controls/numeric-input.scss
+++ b/packages/style/scss/controls/numeric-input.scss
@@ -20,7 +20,7 @@ $numeric-input-digit-padding: 10px;
         text-overflow: ellipsis;
         border: $default-border;
         border-radius: $border-radius;
-        box-shadow: inset 0 0 3px 0 rgb(var(--black-rgb) $transparency-5);
+        box-shadow: inset 0 0 3px 0 rgb(var(--black-rgb) / $transparency-5);
 
         &:focus {
             @include focus-outline;

--- a/packages/style/scss/elements/btn.scss
+++ b/packages/style/scss/elements/btn.scss
@@ -124,7 +124,7 @@
         &:focus {
             background-color: var(--pomegranate-red-60);
             border: $button-border-width solid var(--pomegranate-red-60);
-            box-shadow: 0 0 0 4px rgb(var(--pomegranate-red-70-rgb) 0.2);
+            box-shadow: 0 0 0 4px rgb(var(--pomegranate-red-70-rgb) / 20%);
         }
 
         &:hover {

--- a/packages/style/scss/tables/table.scss
+++ b/packages/style/scss/tables/table.scss
@@ -198,14 +198,14 @@
     &.confirm-delete {
         .row-selected td,
         &.row-selected:hover td {
-            background-color: rgb(var(--deprecated-red-rgb) $transparency-5);
+            background-color: rgb(var(--deprecated-red-rgb) / $transparency-5);
             border-color: var(--critical-70);
             transition: background-color 300ms;
         }
     }
 
     &.mod-deleting tbody tr.selected td {
-        background-color: rgb(var(--deprecated-red-rgb) $transparency-5);
+        background-color: rgb(var(--deprecated-red-rgb) / $transparency-5);
     }
 
     .mod-card-list {
@@ -244,7 +244,7 @@
 
     .mod-card {
         border-radius: $big-border-radius;
-        box-shadow: 0 2px 10px rgb(var(--black-rgb) 0.2);
+        box-shadow: 0 2px 10px rgb(var(--black-rgb) / 20%);
         cursor: pointer;
 
         &:hover {

--- a/packages/style/scss/utility/border.scss
+++ b/packages/style/scss/utility/border.scss
@@ -7,14 +7,14 @@ $borders: border-top border-bottom border-left border-right;
 
     @for $i from 1 through length($transparencies) {
         .mod-#{$border}-transparency-#{$i} {
-            #{$border}: $default-border-size solid rgb(var(--deprecated-medium-grey-rgb) nth($transparencies, $i));
+            #{$border}: $default-border-size solid rgb(var(--deprecated-medium-grey-rgb) / nth($transparencies, $i));
         }
     }
 }
 
 @for $i from 1 through length($transparencies) {
     .mod-border-transparency-#{$i} {
-        border: $default-border-size solid rgb(var(--deprecated-medium-grey-rgb) nth($transparencies, $i));
+        border: $default-border-size solid rgb(var(--deprecated-medium-grey-rgb) / nth($transparencies, $i));
     }
 }
 

--- a/packages/style/scss/utility/shadow.scss
+++ b/packages/style/scss/utility/shadow.scss
@@ -1,13 +1,13 @@
 :root {
-    --low-elevation-on-light: 0px 2px 8px rgb(var(--shadow-on-light-rgb) 0.75);
-    --medium-elevation-on-light: 0px 6px 16px rgb(var(--shadow-on-light-rgb) 0.75);
-    --high-elevation-on-light: 0px 10px 25px rgb(var(--shadow-on-light-rgb) 0.6);
-    --low-elevation-on-neutral: 0px 2px 5px rgb(var(--shadow-on-neutral-rgb) 0.13);
-    --medium-elevation-on-neutral: 0px 8px 17px rgb(var(--shadow-on-neutral-rgb) 0.22);
-    --high-elevation-on-neutral: 0px 14px 26px rgb(var(--shadow-on-neutral-rgb) 0.16);
-    --low-elevation-on-dark: 0px 2px 8px rgb(var(--shadow-on-dark-rgb) 0.5);
-    --medium-elevation-on-dark: 0px 4px 16px rgb(var(--shadow-on-dark-rgb) 0.5);
-    --high-elevation-on-dark: 0px 8px 24px rgb(var(--shadow-on-dark-rgb) 0.6);
+    --low-elevation-on-light: 0px 2px 8px rgb(var(--shadow-on-light-rgb) / 75%);
+    --medium-elevation-on-light: 0px 6px 16px rgb(var(--shadow-on-light-rgb) / 75%);
+    --high-elevation-on-light: 0px 10px 25px rgb(var(--shadow-on-light-rgb) / 60%);
+    --low-elevation-on-neutral: 0px 2px 5px rgb(var(--shadow-on-neutral-rgb) / 13%);
+    --medium-elevation-on-neutral: 0px 8px 17px rgb(var(--shadow-on-neutral-rgb) / 22%);
+    --high-elevation-on-neutral: 0px 14px 26px rgb(var(--shadow-on-neutral-rgb) / 16%);
+    --low-elevation-on-dark: 0px 2px 8px rgb(var(--shadow-on-dark-rgb) / 50%);
+    --medium-elevation-on-dark: 0px 4px 16px rgb(var(--shadow-on-dark-rgb) / 50%);
+    --high-elevation-on-dark: 0px 8px 24px rgb(var(--shadow-on-dark-rgb) / 60%);
 }
 
 .shadow-1 {

--- a/packages/style/scss/variables.scss
+++ b/packages/style/scss/variables.scss
@@ -287,7 +287,7 @@ $table-border-button: $table-border-width solid transparent;
 $table-selected-border-width: 5px;
 $table-column-draggable-width: 25px;
 $table-column-draggable-padding: 7px 10px;
-$table-row-drag-over-color: rgb(var(--deprecated-medium-grey-rgb) $transparency-3);
+$table-row-drag-over-color: rgb(var(--deprecated-medium-grey-rgb) / $transparency-3);
 $big-table-blankslate-section-padding: 20px 40px 20px 35px;
 $big-table-row-height: 36px;
 $big-table-icon-margin: 20px;
@@ -457,7 +457,7 @@ $selected-date-height: 28px;
 $calendar-limit-border-width: 2px;
 $calendar-limit-border-length: 5px;
 $calendar-max-height: 336px;
-$date-picker-button-hover-bg: rgb(var(--deprecated-dark-grey-rgb) $transparency-3);
+$date-picker-button-hover-bg: rgb(var(--deprecated-dark-grey-rgb) / $transparency-3);
 $countdown-cell-height: 28px;
 
 // Home card
@@ -520,9 +520,9 @@ $flippable-transition-duration: 0.8s;
 $flippable-shadow: 0 2px 8px 0 rgb(0 0 0 / 30%);
 
 // Material Card
-$material-card-shadow: 0 2px 20px 0 rgb(var(--black-rgb) 0.1);
-$material-card-shadow-hover: 0 2px 30px 0 rgb(var(--black-rgb) 0.3);
-$material-card-shadow-active: 0 2px 20px 0 rgb(var(--black-rgb) 0.3);
+$material-card-shadow: 0 2px 20px 0 rgb(var(--black-rgb) / 10%);
+$material-card-shadow-hover: 0 2px 30px 0 rgb(var(--black-rgb) / 30%);
+$material-card-shadow-active: 0 2px 20px 0 rgb(var(--black-rgb) / 30%);
 $material-card-colored-border-height: 5px;
 
 // Content placeholder
@@ -585,8 +585,8 @@ $banner-content-padding: 50px;
 $banner-right-width: 300px;
 $banner-warning-icon-fix: 2px;
 $banner-box-shadow:
-    inset 0 5px 10px 0 rgb(var(--black-rgb) $transparency-5),
-    inset 0 -10px 50px 0 rgb(var(--black-rgb) 0.2);
+    inset 0 5px 10px 0 rgb(var(--black-rgb) / $transparency-5),
+    inset 0 -10px 50px 0 rgb(var(--black-rgb) / 20%);
 
 // Status Cards
 $status-card-border-width: 4px;


### PR DESCRIPTION
### Proposed Changes

Since #3471, the old plasma-react tooltips and many other components that relied on the `rgb` function were not displaying properly.

Before

![image](https://github.com/coveo/plasma/assets/35579930/afa02e43-4be3-4a9a-a4be-5fb5408d44b2)
<img width="1145" alt="image" src="https://github.com/coveo/plasma/assets/35579930/ba245259-80b5-45fa-8fda-fcc54e6fa6be">

After

<img width="314" alt="image" src="https://github.com/coveo/plasma/assets/35579930/02ce9656-4f69-4251-9889-9bc05a561028">

<img width="1147" alt="image" src="https://github.com/coveo/plasma/assets/35579930/73263010-2802-434b-81a1-b8701d5319d9">


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
