### PR TITLE
feat(website): misc improvements 🎁 

### DIFF
--- a/packages/mantine/src/components/copyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/copyToClipboard/CopyToClipboard.tsx
@@ -52,6 +52,7 @@ export const CopyToClipboard: React.FunctionComponent<CopyToClipboardProps> = ({
             }}
             value={others.value}
             readOnly
+            autoComplete="off"
             rightSection={<CopyToClipboardButton {...others} />}
         />
     ) : (

--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -44,6 +44,7 @@ export const Header: HeaderType = ({description, borderBottom, children, variant
                 position="apart"
                 p={variant === 'page' ? 'xl' : undefined}
                 pb={variant === 'page' ? 'lg' : undefined}
+                noWrap
                 {...others}
             >
                 <Stack spacing={0}>

--- a/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Header > renders the specified breadcrumbs above the title 1`] = `
 <div>
   <div
-    class="mantine-Group-root mantine-ogmezo"
+    class="mantine-Group-root mantine-1arn2xu"
   >
     <div
       class="mantine-Stack-root mantine-1178y6y"

--- a/packages/mantine/src/components/table/__tests__/TableFilter.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableFilter.spec.tsx
@@ -1,5 +1,5 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
-import {render, screen, userEvent, within} from '@test-utils';
+import {act, render, screen, userEvent, within} from '@test-utils';
 
 import {Table} from '../Table';
 
@@ -29,7 +29,7 @@ describe('Table.Filter', () => {
     });
 
     it('calls onChange when typing something in the filter', async () => {
-        const user = userEvent.setup({delay: null});
+        const user = userEvent.setup({advanceTimers: vi.advanceTimersByTime});
         const onChange = vi.fn();
         render(
             <Table data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns} onChange={onChange}>
@@ -40,13 +40,21 @@ describe('Table.Filter', () => {
         );
 
         await user.type(screen.getByRole('textbox'), 'vegetable');
-        vi.advanceTimersByTime(500);
+
+        act(() => {
+            // 300 ms debounce on TableFilter input
+            vi.advanceTimersByTime(300);
+        });
+        act(() => {
+            // 500 ms debounce on Table onChange callback
+            vi.advanceTimersByTime(500);
+        });
 
         expect(onChange).toHaveBeenCalledWith(expect.objectContaining({globalFilter: 'vegetable'}));
     });
 
     it('goes back to the first page when changing the filter', async () => {
-        const user = userEvent.setup({delay: null});
+        const user = userEvent.setup({advanceTimers: vi.advanceTimersByTime});
         const onChange = vi.fn();
         render(
             <Table data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns} onChange={onChange}>
@@ -61,7 +69,14 @@ describe('Table.Filter', () => {
         );
 
         await user.type(screen.getByRole('textbox'), 'veg');
-        vi.advanceTimersByTime(500);
+        act(() => {
+            // 300 ms debounce on TableFilter input
+            vi.advanceTimersByTime(300);
+        });
+        act(() => {
+            // 500 ms debounce on Table onChange callback
+            vi.advanceTimersByTime(500);
+        });
 
         expect(onChange).toHaveBeenCalledWith(
             expect.objectContaining({globalFilter: 'veg', pagination: {pageIndex: 0, pageSize: 50}}),

--- a/packages/website/src/building-blocs/LegacyWarningBanner.tsx
+++ b/packages/website/src/building-blocs/LegacyWarningBanner.tsx
@@ -1,20 +1,25 @@
 import {Alert, Anchor, Code, Text} from '@coveord/plasma-mantine';
 import {ArrowLeftSize16Px, WarningSize24Px} from '@coveord/plasma-react-icons';
 import Link from 'next/link';
+import {useRouter} from 'next/router';
 
-const LegacyWarningBanner = () => (
-    <Alert color="warning" m="sm" icon={<WarningSize24Px height={24} />}>
-        You are viewing the legacy documentation of Plasma featuring the components from the
-        <Code>@coveord/plasma-react</Code> and <Code>@coveord/plasma-style</Code> packages. Those packages are
-        deprecated and replaced by the <Code>@coveord/plasma-mantine</Code> package.{' '}
-        <Text>
-            <Link href="/" passHref legacyBehavior>
-                <Anchor>
-                    <ArrowLeftSize16Px height={16} /> Return to the latest documentation
-                </Anchor>
-            </Link>
-        </Text>
-    </Alert>
-);
+const LegacyWarningBanner = () => {
+    const {pathname} = useRouter();
+    const isLegacy = /^\/legacy*/.test(pathname);
+    return isLegacy ? (
+        <Alert color="warning" m="sm" icon={<WarningSize24Px height={24} />}>
+            You are viewing the legacy documentation of Plasma featuring the components from the
+            <Code>@coveord/plasma-react</Code> and <Code>@coveord/plasma-style</Code> packages. Those packages are
+            deprecated and replaced by the <Code>@coveord/plasma-mantine</Code> package.{' '}
+            <Text>
+                <Link href="/" passHref legacyBehavior>
+                    <Anchor>
+                        <ArrowLeftSize16Px height={16} /> Return to the latest documentation
+                    </Anchor>
+                </Link>
+            </Text>
+        </Alert>
+    ) : null;
+};
 
 export default LegacyWarningBanner;

--- a/packages/website/src/building-blocs/PageLayout.tsx
+++ b/packages/website/src/building-blocs/PageLayout.tsx
@@ -1,4 +1,4 @@
-import {Stack, Tabs} from '@coveord/plasma-mantine';
+import {Box, Container, Divider, Stack, Tabs} from '@coveord/plasma-mantine';
 import {Fragment, FunctionComponent, ReactNode} from 'react';
 
 import {GuidelinesTab} from './GuidelinesTab';
@@ -30,30 +30,41 @@ export const PageLayout = ({
     sourcePath,
     ...contentProps
 }: PageLayoutProps) => (
-    <div id={id} className="plasma-page-layout">
-        <PageHeader
-            sourcePath={sourcePath}
-            section={section}
-            thumbnail={thumbnail}
-            title={title}
-            description={description}
-        />
-        <Tabs defaultValue="implementation">
-            <Tabs.List pl="xl">
-                <Tabs.Tab value="implementation">Implementation</Tabs.Tab>
-                <Tabs.Tab value="guide">Guidelines</Tabs.Tab>
-            </Tabs.List>
-            <Tabs.Panel value="implementation">
-                <Content id={id} {...contentProps}>
-                    {children}
-                </Content>
-            </Tabs.Panel>
-            <Tabs.Panel value="guide">
-                <GuidelinesTab id={id} />
-            </Tabs.Panel>
-        </Tabs>
-    </div>
+    <Tabs
+        defaultValue="implementation"
+        styles={{tabsList: {borderBottom: 'none'}, root: {display: 'flex', height: '100%'}}}
+    >
+        <Stack spacing={0} align="stretch" sx={{flexBasis: 'auto', flexGrow: 1}}>
+            <Container size="xl" w="100%">
+                <PageHeader
+                    sourcePath={sourcePath}
+                    section={section}
+                    thumbnail={thumbnail}
+                    title={title}
+                    description={description}
+                />
+                <Tabs.List pl="xl">
+                    <Tabs.Tab value="implementation">Implementation</Tabs.Tab>
+                    <Tabs.Tab value="guide">Guidelines</Tabs.Tab>
+                </Tabs.List>
+            </Container>
+            <Divider />
+            <Box bg="gray.0" sx={{flexBasis: 'auto', flexGrow: 1}}>
+                <Container size="xl">
+                    <Tabs.Panel value="implementation">
+                        <Content id={id} {...contentProps}>
+                            {children}
+                        </Content>
+                    </Tabs.Panel>
+                    <Tabs.Panel value="guide">
+                        <GuidelinesTab id={id} />
+                    </Tabs.Panel>
+                </Container>
+            </Box>
+        </Stack>
+    </Tabs>
 );
+
 const Content: FunctionComponent<
     Pick<
         PageLayoutProps,

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import '../styles/colors.scss';
 import '../styles/github-button.scss';
 import '../styles/home.scss';
-import '../styles/iconography.scss';
 import '../styles/loading-screen.css';
 import '../styles/main.scss';
 import '../styles/page-layout.scss';
@@ -12,10 +11,9 @@ import '../styles/tile.scss';
 
 import {AppShell, Group, Image, Notifications, Plasmantine} from '@coveord/plasma-mantine';
 import {Defaults} from '@coveord/plasma-react';
-import {Header as MantineHeader, ScrollArea} from '@mantine/core';
+import {Header as MantineHeader} from '@mantine/core';
 import Head from 'next/head';
 import Link from 'next/link';
-import {useRouter} from 'next/router';
 import {useEffect} from 'react';
 import {Provider} from 'react-redux';
 
@@ -24,9 +22,9 @@ import githubLogo from '../../resources/github-mark.svg';
 import logo from '../../resources/plasma-logo.svg';
 import {Navigation} from '../SideNavigation';
 import {Store} from '../Store';
-import LegacyWarningBanner from '../building-blocs/LegacyWarningBanner';
 import StandaloneSearchBar from '../search/StandaloneSearchBar';
 import {EngineProvider} from '../search/engine/EngineProvider';
+import LegacyWarningBanner from '../building-blocs/LegacyWarningBanner';
 
 const Header = () => (
     <MantineHeader height={100}>
@@ -34,7 +32,10 @@ const Header = () => (
             position="apart"
             px="lg"
             py="xs"
-            sx={(theme) => ({backgroundColor: theme.colors.navy[7], height: '100%'})}
+            sx={(theme) => ({
+                background: `linear-gradient(217deg, ${theme.colors.purple[6]} 0%, ${theme.colors.navy[7]} 74.62%, ${theme.colors.navy[7]} 100%)`,
+                height: '100%',
+            })}
             noWrap
         >
             <Link href="/" className="header-logo-link">
@@ -49,9 +50,6 @@ const Header = () => (
 );
 
 const MyApp = ({Component, pageProps}: AppProps) => {
-    const {pathname} = useRouter();
-    const isLegacy = /^\/legacy*/.test(pathname);
-
     useEffect(() => {
         Defaults.APP_ELEMENT = '#App';
         Defaults.MODAL_ROOT = '#Modals';
@@ -73,10 +71,8 @@ const MyApp = ({Component, pageProps}: AppProps) => {
                     <Plasmantine>
                         <Notifications position="top-center" />
                         <AppShell navbar={<Navigation />} header={<Header />} padding={0}>
-                            <ScrollArea>
-                                {isLegacy ? <LegacyWarningBanner /> : null}
-                                <Component {...pageProps} />
-                            </ScrollArea>
+                            <LegacyWarningBanner />
+                            <Component {...pageProps} />
                         </AppShell>
                     </Plasmantine>
                 </EngineProvider>

--- a/packages/website/src/pages/foundations/Iconography.tsx
+++ b/packages/website/src/pages/foundations/Iconography.tsx
@@ -1,61 +1,181 @@
-import {ITableHOCProps, TableHOC, tableWithFilter, TableWithFilterProps} from '@coveord/plasma-react';
 import * as PlasmaReactIcons from '@coveord/plasma-react-icons';
-import {HTMLAttributes, ComponentType, FunctionComponent} from 'react';
 import IconographyDemo from '@examples/foundations/Iconography/Iconography.demo?demo';
+import {Fragment, FunctionComponent} from 'react';
 
+import {
+    Box,
+    Card,
+    Center,
+    Collapse,
+    ColumnDef,
+    CopyToClipboard,
+    createColumnHelper,
+    FilterFn,
+    getFilteredRowModel,
+    Grid,
+    Group,
+    renderTableCell,
+    Row,
+    SimpleGrid,
+    Space,
+    Table,
+    TableLayout,
+    TableLayoutProps,
+    TableProps,
+    Title,
+    useDisclosure,
+    useTable,
+} from '@coveord/plasma-mantine';
+import {rankItem} from '@tanstack/match-sorter-utils';
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const {iconsList, ...Icons} = PlasmaReactIcons;
 
-const TableWithFilter: ComponentType<
-    React.PropsWithChildren<TableWithFilterProps & ITableHOCProps & HTMLAttributes<HTMLTableElement>>
-> = tableWithFilter()(TableHOC);
+type IconSet = (typeof iconsList)[number];
 
-type IconSet = {iconName: string; variants: Array<keyof typeof Icons>};
+const IconSetCard = <T,>({getVisibleCells}: Row<T>) => {
+    const [opened, {toggle}] = useDisclosure(false);
+    const cells = getVisibleCells();
+    const nameCell = cells.find(({column}) => column.id === 'name');
+    const iconCell = cells.find(({column}) => column.id === 'render');
+    const variantsCell = cells.find(({column}) => column.id === 'variants');
+    return (
+        <div>
+            <Card shadow="md" radius="md" px="md" pb={0}>
+                <Card.Section>
+                    <Group noWrap p="md" position="apart" onClick={toggle} sx={{cursor: 'pointer'}}>
+                        <Group>
+                            {renderTableCell(iconCell.column.columnDef.cell, iconCell.getContext())}
+                            <Title order={5}>
+                                {renderTableCell(nameCell.column.columnDef.cell, nameCell.getContext())}
+                            </Title>
+                        </Group>
+                        {opened ? (
+                            <Icons.ArrowHeadUpSize16Px height={16} />
+                        ) : (
+                            <Icons.ArrowHeadDownSize16Px height={16} />
+                        )}
+                    </Group>
+                </Card.Section>
+                <Collapse in={opened}>
+                    {opened ? (
+                        renderTableCell(variantsCell.column.columnDef.cell, variantsCell.getContext())
+                    ) : (
+                        <Space h={180} />
+                    )}
+                    <Space h="md" />
+                </Collapse>
+            </Card>
+        </div>
+    );
+};
 
-const IconSetCard: FunctionComponent<IconSet> = ({iconName, variants}) => (
-    <div key={iconName} className="card p2 flex-column">
-        <h6 className="h6-subdued mb2">{iconName}</h6>
-        <table className="table">
-            <thead className="mod-no-border-top">
-                <tr>
-                    <th>Icon</th>
-                    <th>Name</th>
-                </tr>
-            </thead>
-            <tbody>
-                {variants.map((svgName) => {
+const IconsListLayout = <T,>({table}: TableLayoutProps<T>) => {
+    const iconSets = table.getRowModel().rows.map((row) => <IconSetCard key={row.id} {...row} />);
+    return (
+        <tr>
+            <td style={{padding: 0}}>
+                <SimpleGrid cols={3} p="lg">
+                    {iconSets}
+                </SimpleGrid>
+            </td>
+        </tr>
+    );
+};
+
+const CardLayout: TableLayout = {
+    name: 'Cards',
+    Body: IconsListLayout,
+    Header: () => null,
+};
+
+const fuzzyFilter: FilterFn<IconSet> = (row, columnId, value, addMeta) => {
+    const itemRank = rankItem(row.getValue('name'), value);
+    addMeta(itemRank);
+    return itemRank.passed;
+};
+
+const options: TableProps<IconSet>['options'] = {
+    globalFilterFn: fuzzyFilter,
+    getFilteredRowModel: getFilteredRowModel(),
+};
+
+const columnHelper = createColumnHelper<IconSet>();
+
+const getIconSizeFromVariantName = (variantName: string) => parseInt(/(\d+)px/i.exec(variantName)?.[0] ?? '16', 10);
+
+const columns: Array<ColumnDef<IconSet>> = [
+    columnHelper.accessor('iconName', {
+        id: 'name',
+        header: 'Name',
+        cell: ({getValue}) => getValue().charAt(0).toUpperCase() + getValue().slice(1),
+    }),
+    columnHelper.accessor('variants', {
+        id: 'render',
+        header: 'Icon',
+        enableGlobalFilter: false,
+        cell: ({getValue}) => {
+            const Variant32px = getValue().find(
+                (variantName) => getIconSizeFromVariantName(variantName) === 32,
+            ) as keyof typeof Icons;
+            const IconComponent = Icons[Variant32px];
+            return <IconComponent height={32} />;
+        },
+    }),
+    columnHelper.accessor('variants', {
+        id: 'variants',
+        header: 'Variants',
+        enableGlobalFilter: false,
+        cell: ({getValue}) => (
+            <Grid columns={4} align="center">
+                {getValue().map((svgName: keyof typeof Icons) => {
                     const IconComponent = Icons[svgName];
                     const size = parseInt(/(\d+)px/i.exec(svgName)?.[0] ?? '16', 10);
                     return IconComponent ? (
-                        <tr key={svgName}>
-                            <td className="mod-no-border-bottom">
-                                <IconComponent height={size} />
-                            </td>
-                            <td className="mod-no-border-bottom">{svgName}</td>
-                        </tr>
+                        <Fragment key={svgName}>
+                            <Grid.Col span={1}>
+                                <Center>
+                                    <IconComponent height={size} />
+                                </Center>
+                            </Grid.Col>
+                            <Grid.Col span={3}>
+                                <CopyToClipboard value={`<${svgName} height={${size}} />`} withLabel />
+                            </Grid.Col>
+                        </Fragment>
                     ) : null;
                 })}
-            </tbody>
-        </table>
-    </div>
-);
+            </Grid>
+        ),
+    }),
+];
+
+const EmptyState = () => {
+    const {state} = useTable();
+    return (
+        <Box mih={500}>
+            <Center p="lg">
+                <Group>
+                    <Icons.BrokenSearchSize32Px height={32} />
+                    <Title order={5}>No icons match the filter "{state.globalFilter}".</Title>
+                </Group>
+            </Center>
+        </Box>
+    );
+};
 
 const IconsTable: FunctionComponent = () => (
-    <TableWithFilter
-        id="iconography"
+    <Table
         data={iconsList}
-        className="plasma-page-layout__section full-content"
-        tbodyClassName="icon-grid"
-        renderBody={(data: typeof iconsList) =>
-            data.map(({iconName, variants}) => (
-                <IconSetCard key={iconName} iconName={iconName} variants={variants as Array<keyof typeof Icons>} />
-            ))
-        }
-        filterBlankslate={{
-            title: <span className="h4-book mb1 nowrap">No icons match the applied filter</span>,
-        }}
-    />
+        layouts={[CardLayout]}
+        columns={columns}
+        getRowId={({iconName}) => iconName}
+        options={options}
+        noDataChildren={<EmptyState />}
+    >
+        <Table.Header bg="gray.0">
+            <Table.Filter placeholder="Search icon" />
+        </Table.Header>
+    </Table>
 );
 
 export const IconographyExamples = () => (

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import {LinkSvg, Section} from '@coveord/plasma-react';
+import {Container} from '@coveord/plasma-mantine';
 import {ExternalSize16Px} from '@coveord/plasma-react-icons';
 import {NextPage} from 'next';
 import Head from 'next/head';
@@ -7,7 +8,7 @@ import {FunctionComponent} from 'react';
 import {Tile} from '../building-blocs/Tile';
 
 export const Index: NextPage = () => (
-    <Section className="home flex-auto overflow-auto">
+    <Container size="xl" className="home">
         <Head>
             <title>Plasma Design System</title>
             <meta property="og:title" content="Plasma Design System" key="title" />
@@ -16,7 +17,7 @@ export const Index: NextPage = () => (
         <FoundationsPages />
         <LayoutPages />
         <FormPages />
-    </Section>
+    </Container>
 );
 
 const WelcomeToPlasma: FunctionComponent = () => (

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -18,13 +18,27 @@ const DemoPage = () => (
         propsMetadata={TableMetadata}
         demo={<TableDemo noPadding layout="vertical" />}
         examples={{
-            multiSelect: <TableMultiSelectionDemo noPadding title="Table with bulk selection of rows" />,
-            disableRowSelection: <TableDisableRowSelection noPadding title="Table with disabled row selection" />,
-            clientSide: (
-                <TableClientSideDemo noPadding title="Table with client side pagination, sorting, and filtering" />
+            multiSelect: (
+                <TableMultiSelectionDemo noPadding layout="vertical" title="Table with bulk selection of rows" />
             ),
-            emptyState: <TableEmptyStateDemo noPadding title="Table with empty states" />,
-            consumer: <TableConsumerDemo noPadding title="Table with a child component using the hook to re-fetch" />,
+            disableRowSelection: (
+                <TableDisableRowSelection noPadding layout="vertical" title="Table with disabled row selection" />
+            ),
+            clientSide: (
+                <TableClientSideDemo
+                    noPadding
+                    layout="vertical"
+                    title="Table with client side pagination, sorting, and filtering"
+                />
+            ),
+            emptyState: <TableEmptyStateDemo noPadding layout="vertical" title="Table with empty states" />,
+            consumer: (
+                <TableConsumerDemo
+                    noPadding
+                    layout="vertical"
+                    title="Table with a child component using the hook to re-fetch"
+                />
+            ),
         }}
     />
 );

--- a/packages/website/src/styles/iconography.scss
+++ b/packages/website/src/styles/iconography.scss
@@ -1,5 +1,0 @@
-.icon-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-    gap: 24px;
-}

--- a/packages/website/src/styles/page-layout.scss
+++ b/packages/website/src/styles/page-layout.scss
@@ -1,8 +1,4 @@
 .plasma-page-layout {
-    &__main-code {
-        background-color: var(--grey-20);
-    }
-
     &__section {
         padding: 32px 24px;
     }


### PR DESCRIPTION
Here's a little unplanned 🎁 

* Put gradient on top bar
* Center all pages' content using `@coveord/plasma-mantine` Containers
* Improve `Iconography` page:
    *  use only `@coveord/plasma-mantine` components
    *  collapse variants to see more icons at once
    *  add code snippets with copy to clipboard for each variant
* Add 300 ms debounce on `TableFilter` input
* Add `autocomplete="off"` on `TableFilter` and `CopyToClipboard`

### Proposed Changes

Before

![image](https://github.com/coveo/plasma/assets/35579930/b6418bfe-dfb8-45f8-af15-02a14263c2fa)
![image](https://github.com/coveo/plasma/assets/35579930/d5b56837-4f43-478a-aed5-cd89bcac75bd)

After

![image](https://github.com/coveo/plasma/assets/35579930/2a7d1e54-53c4-4652-bae5-2e58ffdaba5c)
![image](https://github.com/coveo/plasma/assets/35579930/7d63bd3b-8834-4ba5-85ae-6e9d5240a583)

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
