### PR TITLE
fix(mantine, header): add missing exports

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -16,7 +16,10 @@ import {HeaderActions} from './HeaderActions/HeaderActions';
 import {HeaderBreadcrumbs} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
 import {HeaderDocAnchor} from './HeaderDocAnchor/HeaderDocAnchor';
 
-type HeaderStylesNames = Selectors<typeof useStyles>;
+export type {HeaderDocAnchorProps, HeaderDocAnchorStylesNames} from './HeaderDocAnchor/HeaderDocAnchor';
+export type {HeaderBreadcrumbsProps, HeaderBreadcrumbsStylesNames} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
+export type {HeaderActionsProps, HeaderActionsStylesNames} from './HeaderActions/HeaderActions';
+export type HeaderStylesNames = Selectors<typeof useStyles>;
 
 export interface HeaderProps extends Omit<GroupProps, 'styles'>, DefaultProps<HeaderStylesNames, HeaderStylesParams> {
     /**

--- a/packages/mantine/src/components/header/HeaderActions/HeaderActions.tsx
+++ b/packages/mantine/src/components/header/HeaderActions/HeaderActions.tsx
@@ -2,7 +2,7 @@ import {DefaultProps, Group, GroupProps, Selectors, useComponentDefaultProps} fr
 import {FunctionComponent} from 'react';
 import {HeaderActionsStylesParams, useStyles} from './HeaderActions.styles';
 
-type HeaderActionsStylesNames = Selectors<typeof useStyles>;
+export type HeaderActionsStylesNames = Selectors<typeof useStyles>;
 
 export type HeaderActionsProps = GroupProps & DefaultProps<HeaderActionsStylesNames, HeaderActionsStylesParams>;
 

--- a/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbs.tsx
+++ b/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbs.tsx
@@ -2,7 +2,7 @@ import {Breadcrumbs, BreadcrumbsProps, DefaultProps, Selectors} from '@mantine/c
 import {FunctionComponent} from 'react';
 import {HeaderBreadcrumbsStylesParams, useStyles} from './HeaderBreadcrumbs.styles';
 
-type HeaderBreadcrumbsStylesNames = Selectors<typeof useStyles>;
+export type HeaderBreadcrumbsStylesNames = Selectors<typeof useStyles>;
 
 export type HeaderBreadcrumbsProps = BreadcrumbsProps &
     DefaultProps<HeaderBreadcrumbsStylesNames, HeaderBreadcrumbsStylesParams>;

--- a/packages/mantine/src/components/header/HeaderDocAnchor/HeaderDocAnchor.tsx
+++ b/packages/mantine/src/components/header/HeaderDocAnchor/HeaderDocAnchor.tsx
@@ -3,7 +3,7 @@ import {Anchor, DefaultProps, Selectors, Tooltip, TooltipProps, useComponentDefa
 import {FunctionComponent, ReactNode} from 'react';
 import {HeaderDocAnchorStylesParams, useStyles} from './HeaderDocAnchor.styles';
 
-type HeaderDocAnchorStylesNames = Selectors<typeof useStyles>;
+export type HeaderDocAnchorStylesNames = Selectors<typeof useStyles>;
 
 const defaultProps: Partial<HeaderDocAnchorProps> = {
     position: 'right',


### PR DESCRIPTION
### Proposed Changes

Added missing exports, some were previously exported (e.g.,  `HeaderDocAnchorProps `) and them not being exported is a breaking change

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
