### PR TITLE
fix(table): break long words

### DIFF
--- a/packages/mantine/src/components/table/layouts/RowLayout.tsx
+++ b/packages/mantine/src/components/table/layouts/RowLayout.tsx
@@ -158,6 +158,7 @@ const RowLayoutBody = <T,>({
                                     width: columnSizing.size ?? 'auto',
                                     minWidth: columnSizing.minSize,
                                     maxWidth: columnSizing.maxSize,
+                                    overflowWrap: 'break-word',
                                 }}
                                 className={cx(classes.cell, {
                                     [classes.rowCollapsibleButtonCell]: cell.column.id === TableCollapsibleColumn.id,


### PR DESCRIPTION
### Proposed Changes

Long non breaked words are breaking the table layout. I added a rule in the built in row layout.
Tell me if you think this rule should be applied elsewhere instead.

![workbreak-fix-not](https://github.com/coveo/plasma/assets/45688129/3d45b0fa-7353-413b-8fb4-5e7258e6ee07)

![workbreak-fix](https://github.com/coveo/plasma/assets/45688129/d7701dc7-ebf3-44c8-adb5-6e5381ec360e)

### Potential Breaking Changes

I do not see any.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
