### PR TITLE
feat(mantine): addition of tooltip management on the modal button in plasma

### DIFF
--- a/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
+++ b/packages/mantine/src/components/modal-wizard/ModalWizard.tsx
@@ -230,6 +230,7 @@ export const ModalWizard: ModalWizardType = ({
                     </Button>
 
                     <Button
+                        disabledTooltip={currentStep.props.disabledTooltipLabel}
                         disabled={!isValid}
                         onClick={() => {
                             if (isLastStep) {

--- a/packages/mantine/src/components/modal-wizard/ModalWizardStep.tsx
+++ b/packages/mantine/src/components/modal-wizard/ModalWizardStep.tsx
@@ -42,6 +42,12 @@ export interface ModalWizardStepProps {
      * @default true
      */
     countsAsProgress?: boolean;
+
+    /**
+     *  Tooltip label of the next button when disabled
+     *
+     */
+    disabledTooltipLabel?: string;
 }
 
 const ModalWizardStep: FunctionComponent<PropsWithChildren<ModalWizardStepProps>> = ({children}) => <>{children}</>;

--- a/packages/website/src/examples/layout/ModalWizard/ModalWizardWithTooltip.demo.tsx
+++ b/packages/website/src/examples/layout/ModalWizard/ModalWizardWithTooltip.demo.tsx
@@ -1,0 +1,37 @@
+import {Box, Button, ModalWizard} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+export default () => {
+    const [opened, setOpened] = useState(false);
+
+    return (
+        <>
+            <Button m="md" onClick={() => setOpened(true)}>
+                Open Modal Wizard
+            </Button>
+            <ModalWizard onClose={() => setOpened(false)} opened={opened} onFinish={() => setOpened(false)}>
+                <ModalWizard.Step
+                    docLink="https://coveo.com"
+                    title="Current Step is 1"
+                    showProgressBar={false}
+                    countsAsProgress={false}
+                    description="Description of step 1"
+                    validateStep={() => ({isValid: true})}
+                    docLinkTooltipLabel="Tooltip label"
+                >
+                    <Box mih={300}>Slide 1</Box>
+                </ModalWizard.Step>
+                <ModalWizard.Step
+                    docLink="https://coveo.com"
+                    title="Current Step is 2"
+                    description="Description of step 2"
+                    validateStep={() => ({isValid: false})}
+                    docLinkTooltipLabel="Tooltip label"
+                    disabledTooltipLabel="Tooltip label on disabled button"
+                >
+                    <Box mih={300}>Slide 2</Box>
+                </ModalWizard.Step>
+            </ModalWizard>
+        </>
+    );
+};

--- a/packages/website/src/pages/layout/ModalWizard.tsx
+++ b/packages/website/src/pages/layout/ModalWizard.tsx
@@ -1,6 +1,7 @@
 import {ModalWizardMetadata} from '@coveord/plasma-components-props-analyzer';
 import ModalWizardDemo from '@examples/layout/ModalWizard/ModalWizard.demo';
 import ModalWizardWithFormValidation from '@examples/layout/ModalWizard/ModalWizardWithFormValidation.demo?demo';
+import ModalWizardWithTooltip from '@examples/layout/ModalWizard/ModalWizardWithTooltip.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -15,6 +16,7 @@ export default () => (
         demo={<ModalWizardDemo />}
         examples={{
             formValidation: <ModalWizardWithFormValidation noPadding title="Modal Wizard with Form Validation" />,
+            tooltip: <ModalWizardWithTooltip noPadding title="Modal Wizard with tooltip on next button" />,
         }}
     />
 );


### PR DESCRIPTION
### Proposed Changes

For a story, I need to bring back a functionality present in an old modal, adding a tooltip to a deactivated button

![Capture d’écran, le 2023-09-20 à 21 37 51](https://github.com/coveo/plasma/assets/14080002/cf379985-a592-46f4-9212-25e7049173a8)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
