### PR TITLE
fix(table): +reset page on predicate change, +unit tests

### DIFF
--- a/packages/mantine/src/components/table/TablePredicate.tsx
+++ b/packages/mantine/src/components/table/TablePredicate.tsx
@@ -8,7 +8,7 @@ const useStyles = createStyles((theme) => ({
     root: {},
     wrapper: {},
     label: {},
-    select: {}
+    select: {},
 }));
 
 type TablePredicateStylesNames = Selectors<typeof useStyles>;
@@ -40,10 +40,16 @@ export const TablePredicate: FunctionComponent<TablePredicateProps> = ({
     ...others
 }) => {
     const {classes} = useStyles(null, {name: 'TablePredicate', classNames, styles, unstyled});
-    const {form} = useTable();
+    const {form, setState} = useTable();
 
-    const onUpdate = (newValue: string) => {
+    const handleChange = (newValue: string) => {
         form.setFieldValue('predicates', {...form.values.predicates, [id]: newValue});
+        setState((prevState) => ({
+            ...prevState,
+            pagination: prevState.pagination
+                ? {pageIndex: 0, pageSize: prevState.pagination.pageSize}
+                : prevState.pagination,
+        }));
     };
 
     return (
@@ -53,7 +59,7 @@ export const TablePredicate: FunctionComponent<TablePredicateProps> = ({
                 <Select
                     withinPortal
                     value={form.values.predicates[id]}
-                    onChange={onUpdate}
+                    onChange={handleChange}
                     data={data}
                     aria-label={label ?? id}
                     searchable={data.length > 7}

--- a/packages/mantine/src/components/table/__tests__/TablePredicate.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TablePredicate.spec.tsx
@@ -62,4 +62,35 @@ describe('Table.Predicate', () => {
         });
         expect(onChange).toHaveBeenCalledWith(expect.objectContaining({predicates: {rank: 'first'}}));
     });
+
+    it('goes back to the first page when changing the predicate', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(
+            <Table data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns} onChange={onChange}>
+                <Table.Header>
+                    <Table.Predicate
+                        id="rank"
+                        data={[
+                            {value: 'first', label: 'First'},
+                            {value: 'second', label: 'Second'},
+                        ]}
+                    />
+                </Table.Header>
+                <Table.Footer>
+                    <Table.PerPage />
+                    <Table.Pagination totalPages={2} />
+                </Table.Footer>
+            </Table>,
+        );
+        await user.click(screen.getByRole('searchbox', {name: 'rank'}));
+        await user.click(screen.getByRole('option', {name: 'First'}));
+        expect(screen.getByRole('searchbox', {name: 'rank'})).toHaveValue('First');
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledTimes(1);
+        });
+        expect(onChange).toHaveBeenCalledWith(
+            expect.objectContaining({predicates: {rank: 'first'}, pagination: {pageIndex: 0, pageSize: 50}}),
+        );
+    });
 });


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-9179

When changing predicates, it sets the state to page: 0 the same way changing filter does.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
