### PR TITLE
feat(mantine, header): make component theme-able

### DIFF
--- a/packages/mantine/src/components/header/Header.styles.ts
+++ b/packages/mantine/src/components/header/Header.styles.ts
@@ -1,0 +1,20 @@
+import {createStyles} from '@mantine/core';
+
+export interface HeaderStylesParams {
+    variant?: 'page' | 'modal';
+}
+
+export const useStyles = createStyles((theme, {variant}: HeaderStylesParams) => ({
+    root: {
+        padding: variant === 'page' ? theme.spacing.xl : undefined,
+        paddingBottom: variant === 'page' ? theme.spacing.lg : undefined,
+    },
+    title: {
+        wordBreak: 'break-word',
+        color: variant === 'page' ? theme.colors.gray[5] : undefined,
+    },
+    description: {
+        color: theme.colors.gray[6],
+    },
+    divider: {},
+}));

--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -1,8 +1,24 @@
-import {QuestionSize16Px} from '@coveord/plasma-react-icons';
-import {Anchor, Breadcrumbs, DefaultProps, Divider, Group, Stack, Text, Title, Tooltip} from '@mantine/core';
-import {Children, FunctionComponent, ReactElement, ReactNode} from 'react';
+import {
+    DefaultProps,
+    Divider,
+    Group,
+    GroupProps,
+    Selectors,
+    Stack,
+    Text,
+    Title,
+    useComponentDefaultProps,
+} from '@mantine/core';
+import {Children, ReactElement, ReactNode} from 'react';
 
-export interface HeaderProps extends DefaultProps {
+import {HeaderStylesParams, useStyles} from './Header.styles';
+import {HeaderActions} from './HeaderActions/HeaderActions';
+import {HeaderBreadcrumbs} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
+import {HeaderDocAnchor} from './HeaderDocAnchor/HeaderDocAnchor';
+
+type HeaderStylesNames = Selectors<typeof useStyles>;
+
+export interface HeaderProps extends Omit<GroupProps, 'styles'>, DefaultProps<HeaderStylesNames, HeaderStylesParams> {
     /**
      * The description text displayed inside the header underneath the title
      */
@@ -30,7 +46,17 @@ interface HeaderType {
     DocAnchor: typeof HeaderDocAnchor;
 }
 
-export const Header: HeaderType = ({description, borderBottom, children, variant = 'page', ...others}) => {
+const defaultProps: Partial<HeaderProps> = {
+    variant: 'page',
+    position: 'apart',
+    noWrap: true,
+};
+
+export const Header: HeaderType = (props: HeaderProps) => {
+    const {classNames, styles, unstyled, className, description, borderBottom, variant, children, ...others} =
+        useComponentDefaultProps('PlasmaHeader', defaultProps, props);
+    const {classes, cx} = useStyles({variant}, {name: 'PlasmaHeader', classNames, styles, unstyled});
+
     const convertedChildren = Children.toArray(children) as ReactElement[];
     const breadcrumbs = convertedChildren.find((child) => child.type === HeaderBreadcrumbs);
     const actions = convertedChildren.find((child) => child.type === HeaderActions);
@@ -40,66 +66,23 @@ export const Header: HeaderType = ({description, borderBottom, children, variant
     );
     return (
         <>
-            <Group
-                position="apart"
-                p={variant === 'page' ? 'xl' : undefined}
-                pb={variant === 'page' ? 'lg' : undefined}
-                noWrap
-                {...others}
-            >
+            <Group className={cx(className, classes.root)} {...others}>
                 <Stack spacing={0}>
                     {breadcrumbs}
-                    <Title
-                        order={variant === 'page' ? 1 : 3}
-                        color={variant === 'page' ? 'gray.5' : undefined}
-                        sx={{wordBreak: 'break-word'}}
-                    >
+                    <Title order={variant === 'page' ? 1 : 3} className={classes.title}>
                         {otherChildren}
                         {docAnchor}
                     </Title>
-                    <Text size={variant === 'page' ? 'md' : 'sm'} color="gray.6">
+                    <Text className={classes.description} size={variant === 'page' ? 'md' : 'sm'}>
                         {description}
                     </Text>
                 </Stack>
                 {actions}
             </Group>
-            {borderBottom ? <Divider size="xs" /> : null}
+            {borderBottom ? <Divider className={classes.divider} size="xs" /> : null}
         </>
     );
 };
-
-const HeaderBreadcrumbs: FunctionComponent<{children: ReactNode}> = ({children}) => (
-    <Breadcrumbs
-        styles={(theme) => ({
-            breadcrumb: {fontSize: theme.fontSizes.sm, fontWeight: 300},
-            separator: {color: theme.colors.gray[5]},
-        })}
-    >
-        {children}
-    </Breadcrumbs>
-);
-
-const HeaderActions: FunctionComponent<{children: ReactNode}> = ({children}) => <Group spacing="sm">{children}</Group>;
-
-export interface HeaderDocAnchorProps {
-    /**
-     * A href pointing to documentation related to the current panel.
-     * When provided, an info icon is rendered next to the title as link to this documentation
-     */
-    href: string;
-    /**
-     * The tooltip text shown when hovering over the doc link icon
-     */
-    label?: string;
-}
-
-const HeaderDocAnchor: FunctionComponent<HeaderDocAnchorProps> = ({href: docLink, label: docLinkTooltipLabel}) => (
-    <Tooltip label={docLinkTooltipLabel} disabled={!docLinkTooltipLabel} position="right">
-        <Anchor inline href={docLink} target="_blank" ml="xs" style={{verticalAlign: 'middle'}}>
-            <QuestionSize16Px height={16} />
-        </Anchor>
-    </Tooltip>
-);
 
 Header.Breadcrumbs = HeaderBreadcrumbs;
 Header.Actions = HeaderActions;

--- a/packages/mantine/src/components/header/HeaderActions/HeaderActions.styles.ts
+++ b/packages/mantine/src/components/header/HeaderActions/HeaderActions.styles.ts
@@ -1,0 +1,7 @@
+import {createStyles} from '@mantine/core';
+
+export interface HeaderActionsStylesParams {}
+
+export const useStyles = createStyles((theme, {}: HeaderActionsStylesParams) => ({
+    root: {},
+}));

--- a/packages/mantine/src/components/header/HeaderActions/HeaderActions.tsx
+++ b/packages/mantine/src/components/header/HeaderActions/HeaderActions.tsx
@@ -1,0 +1,26 @@
+import {DefaultProps, Group, GroupProps, Selectors, useComponentDefaultProps} from '@mantine/core';
+import {FunctionComponent} from 'react';
+import {HeaderActionsStylesParams, useStyles} from './HeaderActions.styles';
+
+type HeaderActionsStylesNames = Selectors<typeof useStyles>;
+
+export type HeaderActionsProps = GroupProps & DefaultProps<HeaderActionsStylesNames, HeaderActionsStylesParams>;
+
+const defaultProps: Partial<HeaderActionsProps> = {
+    spacing: 'sm',
+};
+
+export const HeaderActions: FunctionComponent<HeaderActionsProps> = (props: HeaderActionsProps) => {
+    const {classNames, styles, unstyled, className, children, ...others} = useComponentDefaultProps(
+        'PlasmaHeaderActions',
+        defaultProps,
+        props,
+    );
+    const {classes, cx} = useStyles({}, {name: 'PlasmaHeaderActions', classNames, styles, unstyled});
+
+    return (
+        <Group className={cx(className, classes.root)} {...others}>
+            {children}
+        </Group>
+    );
+};

--- a/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbs.styles.ts
+++ b/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbs.styles.ts
@@ -1,0 +1,8 @@
+import {createStyles} from '@mantine/core';
+
+export interface HeaderBreadcrumbsStylesParams {}
+
+export const useStyles = createStyles((theme, {}: HeaderBreadcrumbsStylesParams) => ({
+    breadcrumb: {fontSize: theme.fontSizes.sm, fontWeight: 300},
+    separator: {color: theme.colors.gray[5]},
+}));

--- a/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbs.tsx
+++ b/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbs.tsx
@@ -1,0 +1,31 @@
+import {Breadcrumbs, BreadcrumbsProps, DefaultProps, Selectors} from '@mantine/core';
+import {FunctionComponent} from 'react';
+import {HeaderBreadcrumbsStylesParams, useStyles} from './HeaderBreadcrumbs.styles';
+
+type HeaderBreadcrumbsStylesNames = Selectors<typeof useStyles>;
+
+export type HeaderBreadcrumbsProps = BreadcrumbsProps &
+    DefaultProps<HeaderBreadcrumbsStylesNames, HeaderBreadcrumbsStylesParams>;
+
+export const HeaderBreadcrumbs: FunctionComponent<HeaderBreadcrumbsProps> = ({
+    classNames,
+    styles,
+    unstyled,
+    children,
+    ...others
+}) => {
+    const {classes} = useStyles(
+        {},
+        {
+            name: 'PlasmaHeaderBreadcrumbs',
+            classNames,
+            styles,
+            unstyled,
+        },
+    );
+    return (
+        <Breadcrumbs classNames={{breadcrumb: classes.breadcrumb, separator: classes.separator}} {...others}>
+            {children}
+        </Breadcrumbs>
+    );
+};

--- a/packages/mantine/src/components/header/HeaderDocAnchor/HeaderDocAnchor.styles.ts
+++ b/packages/mantine/src/components/header/HeaderDocAnchor/HeaderDocAnchor.styles.ts
@@ -1,0 +1,11 @@
+import {createStyles} from '@mantine/core';
+
+export interface HeaderDocAnchorStylesParams {}
+
+export const useStyles = createStyles((theme, {}: HeaderDocAnchorStylesParams) => ({
+    tooltip: {},
+    anchor: {
+        marginLeft: theme.spacing.xs,
+        verticalAlign: 'middle',
+    },
+}));

--- a/packages/mantine/src/components/header/HeaderDocAnchor/HeaderDocAnchor.tsx
+++ b/packages/mantine/src/components/header/HeaderDocAnchor/HeaderDocAnchor.tsx
@@ -1,0 +1,55 @@
+import {QuestionSize16Px} from '@coveord/plasma-react-icons';
+import {Anchor, DefaultProps, Selectors, Tooltip, TooltipProps, useComponentDefaultProps} from '@mantine/core';
+import {FunctionComponent, ReactNode} from 'react';
+import {HeaderDocAnchorStylesParams, useStyles} from './HeaderDocAnchor.styles';
+
+type HeaderDocAnchorStylesNames = Selectors<typeof useStyles>;
+
+const defaultProps: Partial<HeaderDocAnchorProps> = {
+    position: 'right',
+    children: <QuestionSize16Px height={16} />,
+};
+
+export interface HeaderDocAnchorProps
+    extends Pick<TooltipProps, 'position'>,
+        DefaultProps<HeaderDocAnchorStylesNames, HeaderDocAnchorStylesParams> {
+    /**
+     * A href pointing to documentation related to the current panel.
+     * When provided, an info icon is rendered next to the title as link to this documentation
+     */
+    href: string;
+    /**
+     * The tooltip text shown when hovering over the doc link icon
+     */
+    label?: string;
+    /**
+     * React component to add the tooltip and anchor on
+     */
+    children?: ReactNode;
+}
+
+export const HeaderDocAnchor: FunctionComponent<HeaderDocAnchorProps> = (props: HeaderDocAnchorProps) => {
+    const {
+        classNames,
+        styles,
+        unstyled,
+        className,
+        children,
+        href: docLink,
+        label: docLinkTooltipLabel,
+        ...others
+    } = useComponentDefaultProps('PlasmaHeaderActions', defaultProps, props);
+    const {classes, cx} = useStyles({}, {name: 'PlasmaHeaderActions', classNames, styles, unstyled});
+    return (
+        <Tooltip
+            className={cx(className, classes.tooltip)}
+            label={docLinkTooltipLabel}
+            disabled={!docLinkTooltipLabel}
+            {...others}
+        >
+            <Anchor className={classes.anchor} inline href={docLink} target="_blank">
+                {children}
+            </Anchor>
+        </Tooltip>
+    );
+};

--- a/packages/mantine/src/components/header/__tests__/Header.spec.tsx
+++ b/packages/mantine/src/components/header/__tests__/Header.spec.tsx
@@ -10,7 +10,7 @@ describe('Header', () => {
         const header = screen.getByRole('heading');
         expect(header).toMatchInlineSnapshot(`
           <h1
-            class="mantine-Text-root mantine-Title-root mantine-m67b81"
+            class="mantine-Text-root mantine-Title-root mantine-PlasmaHeader-title mantine-1o7jx33"
           >
             child
           </h1>

--- a/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Header > renders the specified breadcrumbs above the title 1`] = `
 <div>
   <div
-    class="mantine-Group-root mantine-1arn2xu"
+    class="mantine-Group-root mantine-PlasmaHeader-root mantine-15aa8um"
   >
     <div
       class="mantine-Stack-root mantine-1178y6y"
@@ -12,38 +12,38 @@ exports[`Header > renders the specified breadcrumbs above the title 1`] = `
         class="mantine-Breadcrumbs-root mantine-1ujbd2v"
       >
         <a
-          class="mantine-Text-root mantine-Anchor-root mantine-Breadcrumbs-breadcrumb mantine-1yycs9g"
+          class="mantine-Text-root mantine-Anchor-root mantine-PlasmaHeaderBreadcrumbs-breadcrumb mantine-Breadcrumbs-breadcrumb mantine-1p2lvqc"
         >
           One
         </a>
         <div
-          class="mantine-Text-root mantine-Breadcrumbs-separator mantine-c5usyo"
+          class="mantine-Text-root mantine-PlasmaHeaderBreadcrumbs-separator mantine-Breadcrumbs-separator mantine-1y8084r"
         >
           /
         </div>
         <a
-          class="mantine-Text-root mantine-Anchor-root mantine-Breadcrumbs-breadcrumb mantine-1yycs9g"
+          class="mantine-Text-root mantine-Anchor-root mantine-PlasmaHeaderBreadcrumbs-breadcrumb mantine-Breadcrumbs-breadcrumb mantine-1p2lvqc"
         >
           Two
         </a>
         <div
-          class="mantine-Text-root mantine-Breadcrumbs-separator mantine-c5usyo"
+          class="mantine-Text-root mantine-PlasmaHeaderBreadcrumbs-separator mantine-Breadcrumbs-separator mantine-1y8084r"
         >
           /
         </div>
         <a
-          class="mantine-Text-root mantine-Anchor-root mantine-Breadcrumbs-breadcrumb mantine-1yycs9g"
+          class="mantine-Text-root mantine-Anchor-root mantine-PlasmaHeaderBreadcrumbs-breadcrumb mantine-Breadcrumbs-breadcrumb mantine-1p2lvqc"
         >
           Three
         </a>
       </div>
       <h1
-        class="mantine-Text-root mantine-Title-root mantine-m67b81"
+        class="mantine-Text-root mantine-Title-root mantine-PlasmaHeader-title mantine-1o7jx33"
       >
         Title
       </h1>
       <div
-        class="mantine-Text-root mantine-1w25z6f"
+        class="mantine-Text-root mantine-PlasmaHeader-description mantine-52dv7d"
       />
     </div>
   </div>

--- a/packages/website/src/examples/layout/Header/HeaderModal.demo.tsx
+++ b/packages/website/src/examples/layout/Header/HeaderModal.demo.tsx
@@ -1,0 +1,12 @@
+import {CloseButton, Header} from '@coveord/plasma-mantine';
+
+const Demo = () => (
+    <Header variant="modal">
+        Title
+        <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
+        <Header.Actions>
+            <CloseButton />
+        </Header.Actions>
+    </Header>
+);
+export default Demo;

--- a/packages/website/src/pages/layout/Header.tsx
+++ b/packages/website/src/pages/layout/Header.tsx
@@ -1,5 +1,6 @@
 import {HeaderMetadata} from '@coveord/plasma-components-props-analyzer';
 import HeaderDemo from '@examples/layout/Header/Header.demo?demo';
+import HeaderModalDemo from '@examples/layout/Header/HeaderModal.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -13,5 +14,8 @@ export default () => (
         id="Header"
         propsMetadata={HeaderMetadata}
         demo={<HeaderDemo />}
+        examples={{
+            modalVariant: <HeaderModalDemo grow title="Modal variant" />,
+        }}
     />
 );


### PR DESCRIPTION
### Proposed Changes

Followed [Mantine's guide on custom component](https://mantine.dev/guides/custom-components/) to make the Header themeable through the `theme` or `styles` attribute

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
