### PR TITLE
fix(mantine): make sure input components have uniform line-height

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -141,6 +141,7 @@ export const plasmaTheme: MantineThemeOverride = {
                     fontSize: theme.fontSizes.sm,
                     color: theme.colors.gray[7],
                     marginBottom: theme.spacing.xs,
+                    lineHeight: theme.lineHeight,
                 },
                 invalid: {
                     color: theme.colors.red[9],
@@ -148,6 +149,7 @@ export const plasmaTheme: MantineThemeOverride = {
                 },
                 error: {
                     color: theme.colors.red[9],
+                    lineHeight: theme.lineHeight,
                 },
             }),
         },


### PR DESCRIPTION
### Proposed Changes

[`InputDescription`](https://github.com/mantinedev/mantine/blob/cf0f85faec56615ea5fbd7813e83bac60dbaefb7/src/mantine-core/src/Input/InputDescription/InputDescription.styles.ts#L8) & [`InputError`](https://github.com/mantinedev/mantine/blob/cf0f85faec56615ea5fbd7813e83bac60dbaefb7/src/mantine-core/src/Input/InputError/InputError.styles.ts#L8) had line-height of `1.2` while everything else had `1.5`. This could cause misalignments. 

For example here:

![image](https://github.com/coveo/plasma/assets/35579930/a5247cdc-3bf5-4b2b-a868-75410e09188d)

One input (right) has an Anchor (line-height 1.5) within its description, the other one (left) does not.

I did a [quick search](https://github.com/search?q=repo%3Amantinedev%2Fmantine+lineHeight+path%3A%2F%5Esrc%5C%2Fmantine-core%5C%2Fsrc%5C%2F%2F&type=code) in the mantine/core package source code and these were the only 2 instances where I was confident it is safe to make the change. 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
