### PR TITLE
fix(mantine): sticky footer doesn't stick anymore

### DIFF
--- a/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
@@ -35,12 +35,13 @@ export interface StickyFooterProps extends DefaultProps<Selectors<typeof useStyl
 }
 
 const useStyles = createStyles((theme) => ({
-    root: {},
-    footer: {
+    root: {
         position: 'sticky',
         bottom: 0,
         zIndex: 10,
         backgroundColor: 'white',
+    },
+    footer: {
         padding: theme.spacing.lg,
     },
     divider: {},


### PR DESCRIPTION
### Proposed Changes

When [making the StickyFooter customizable through the theme](https://github.com/coveo/plasma/pull/3547), I made a mistake by moving the root styles to the inner Group component. The current PR moves the styles back on the root element of the StickyFooter just like it was before. 

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
