### PR TITLE
fix(mantine): performance issue in CodeEditor

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -188,7 +188,6 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                 options={{
                     minimap: {enabled: false},
                     wordWrap: 'on',
-                    wrappingStrategy: 'advanced',
                     scrollBeyondLastLine: false,
                     formatOnPaste: true,
                     fontSize: px(theme.fontSizes.xs),


### PR DESCRIPTION
### Proposed Changes

#### Problem

While debugging a performance issue using the browser's performance profiler, I found out that the `CodeEditor` component from `@coveord/plasma-mantine` was having issues rendering very large chunks of text.

![image](https://github.com/coveo/plasma/assets/35579930/7077f332-a9d4-4d61-af1a-8a3bec8d0e8a)

As we can see it in this screenshot, it would spend over 16 seconds in the `discoverBreaks` function. So I did a bit of research on monaco editor and found out about the `wrappingStrategy` option:

> wrappingStrategy: 'advanced' means that we delegate the wrap points computations to the browser. This works by us creating a dom node for each line of the editor, setting the contents of each dom node to the text on each line, and then setting a specific width. We then proceed to use browser APIs to detect the wrapping points. This is super slow (causes a forced browser layout). - https://github.com/microsoft/vscode/issues/132220#issuecomment-927856270

From my understanding, with this strategy, one dom node is created for each line of the editor. When the editor content is so large that it wraps over thousands of lines, it generates too many DOM nodes for the browser to manage efficiently.

#### Solution

The solution is actually a very simple one liner: use the default wrapping strategy called `simple`. 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
