### PR TITLE
feat(mantine): simplifying disabled tooltips on ActionIcon

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -314,6 +314,11 @@ const components: Component[] = [
         propsType: 'ButtonProps',
     },
     {
+        name: 'ActionIcon',
+        packageName: '@coveord/plasma-mantine',
+        propsType: 'ActionIconProps',
+    },
+    {
         name: 'CopyToClipboard',
         packageName: '@coveord/plasma-mantine',
         propsType: 'CopyToClipboardProps',

--- a/packages/mantine/src/components/action-icon/ActionIcon.tsx
+++ b/packages/mantine/src/components/action-icon/ActionIcon.tsx
@@ -1,0 +1,60 @@
+import {ActionIcon as MantineActionIcon, type ActionIconProps as MantineActionIconProps} from '@mantine/core';
+import {forwardRef, MouseEvent, MouseEventHandler, useState} from 'react';
+
+import {createPolymorphicComponent} from '../../utils';
+import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from '../button/ButtonWithDisabledTooltip';
+
+export interface ActionIconProps extends MantineActionIconProps, ButtonWithDisabledTooltipProps {
+    /* Handler executed on click */
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+const useLoadingHandler = (handler?: MouseEventHandler<HTMLButtonElement>) => {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+        const possiblePromise: unknown = handler?.(event);
+        try {
+            if (possiblePromise instanceof Promise) {
+                setIsLoading(true);
+                await possiblePromise;
+                setIsLoading(false);
+            }
+        } catch (err) {
+            setIsLoading(false);
+            console.error(err);
+        }
+    };
+
+    return {isLoading, handleClick};
+};
+
+const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
+    ({disabledTooltip, disabled, disabledTooltipProps, loading, onClick, ...others}, ref) => {
+        const {isLoading, handleClick} = useLoadingHandler(onClick);
+        return (
+            <ButtonWithDisabledTooltip
+                disabled={disabled}
+                disabledTooltip={disabledTooltip}
+                disabledTooltipProps={disabledTooltipProps}
+                fullWidth={others.fullWidth}
+            >
+                <MantineActionIcon
+                    loaderProps={{variant: 'oval'}}
+                    ref={ref}
+                    loading={isLoading || loading}
+                    onClick={handleClick}
+                    disabled={disabled}
+                    {...others}
+                />
+            </ButtonWithDisabledTooltip>
+        );
+    },
+);
+
+export const ActionIcon = createPolymorphicComponent<
+    'button',
+    ActionIconProps,
+    {Group: typeof MantineActionIcon.Group}
+>(_ActionIcon);
+ActionIcon.Group = MantineActionIcon.Group;

--- a/packages/mantine/src/components/action-icon/index.ts
+++ b/packages/mantine/src/components/action-icon/index.ts
@@ -1,0 +1,1 @@
+export * from './ActionIcon';

--- a/packages/mantine/src/components/index.ts
+++ b/packages/mantine/src/components/index.ts
@@ -9,5 +9,6 @@ export * from './table';
 export * from './prompt';
 export * from './modal-wizard';
 export * from './button';
+export * from './action-icon';
 export * from './menu';
 export * from './copyToClipboard';

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -20,6 +20,8 @@ export {
     type TableProps,
     type TableState,
     type InitialTableState,
+    ActionIcon,
+    type ActionIconProps,
     Button,
     type ButtonProps,
     Menu,

--- a/packages/website/src/SideNavigation.tsx
+++ b/packages/website/src/SideNavigation.tsx
@@ -112,6 +112,7 @@ const MantineNavigation = () => (
                 <InternalNavLink href="/layout/StickyFooter" label="Sticky footer" />
             </NavLink>
             <NavLink label="Form" icon={<ClickSize16Px height={16} />} defaultOpened>
+                <InternalNavLink href="/form/ActionIcon" label="Action Icon" />
                 <InternalNavLink href="/form/Button" label="Button" />
                 <InternalNavLink href="/form/CodeEditor" label="Code editor" />
                 <InternalNavLink href="/form/Collection" label="Collection" />

--- a/packages/website/src/examples/form/action-icon/ActionIcon.demo.tsx
+++ b/packages/website/src/examples/form/action-icon/ActionIcon.demo.tsx
@@ -1,0 +1,9 @@
+import {ActionIcon, showNotification} from '@coveord/plasma-mantine';
+import {EditSize16Px} from '@coveord/plasma-react-icons';
+
+const Demo = () => (
+    <ActionIcon onClick={() => showNotification({message: 'Button clicked'})} variant="filled" color="action" size="lg">
+        <EditSize16Px height={16} />
+    </ActionIcon>
+);
+export default Demo;

--- a/packages/website/src/examples/form/action-icon/ActionIconDisabled.demo.tsx
+++ b/packages/website/src/examples/form/action-icon/ActionIconDisabled.demo.tsx
@@ -1,0 +1,16 @@
+import {ActionIcon, showNotification} from '@coveord/plasma-mantine';
+import {ZombieSize16Px} from '@coveord/plasma-react-icons';
+
+const Demo = () => (
+    <ActionIcon
+        onClick={() => showNotification({message: 'Button clicked'})}
+        disabled
+        disabledTooltip="This button is disabled"
+        variant="outline"
+        color="action"
+        size="lg"
+    >
+        <ZombieSize16Px height={16} />
+    </ActionIcon>
+);
+export default Demo;

--- a/packages/website/src/examples/form/action-icon/ActionIconSecondary.demo.tsx
+++ b/packages/website/src/examples/form/action-icon/ActionIconSecondary.demo.tsx
@@ -1,0 +1,14 @@
+import {ActionIcon, showNotification} from '@coveord/plasma-mantine';
+import {SettingsSize16Px} from '@coveord/plasma-react-icons';
+
+const Demo = () => (
+    <ActionIcon
+        onClick={() => showNotification({message: 'Button clicked'})}
+        variant="outline"
+        color="action"
+        size="lg"
+    >
+        <SettingsSize16Px height={16} />
+    </ActionIcon>
+);
+export default Demo;

--- a/packages/website/src/examples/form/action-icon/ActionIconWithAsyncLoader.demo.tsx
+++ b/packages/website/src/examples/form/action-icon/ActionIconWithAsyncLoader.demo.tsx
@@ -1,0 +1,22 @@
+import {ActionIcon, showNotification} from '@coveord/plasma-mantine';
+import {CheckmarkSize24Px, DeleteSize16Px} from '@coveord/plasma-react-icons';
+
+const somethingAsync = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const promise = async () => {
+    await somethingAsync(3000);
+    showNotification({
+        title: 'Deleted successfully',
+        message: 'The delete button was put in a loading state while it was waiting for the delete to resolve.',
+        autoClose: false,
+        icon: <CheckmarkSize24Px height={24} />,
+        color: 'success',
+    });
+};
+
+const Demo = () => (
+    <ActionIcon onClick={promise} color="red" size="lg">
+        <DeleteSize16Px height={16} />
+    </ActionIcon>
+);
+export default Demo;

--- a/packages/website/src/pages/form/ActionIcon.tsx
+++ b/packages/website/src/pages/form/ActionIcon.tsx
@@ -1,0 +1,27 @@
+import {ActionIconMetadata} from '@coveord/plasma-components-props-analyzer';
+import ActionIconDemo from '@examples/form/action-icon/ActionIcon.demo?demo';
+import ActionIconDisabledDemo from '@examples/form/action-icon/ActionIconDisabled.demo?demo';
+import ActionIconSecondaryDemo from '@examples/form/action-icon/ActionIconSecondary.demo?demo';
+import ActionIconWithAsyncLoaderDemo from '../../examples/form/action-icon/ActionIconWithAsyncLoader.demo?demo';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
+
+const ActionIconPage = () => (
+    <PageLayout
+        id="ActionIcon"
+        title="Action Icon"
+        section="Form"
+        thumbnail="actionButton"
+        description="An ActionIcon is an icon-only button."
+        demo={<ActionIconDemo center />}
+        examples={{
+            secondary: <ActionIconSecondaryDemo center title="Secondary" />,
+            disabled: <ActionIconDisabledDemo center title="Disabled" />,
+            promiseHandler: <ActionIconWithAsyncLoaderDemo center title="Async click handler" />,
+        }}
+        sourcePath="/packages/mantine/src/components/action-icon/ActionIcon.tsx"
+        propsMetadata={ActionIconMetadata}
+    />
+);
+
+export default ActionIconPage;


### PR DESCRIPTION
### Proposed Changes

Doing the same trick we did on the Button component, but this time on the ActionIcon component. Meaning we're simplifying the combination of having tooltips over a disabled ActionIcon.

![image](https://github.com/coveo/plasma/assets/35579930/4c312e32-3b5d-4ead-96ca-ef69b93211e2)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
