### PR TITLE
feat(mantine, browserpreview): add new Mantine BrowserPreview component

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -319,6 +319,11 @@ const components: Component[] = [
         propsType: 'ActionIconProps',
     },
     {
+        name: 'BrowserPreviewMantine',
+        packageName: '@coveord/plasma-mantine',
+        propsType: 'BrowserPreviewProps',
+    },
+    {
         name: 'CopyToClipboard',
         packageName: '@coveord/plasma-mantine',
         propsType: 'CopyToClipboardProps',

--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -50,7 +50,7 @@ const components: Component[] = [
         packageName: '@coveord/plasma-react',
     },
     {
-        name: 'BrowserPreview',
+        name: 'BrowserPreviewLegacy',
         packageName: '@coveord/plasma-react',
     },
     {
@@ -319,7 +319,7 @@ const components: Component[] = [
         propsType: 'ActionIconProps',
     },
     {
-        name: 'BrowserPreviewMantine',
+        name: 'BrowserPreview',
         packageName: '@coveord/plasma-mantine',
         propsType: 'BrowserPreviewProps',
     },

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.styles.ts
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.styles.ts
@@ -8,6 +8,7 @@ export default createStyles((theme) => ({
         borderColor: theme.colors.gray[3],
         flex: 1,
     },
-    header: {boxShadow: theme.shadows.xs, borderRadius: '8px 8px 0 0'},
+    header: {boxShadow: theme.shadows.xs, borderRadius: `${theme.defaultRadius}px ${theme.defaultRadius}px 0 0`},
     content: {overflow: 'auto', flexGrow: 1},
+    infoIcon: {color: theme.colors.gray[5]},
 }));

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.styles.ts
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.styles.ts
@@ -1,0 +1,15 @@
+// MyComponent.styles.ts
+import {createStyles} from '@mantine/core';
+
+export default createStyles((theme) => ({
+    // add all styles as usual
+    root: {
+        boxShadow: theme.shadows.md,
+        borderRadius: theme.defaultRadius,
+        border: '1px solid',
+        borderColor: theme.colors.gray[3],
+        flex: 1,
+    },
+    header: {boxShadow: theme.shadows.xs, borderRadius: '8px 8px 0 0'},
+    content: {overflow: 'auto', flexGrow: 1},
+}));

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.styles.ts
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.styles.ts
@@ -1,8 +1,6 @@
-// MyComponent.styles.ts
 import {createStyles} from '@mantine/core';
 
 export default createStyles((theme) => ({
-    // add all styles as usual
     root: {
         boxShadow: theme.shadows.md,
         borderRadius: theme.defaultRadius,

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -1,0 +1,39 @@
+import {InfoSize16Px} from '@coveord/plasma-react-icons';
+import {Box, Group, Image, Stack, Text, Title, Tooltip} from '@mantine/core';
+import {PropsWithChildren} from 'react';
+
+export interface BrowserPreviewProps {
+    /**
+     * Text that will be displayed in the tooltip on the info icon
+     *
+     * @default The final look in your search page may differ due to the customization you made in your page.
+     *
+     */
+    headerDescription?: string;
+    /**
+     * Title of the browser preview.
+     */
+    title?: string;
+}
+
+export const BrowserPreview = ({
+    children,
+    headerDescription = 'The final look in your search page may differ due to the customization you made in your page.',
+    title,
+}: PropsWithChildren<BrowserPreviewProps>) => (
+    <Stack mih={512} sx={{border: '1px solid', borderRadius: '8px', boxShadow: '0px 1px 0px 0px rgba(4, 8, 31, 0.08)'}}>
+        <Box>
+            <Group px={16} py={8} sx={(theme) => ({backgroundColor: theme.colors.gray[1]})}>
+                <Title order={4}>Preview</Title>
+                <Tooltip label={headerDescription} position="right">
+                    <InfoSize16Px height={16} />
+                </Tooltip>
+                <Text truncate>{title}</Text>
+                <Box>
+                    <Image />
+                </Box>
+            </Group>
+        </Box>
+        <Box>{children}</Box>
+    </Stack>
+);

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -1,12 +1,23 @@
 import {InfoSize16Px} from '@coveord/plasma-react-icons';
-import {Box, ColorSwatch, Flex, Group, Stack, Text, Title, Tooltip, useMantineTheme} from '@mantine/core';
+import {
+    Box,
+    ColorSwatch,
+    DefaultProps,
+    Flex,
+    Group,
+    Selectors,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine/core';
 import {PropsWithChildren} from 'react';
+import useStyles from './BrowserPreview.styles';
 
-export interface BrowserPreviewProps {
+export interface BrowserPreviewProps extends DefaultProps<Selectors<typeof useStyles>> {
     /**
-     * Text that will be displayed in the tooltip on the info icon
-     *
-     * @default The final look in your search page may differ due to the customization you made in your page.
+     * Text to display in a tooltip in the header.
      *
      */
     headerTooltip?: string;
@@ -18,39 +29,29 @@ export interface BrowserPreviewProps {
 
 export const BrowserPreview = ({
     children,
-    headerTooltip = 'The final look in your search page may differ due to the customization you made in your page.',
+    headerTooltip,
     title,
+    // Style props
+    classNames,
+    className,
+    styles,
+    unstyled,
 }: PropsWithChildren<BrowserPreviewProps>) => {
     const theme = useMantineTheme();
+    const {classes, cx} = useStyles(null, {classNames, name: 'BrowserPreview', styles, unstyled});
     return (
-        <Stack
-            spacing={0}
-            maw={544}
-            mih={0}
-            style={{
-                boxShadow: theme.shadows.md,
-                borderRadius: theme.defaultRadius,
-                border: '1px solid',
-                borderColor: theme.colors.gray[3],
-                flex: 1,
-            }}
-        >
+        <Stack className={cx(classes.root, className)} spacing={0} maw={544} mih={0}>
             <Box>
-                <Group
-                    position="apart"
-                    px="sm"
-                    py="xs"
-                    bg="gray.1"
-                    style={{boxShadow: theme.shadows.xs, borderRadius: '8px 8px 0 0'}}
-                    noWrap
-                >
+                <Group className={classes.header} position="apart" px="sm" py="xs" bg="gray.1" noWrap>
                     <Group spacing="xs" noWrap>
                         <Title color="gray.6" order={4}>
                             Preview
                         </Title>
-                        <Tooltip label={headerTooltip} position="right" maw={400}>
-                            <InfoSize16Px height={16} style={{color: theme.colors.gray[5]}} />
-                        </Tooltip>
+                        {!!headerTooltip && (
+                            <Tooltip label={headerTooltip} position="right" maw={400}>
+                                <InfoSize16Px height={16} style={{color: theme.colors.gray[5]}} />
+                            </Tooltip>
+                        )}
                     </Group>
                     <Text lineClamp={1} color="gray.6">
                         {title}
@@ -62,7 +63,7 @@ export const BrowserPreview = ({
                     </Group>
                 </Group>
             </Box>
-            <Flex p="xl" direction="column" style={{overflow: 'auto', flexGrow: 1}}>
+            <Flex className={classes.content} p="xl" direction="column">
                 {children}
             </Flex>
         </Stack>

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -14,26 +14,26 @@ export interface BrowserPreviewProps {
      * Title of the browser preview.
      */
     title?: string;
-    /**
-     * Maximum height of the window.
-     *
-     */
-    maxHeight?: number;
 }
 
 export const BrowserPreview = ({
     children,
     headerTooltip = 'The final look in your search page may differ due to the customization you made in your page.',
     title,
-    maxHeight,
 }: PropsWithChildren<BrowserPreviewProps>) => {
     const theme = useMantineTheme();
     return (
         <Stack
             spacing={0}
-            style={{boxShadow: theme.shadows.md, borderRadius: theme.defaultRadius}}
-            mah={maxHeight ?? 'none'}
+            style={{
+                boxShadow: theme.shadows.md,
+                borderRadius: theme.defaultRadius,
+                border: '1px solid',
+                borderColor: theme.colors.gray[3],
+                flex: 1,
+            }}
             maw={544}
+            mih={0}
         >
             <Box>
                 <Group
@@ -62,7 +62,7 @@ export const BrowserPreview = ({
                     </Group>
                 </Group>
             </Box>
-            <Flex py="xl" px="lg" direction="column" style={{overflowY: 'auto', flexGrow: 1}}>
+            <Flex p="xl" direction="column" style={{overflow: 'auto', flexGrow: 1}}>
                 {children}
             </Flex>
         </Stack>

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -33,7 +33,7 @@ export const BrowserPreview = ({
             spacing={0}
             style={{boxShadow: theme.shadows.md, borderRadius: theme.defaultRadius}}
             mah={maxHeight ?? 'none'}
-            w={544}
+            maw={544}
         >
             <Box>
                 <Group

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -36,11 +36,12 @@ export const BrowserPreview = ({
     className,
     styles,
     unstyled,
+    ...others
 }: PropsWithChildren<BrowserPreviewProps>) => {
     const theme = useMantineTheme();
     const {classes, cx} = useStyles(null, {classNames, name: 'BrowserPreview', styles, unstyled});
     return (
-        <Stack className={cx(classes.root, className)} spacing={0} maw={544} mih={0}>
+        <Stack className={cx(classes.root, className)} spacing={0} maw={544} mih={0} {...others}>
             <Box>
                 <Group className={classes.header} position="apart" px="sm" py="xs" bg="gray.1" noWrap>
                     <Group spacing="xs" noWrap>
@@ -49,7 +50,7 @@ export const BrowserPreview = ({
                         </Title>
                         {!!headerTooltip && (
                             <Tooltip label={headerTooltip} position="right" maw={400}>
-                                <InfoSize16Px height={16} style={{color: theme.colors.gray[5]}} />
+                                <InfoSize16Px height={16} className={classes.infoIcon} />
                             </Tooltip>
                         )}
                     </Group>

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -11,7 +11,7 @@ export interface BrowserPreviewProps {
      */
     headerTooltip?: string;
     /**
-     * Title of the browser preview.
+     * Custom title to be displayed at the center of the header.
      */
     title?: string;
 }
@@ -25,6 +25,8 @@ export const BrowserPreview = ({
     return (
         <Stack
             spacing={0}
+            maw={544}
+            mih={0}
             style={{
                 boxShadow: theme.shadows.md,
                 borderRadius: theme.defaultRadius,
@@ -32,8 +34,6 @@ export const BrowserPreview = ({
                 borderColor: theme.colors.gray[3],
                 flex: 1,
             }}
-            maw={544}
-            mih={0}
         >
             <Box>
                 <Group

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -37,7 +37,7 @@ export const BrowserPreview = ({
                         <Title color="gray.6" order={4}>
                             Preview
                         </Title>
-                        <Tooltip label={headerTooltip} position="right" maw={400} multiline>
+                        <Tooltip label={headerTooltip} position="right" maw={400}>
                             <InfoSize16Px height={16} style={{color: theme.colors.gray[5]}} />
                         </Tooltip>
                     </Group>

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -1,5 +1,5 @@
 import {InfoSize16Px} from '@coveord/plasma-react-icons';
-import {Box, ColorSwatch, Group, Stack, Text, Title, Tooltip, useMantineTheme} from '@mantine/core';
+import {Box, ColorSwatch, Flex, Group, Stack, Text, Title, Tooltip, useMantineTheme} from '@mantine/core';
 import {PropsWithChildren} from 'react';
 
 export interface BrowserPreviewProps {
@@ -23,12 +23,12 @@ export const BrowserPreview = ({
 }: PropsWithChildren<BrowserPreviewProps>) => {
     const theme = useMantineTheme();
     return (
-        <Stack spacing={0} h={762} maw={544} style={{boxShadow: theme.shadows.md, borderRadius: '8px'}}>
+        <Stack spacing={0} h={762} maw={544} style={{boxShadow: theme.shadows.md, borderRadius: theme.defaultRadius}}>
             <Box>
                 <Group
                     position="apart"
-                    px={16}
-                    py={8}
+                    px="sm"
+                    py="xs"
                     bg="gray.1"
                     style={{boxShadow: theme.shadows.xs, borderRadius: '8px 8px 0 0'}}
                     noWrap
@@ -51,9 +51,9 @@ export const BrowserPreview = ({
                     </Group>
                 </Group>
             </Box>
-            <Box py="xl" px="lg" style={{overflowY: 'auto', display: 'flex', flexDirection: 'column', flexGrow: 1}}>
+            <Flex py="xl" px="lg" direction="column" style={{overflowY: 'auto', flexGrow: 1}}>
                 {children}
-            </Box>
+            </Flex>
         </Stack>
     );
 };

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -1,5 +1,5 @@
 import {InfoSize16Px} from '@coveord/plasma-react-icons';
-import {Box, Group, Image, Stack, Text, Title, Tooltip} from '@mantine/core';
+import {Box, ColorSwatch, Group, Stack, Text, Title, Tooltip, useMantineTheme} from '@mantine/core';
 import {PropsWithChildren} from 'react';
 
 export interface BrowserPreviewProps {
@@ -9,7 +9,7 @@ export interface BrowserPreviewProps {
      * @default The final look in your search page may differ due to the customization you made in your page.
      *
      */
-    headerDescription?: string;
+    headerTooltip?: string;
     /**
      * Title of the browser preview.
      */
@@ -18,22 +18,42 @@ export interface BrowserPreviewProps {
 
 export const BrowserPreview = ({
     children,
-    headerDescription = 'The final look in your search page may differ due to the customization you made in your page.',
+    headerTooltip = 'The final look in your search page may differ due to the customization you made in your page.',
     title,
-}: PropsWithChildren<BrowserPreviewProps>) => (
-    <Stack mih={512} sx={{border: '1px solid', borderRadius: '8px', boxShadow: '0px 1px 0px 0px rgba(4, 8, 31, 0.08)'}}>
-        <Box>
-            <Group px={16} py={8} sx={(theme) => ({backgroundColor: theme.colors.gray[1]})}>
-                <Title order={4}>Preview</Title>
-                <Tooltip label={headerDescription} position="right">
-                    <InfoSize16Px height={16} />
-                </Tooltip>
-                <Text truncate>{title}</Text>
-                <Box>
-                    <Image />
-                </Box>
-            </Group>
-        </Box>
-        <Box>{children}</Box>
-    </Stack>
-);
+}: PropsWithChildren<BrowserPreviewProps>) => {
+    const theme = useMantineTheme();
+    return (
+        <Stack spacing={0} h={762} maw={544} style={{boxShadow: theme.shadows.md, borderRadius: '8px'}}>
+            <Box>
+                <Group
+                    position="apart"
+                    px={16}
+                    py={8}
+                    bg="gray.1"
+                    style={{boxShadow: theme.shadows.xs, borderRadius: '8px 8px 0 0'}}
+                    noWrap
+                >
+                    <Group spacing="xs" noWrap>
+                        <Title color="gray.6" order={4}>
+                            Preview
+                        </Title>
+                        <Tooltip label={headerTooltip} position="right" maw={400} multiline>
+                            <InfoSize16Px height={16} style={{color: theme.colors.gray[5]}} />
+                        </Tooltip>
+                    </Group>
+                    <Text lineClamp={1} color="gray.6">
+                        {title}
+                    </Text>
+                    <Group spacing="xs" noWrap>
+                        <ColorSwatch color={theme.colors.gray[3]} />
+                        <ColorSwatch color={theme.colors.gray[3]} />
+                        <ColorSwatch color={theme.colors.gray[3]} />
+                    </Group>
+                </Group>
+            </Box>
+            <Box py="xl" px="lg" style={{overflowY: 'auto', display: 'flex', flexDirection: 'column', flexGrow: 1}}>
+                {children}
+            </Box>
+        </Stack>
+    );
+};

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -14,16 +14,27 @@ export interface BrowserPreviewProps {
      * Title of the browser preview.
      */
     title?: string;
+    /**
+     * Maximum height of the window.
+     *
+     */
+    maxHeight?: number;
 }
 
 export const BrowserPreview = ({
     children,
     headerTooltip = 'The final look in your search page may differ due to the customization you made in your page.',
     title,
+    maxHeight,
 }: PropsWithChildren<BrowserPreviewProps>) => {
     const theme = useMantineTheme();
     return (
-        <Stack spacing={0} h={762} maw={544} style={{boxShadow: theme.shadows.md, borderRadius: theme.defaultRadius}}>
+        <Stack
+            spacing={0}
+            style={{boxShadow: theme.shadows.md, borderRadius: theme.defaultRadius}}
+            mah={maxHeight ?? 'none'}
+            w={544}
+        >
             <Box>
                 <Group
                     position="apart"

--- a/packages/mantine/src/components/browser-preview/__tests__/BrowserPreview.spec.tsx
+++ b/packages/mantine/src/components/browser-preview/__tests__/BrowserPreview.spec.tsx
@@ -1,0 +1,44 @@
+import userEvent from '@testing-library/user-event';
+import {render, screen, waitFor} from '@testing-library/react';
+import {BrowserPreview} from '../BrowserPreview';
+
+describe('BrowserPreview', () => {
+    it('renders the default tooltip content when none specified', async () => {
+        const user = userEvent.setup();
+
+        render(<BrowserPreview />);
+
+        await waitFor(() => screen.findByRole('img', {name: /info/i}));
+        await user.hover(screen.getByRole('img', {name: /info/i}));
+
+        expect(
+            await screen.findByText(
+                'The final look in your search page may differ due to the customization you made in your page.',
+            ),
+        ).toBeVisible();
+    });
+    it('renders the specified text as the header tooltip content', async () => {
+        const user = userEvent.setup();
+        const headerTooltip = 'This is a custom description.';
+
+        render(<BrowserPreview headerTooltip={headerTooltip} />);
+
+        await waitFor(() => screen.findByRole('img', {name: /info/i}));
+        await user.hover(screen.getByRole('img', {name: /info/i}));
+
+        expect(await screen.findByText(headerTooltip)).toBeVisible();
+    });
+
+    it('renders the specific title when provided', () => {
+        const headerTitle = 'Custom title.';
+        render(<BrowserPreview title={headerTitle} />);
+
+        expect(screen.getByText(/custom title/i)).toBeInTheDocument();
+    });
+
+    it('renders the children', () => {
+        render(<BrowserPreview>This is awesome content</BrowserPreview>);
+
+        expect(screen.getByText(/this is awesome content/i)).toBeInTheDocument();
+    });
+});

--- a/packages/mantine/src/components/browser-preview/__tests__/BrowserPreview.spec.tsx
+++ b/packages/mantine/src/components/browser-preview/__tests__/BrowserPreview.spec.tsx
@@ -3,19 +3,10 @@ import {render, screen, waitFor} from '@testing-library/react';
 import {BrowserPreview} from '../BrowserPreview';
 
 describe('BrowserPreview', () => {
-    it('renders the default tooltip content when none specified', async () => {
-        const user = userEvent.setup();
-
+    it('shows no tooltip when none specified', async () => {
         render(<BrowserPreview />);
 
-        await waitFor(() => screen.findByRole('img', {name: /info/i}));
-        await user.hover(screen.getByRole('img', {name: /info/i}));
-
-        expect(
-            await screen.findByText(
-                'The final look in your search page may differ due to the customization you made in your page.',
-            ),
-        ).toBeVisible();
+        expect(screen.queryByRole('img', {name: /info/i})).not.toBeInTheDocument();
     });
     it('renders the specified text as the header tooltip content', async () => {
         const user = userEvent.setup();

--- a/packages/mantine/src/components/browser-preview/index.ts
+++ b/packages/mantine/src/components/browser-preview/index.ts
@@ -1,0 +1,1 @@
+export * from './BrowserPreview';

--- a/packages/mantine/src/components/index.ts
+++ b/packages/mantine/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './blank-slate';
+export * from './browser-preview';
 export * from './code-editor';
 export * from './collection';
 export * from './date-range-picker';

--- a/packages/mantine/src/hooks/useRowSelection.ts
+++ b/packages/mantine/src/hooks/useRowSelection.ts
@@ -11,7 +11,7 @@ export const useRowSelection = <T>(
         onRowSelectionChange,
         multiRowSelectionEnabled,
         additionalRootNodes = [],
-    }: Pick<TableProps<T>, 'onRowSelectionChange' | 'multiRowSelectionEnabled' | 'additionalRootNodes'>
+    }: Pick<TableProps<T>, 'onRowSelectionChange' | 'multiRowSelectionEnabled' | 'additionalRootNodes'>,
 ) => {
     const outsideClickRef = useRef<HTMLDivElement>();
     useClickOutside(
@@ -21,7 +21,7 @@ export const useRowSelection = <T>(
             }
         },
         null,
-        [outsideClickRef.current, ...additionalRootNodes]
+        [outsideClickRef.current, ...additionalRootNodes],
     );
 
     // Need to call this outside of the onRowSelectionChange of the table to avoid rendering conflicts if the callback queues an update in a parent component.
@@ -36,7 +36,7 @@ export const useRowSelection = <T>(
             table.setState((old) => {
                 const newRowSelection = functionalUpdate(
                     rowSelectionUpdater,
-                    old['rowSelection']
+                    old['rowSelection'],
                 ) as RowSelectionWithData<T>;
 
                 if (isEqual(old['rowSelection'], newRowSelection)) {
@@ -49,7 +49,7 @@ export const useRowSelection = <T>(
                     if (newRowSelection[rowId] === true) {
                         if (!rows[rowId]) {
                             console.error(
-                                'The table was not initialized properly, the rowSelection state should contain an object of type Record<string, TData>.'
+                                'The table was not initialized properly, the rowSelection state should contain an object of type Record<string, TData>.',
                             );
                         }
                         newRowSelection[rowId] = rows[rowId]?.original ?? (true as T);

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -14,6 +14,7 @@ export {type NotificationProps} from '@mantine/notifications';
 export {Pagination} from '@mantine/core';
 // explicitly overriding mantine components
 export {
+    BrowserPreview,
     Header,
     type HeaderProps,
     Table,

--- a/packages/react/src/components/browserPreview/BrowserPreview.tsx
+++ b/packages/react/src/components/browserPreview/BrowserPreview.tsx
@@ -20,7 +20,7 @@ export interface BrowserPreviewProps {
 }
 
 /**
- * @deprecated Use Mantine instead
+ * @deprecated Use `BrowserPreview` from `@coveord/plasma-mantine` instead.
  */
 export const BrowserPreview: FunctionComponent<PropsWithChildren<BrowserPreviewProps>> = ({
     children,

--- a/packages/website/src/SideNavigation.tsx
+++ b/packages/website/src/SideNavigation.tsx
@@ -105,6 +105,7 @@ const MantineNavigation = () => (
             </NavLink>
             <NavLink label="Layout" icon={<RichUiSize16Px height={16} />} defaultOpened>
                 <InternalNavLink href="/layout/Header" label="Header" />
+                <InternalNavLink href="/layout/BrowserPreview" label="Browser Preview" />
                 <InternalNavLink href="/layout/Table" label="Table" />
                 <InternalNavLink href="/layout/Modal" label="Modal" />
                 <InternalNavLink href="/layout/ModalWizard" label="ModalWizard" />

--- a/packages/website/src/SideNavigation.tsx
+++ b/packages/website/src/SideNavigation.tsx
@@ -99,18 +99,18 @@ const MantineNavigation = () => (
                 rightSection={<ExternalSize16Px height={16} />}
             />
             <NavLink label="Foundations" icon={<LayeringTechniquesSize16Px height={16} />} defaultOpened>
-                <InternalNavLink href="/foundations/Iconography" label="Iconography" />
                 <InternalNavLink href="/foundations/Colors" label="Colors" />
+                <InternalNavLink href="/foundations/Iconography" label="Iconography" />
                 <InternalNavLink href="/foundations/TypeKit" label="TypeKit" />
             </NavLink>
             <NavLink label="Layout" icon={<RichUiSize16Px height={16} />} defaultOpened>
-                <InternalNavLink href="/layout/Header" label="Header" />
                 <InternalNavLink href="/layout/BrowserPreview" label="Browser Preview" />
-                <InternalNavLink href="/layout/Table" label="Table" />
+                <InternalNavLink href="/layout/Header" label="Header" />
                 <InternalNavLink href="/layout/Modal" label="Modal" />
                 <InternalNavLink href="/layout/ModalWizard" label="ModalWizard" />
                 <InternalNavLink href="/layout/Prompt" label="Prompt" />
                 <InternalNavLink href="/layout/StickyFooter" label="Sticky footer" />
+                <InternalNavLink href="/layout/Table" label="Table" />
             </NavLink>
             <NavLink label="Form" icon={<ClickSize16Px height={16} />} defaultOpened>
                 <InternalNavLink href="/form/ActionIcon" label="Action Icon" />

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -3,6 +3,7 @@ import {
     Box,
     Center,
     createStyles,
+    Flex,
     ScrollArea,
     SimpleGrid,
     Stack,
@@ -47,10 +48,18 @@ const useStyles = createStyles((theme, {grow, noPadding}: DemoComponentProps) =>
     preview: {
         backgroundColor: 'white',
         minHeight: 100,
+        display: 'flex',
+        flexDirection: 'column',
     },
     previewWrapper: {
         padding: noPadding ? 0 : theme.spacing.md,
         height: grow ? MAX_HEIGHT : '100%',
+    },
+    flexPreviewWrapper: {
+        padding: noPadding ? 0 : theme.spacing.md,
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0,
     },
     code: {
         minHeight: 100,
@@ -81,9 +90,15 @@ const Demo = ({children, snippet, center = false, grow = false, title, layout, n
             ) : null}
             <SimpleGrid className={classes.sandbox} cols={layout === 'vertical' ? 1 : 2} spacing={0}>
                 <Box component={center ? Center : 'div'} className={classes.preview}>
-                    <ScrollArea.Autosize mah={maxHeight ?? MAX_HEIGHT}>
-                        <div className={classes.previewWrapper}>{children}</div>
-                    </ScrollArea.Autosize>
+                    {!!maxHeight ? (
+                        <Flex direction={'column'} mah={maxHeight} style={{flex: 1}}>
+                            <div className={classes.flexPreviewWrapper}>{children}</div>
+                        </Flex>
+                    ) : (
+                        <ScrollArea.Autosize mah={MAX_HEIGHT}>
+                            <div className={classes.previewWrapper}>{children}</div>
+                        </ScrollArea.Autosize>
+                    )}
                 </Box>
                 <div className={classes.code}>
                     <Prism

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -60,6 +60,7 @@ const useStyles = createStyles((theme, {grow, noPadding}: DemoComponentProps) =>
         display: 'flex',
         flexDirection: 'column',
         minHeight: 0,
+        flex: 1,
     },
     code: {
         minHeight: 100,

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -110,7 +110,7 @@ const Demo = ({children, snippet, center = false, grow = false, title, layout, n
                         radius={0}
                         noCopy
                         scrollAreaComponent={ScrollArea.Autosize}
-                        styles={{scrollArea: {maxHeight: MAX_HEIGHT, minHeight: MIN_HEIGHT}}}
+                        styles={{scrollArea: {maxHeight: maxHeight ?? MAX_HEIGHT, minHeight: MIN_HEIGHT}}}
                     >
                         {snippet}
                     </Prism>

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -59,7 +59,7 @@ const useStyles = createStyles((theme, {grow, noPadding}: DemoComponentProps) =>
     },
 }));
 
-const Demo = ({children, snippet, center = false, grow = false, title, layout, noPadding}: DemoProps) => {
+const Demo = ({children, snippet, center = false, grow = false, title, layout, noPadding, maxHeight}: DemoProps) => {
     const {classes} = useStyles({center, grow, noPadding});
     const clipboard = useClipboard();
     const createSandbox = async () => {
@@ -81,7 +81,7 @@ const Demo = ({children, snippet, center = false, grow = false, title, layout, n
             ) : null}
             <SimpleGrid className={classes.sandbox} cols={layout === 'vertical' ? 1 : 2} spacing={0}>
                 <Box component={center ? Center : 'div'} className={classes.preview}>
-                    <ScrollArea.Autosize mah={MAX_HEIGHT}>
+                    <ScrollArea.Autosize mah={maxHeight ?? MAX_HEIGHT}>
                         <div className={classes.previewWrapper}>{children}</div>
                     </ScrollArea.Autosize>
                 </Box>

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreview.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreview.demo.tsx
@@ -22,7 +22,7 @@ const makeData = (len: number): Product[] =>
             price: faker.commerce.price(),
         }));
 
-const Demo = ({pageSize = 7, numberOfItems = 40}: DemoProps) => {
+const Demo = ({pageSize = 5, numberOfItems = 40}: DemoProps) => {
     const [page, setPage] = useState(1);
     const data: Product[][] = makeData(40).reduce((all, one, i) => {
         const ch = Math.floor(i / pageSize);
@@ -34,7 +34,7 @@ const Demo = ({pageSize = 7, numberOfItems = 40}: DemoProps) => {
     return (
         <BrowserPreview>
             <Stack style={{flexGrow: 1}}>
-                <Stack spacing="sm" justify="space-between">
+                <Stack spacing="xl" pb="sm">
                     {data[page - 1].map((product) => (
                         <Stack spacing={0}>
                             <Text size="md" color="gray.7">

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreview.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreview.demo.tsx
@@ -1,8 +1,65 @@
-import {BrowserPreview} from '@coveord/plasma-mantine';
+import {BrowserPreview, Flex, Pagination, Stack, Text} from '@coveord/plasma-mantine';
+import {faker} from '@faker-js/faker';
+import {useState} from 'react';
 
-const Demo = () => (
-    <BrowserPreview headerDescription="test" title="test title">
-        test
-    </BrowserPreview>
-);
+interface DemoProps extends DemoComponentProps {
+    pageSize?: number;
+    numberOfItems?: number;
+}
+
+export type Product = {
+    name: string;
+    department: string;
+    price: string;
+};
+
+const makeData = (len: number): Product[] =>
+    Array(len)
+        .fill(0)
+        .map(() => ({
+            name: faker.commerce.productName(),
+            department: faker.commerce.department(),
+            price: faker.commerce.price(),
+        }));
+
+const Demo = ({pageSize = 7, numberOfItems = 40}: DemoProps) => {
+    const [page, setPage] = useState(1);
+    const data: Product[][] = makeData(40).reduce((all, one, i) => {
+        const ch = Math.floor(i / pageSize);
+        all[ch] = [].concat(all[ch] || [], one);
+        return all;
+    }, []);
+    const numberOfPages = Math.ceil(numberOfItems / pageSize);
+
+    return (
+        <BrowserPreview>
+            <Stack style={{flexGrow: 1}}>
+                <Stack spacing="sm" justify="space-between">
+                    {data[page - 1].map((product) => (
+                        <Stack spacing={0}>
+                            <Text size="md" color="gray.7">
+                                {product.name}
+                            </Text>
+                            <Text size="xs" color="gray.6" span>
+                                <Text size="xs" weight={500} span>
+                                    Dept:{' '}
+                                </Text>
+                                {product.department}
+                            </Text>
+                            <Text size="xs" color="gray.6" span>
+                                <Text size="xs" weight={500} span>
+                                    Price:{' '}
+                                </Text>
+                                {product.price}$
+                            </Text>
+                        </Stack>
+                    ))}
+                </Stack>
+                <Flex align="flex-end" justify="center" style={{flexGrow: 1}}>
+                    <Pagination value={page} total={numberOfPages} onChange={setPage} align="center" />
+                </Flex>
+            </Stack>
+        </BrowserPreview>
+    );
+};
 export default Demo;

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreview.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreview.demo.tsx
@@ -1,0 +1,8 @@
+import {BrowserPreview} from '@coveord/plasma-mantine';
+
+const Demo = () => (
+    <BrowserPreview headerDescription="test" title="test title">
+        test
+    </BrowserPreview>
+);
+export default Demo;

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewOverflow.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewOverflow.demo.tsx
@@ -4,7 +4,7 @@ import {faker} from '@faker-js/faker';
 const Demo = () => {
     const content = faker.lorem.paragraphs(20);
     return (
-        <BrowserPreview>
+        <BrowserPreview maxHeight={750}>
             <Stack spacing="xs">
                 <Title order={3} align="center">
                     Hello World !

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewOverflow.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewOverflow.demo.tsx
@@ -4,7 +4,7 @@ import {faker} from '@faker-js/faker';
 const Demo = () => {
     const content = faker.lorem.paragraphs(20);
     return (
-        <BrowserPreview maxHeight={750}>
+        <BrowserPreview>
             <Stack spacing="xs">
                 <Title order={3} align="center">
                     Hello World !

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewOverflow.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewOverflow.demo.tsx
@@ -1,0 +1,17 @@
+import {BrowserPreview, Stack, Text, Title} from '@coveord/plasma-mantine';
+import {faker} from '@faker-js/faker';
+
+const Demo = () => {
+    const content = faker.lorem.paragraphs(20);
+    return (
+        <BrowserPreview>
+            <Stack spacing="xs">
+                <Title order={3} align="center">
+                    Hello World !
+                </Title>
+                <Text>{content}</Text>
+            </Stack>
+        </BrowserPreview>
+    );
+};
+export default Demo;

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewWithTitleAndDescription.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewWithTitleAndDescription.demo.tsx
@@ -1,0 +1,18 @@
+import {BrowserPreview, Stack, Text, Title} from '@coveord/plasma-mantine';
+import {faker} from '@faker-js/faker';
+
+const Demo = () => {
+    const title = faker.lorem.sentence(20);
+    const content = faker.lorem.paragraph(10);
+    return (
+        <BrowserPreview title={title} headerTooltip="This is a custom tooltip message.">
+            <Stack spacing="xs">
+                <Title order={3} align="center">
+                    Hello World !
+                </Title>
+                <Text>{content}</Text>
+            </Stack>
+        </BrowserPreview>
+    );
+};
+export default Demo;

--- a/packages/website/src/pages/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/layout/BrowserPreview.tsx
@@ -13,10 +13,12 @@ export default () => (
         thumbnail="placeholder"
         propsMetadata={BrowserPreviewMetadata}
         id="BrowserPreview"
-        demo={<BrowserPreviewDemo />}
+        demo={<BrowserPreviewDemo maxHeight="none" />}
         examples={{
-            withTitleAndCustomTooltip: <BrowserPreviewWithTitleAndDescriptionDemo title="Custom title and tooltip" />,
-            withOverflowingContent: <BrowserPreviewOverflowDemo title="Overflowing content" />,
+            withTitleAndCustomTooltip: (
+                <BrowserPreviewWithTitleAndDescriptionDemo maxHeight="none" title="Custom title and tooltip" />
+            ),
+            withOverflowingContent: <BrowserPreviewOverflowDemo maxHeight="none" title="Overflowing content" />,
         }}
     />
 );

--- a/packages/website/src/pages/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/layout/BrowserPreview.tsx
@@ -13,12 +13,12 @@ export default () => (
         thumbnail="placeholder"
         propsMetadata={BrowserPreviewMetadata}
         id="BrowserPreview"
-        demo={<BrowserPreviewDemo maxHeight="none" />}
+        demo={<BrowserPreviewDemo maxHeight={750} />}
         examples={{
             withTitleAndCustomTooltip: (
-                <BrowserPreviewWithTitleAndDescriptionDemo maxHeight="none" title="Custom title and tooltip" />
+                <BrowserPreviewWithTitleAndDescriptionDemo maxHeight="none" grow title="Custom title and tooltip" />
             ),
-            withMaximumHeight: <BrowserPreviewOverflowDemo maxHeight="none" title="Maxium height" />,
+            withOverflowingContent: <BrowserPreviewOverflowDemo maxHeight={700} title="Overflowing content" />,
         }}
     />
 );

--- a/packages/website/src/pages/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/layout/BrowserPreview.tsx
@@ -1,7 +1,7 @@
 import BrowserPreviewDemo from '@examples/layout/BrowserPreview/BrowserPreview.demo?demo';
 import BrowserPreviewWithTitleAndDescriptionDemo from '@examples/layout/BrowserPreview/BrowserPreviewWithTitleAndDescription.demo?demo';
 import BrowserPreviewOverflowDemo from '@examples/layout/BrowserPreview/BrowserPreviewOverflow.demo?demo';
-import {BrowserPreviewMantineMetadata} from '@coveord/plasma-components-props-analyzer';
+import {BrowserPreviewMetadata} from '@coveord/plasma-components-props-analyzer';
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 export default () => (
@@ -11,7 +11,7 @@ export default () => (
         sourcePath="/packages/mantine/src/components/browser-preview/BrowserPreview.tsx"
         description="A browser preview shows the result of configuration changes in a simplified representation of a browser interface."
         thumbnail="placeholder"
-        propsMetadata={BrowserPreviewMantineMetadata}
+        propsMetadata={BrowserPreviewMetadata}
         id="BrowserPreview"
         demo={<BrowserPreviewDemo />}
         examples={{

--- a/packages/website/src/pages/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/layout/BrowserPreview.tsx
@@ -18,7 +18,7 @@ export default () => (
             withTitleAndCustomTooltip: (
                 <BrowserPreviewWithTitleAndDescriptionDemo maxHeight="none" title="Custom title and tooltip" />
             ),
-            withOverflowingContent: <BrowserPreviewOverflowDemo maxHeight="none" title="Overflowing content" />,
+            withMaximumHeight: <BrowserPreviewOverflowDemo maxHeight="none" title="Maxium height" />,
         }}
     />
 );

--- a/packages/website/src/pages/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/layout/BrowserPreview.tsx
@@ -1,0 +1,14 @@
+import BrowserPreviewDemo from '@examples/layout/BrowserPreview/BrowserPreview.demo?demo';
+import {PageLayout} from '../../building-blocs/PageLayout';
+
+export default () => (
+    <PageLayout
+        section="Layout"
+        title="Header"
+        sourcePath="/packages/mantine/src/components/browser-preview/BrowserPreview.tsx"
+        description="A page header informs a user of the section of the product they are currently in. It includes a breadcrumb and optional call to actions."
+        thumbnail="header"
+        id="BrowserPreview"
+        demo={<BrowserPreviewDemo />}
+    />
+);

--- a/packages/website/src/pages/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/layout/BrowserPreview.tsx
@@ -1,14 +1,22 @@
 import BrowserPreviewDemo from '@examples/layout/BrowserPreview/BrowserPreview.demo?demo';
+import BrowserPreviewWithTitleAndDescriptionDemo from '@examples/layout/BrowserPreview/BrowserPreviewWithTitleAndDescription.demo?demo';
+import BrowserPreviewOverflowDemo from '@examples/layout/BrowserPreview/BrowserPreviewOverflow.demo?demo';
+import {BrowserPreviewMantineMetadata} from '@coveord/plasma-components-props-analyzer';
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 export default () => (
     <PageLayout
         section="Layout"
-        title="Header"
+        title="Browser Preview"
         sourcePath="/packages/mantine/src/components/browser-preview/BrowserPreview.tsx"
-        description="A page header informs a user of the section of the product they are currently in. It includes a breadcrumb and optional call to actions."
-        thumbnail="header"
+        description="A browser preview shows the result of configuration changes in a simplified representation of a browser interface."
+        thumbnail="placeholder"
+        propsMetadata={BrowserPreviewMantineMetadata}
         id="BrowserPreview"
         demo={<BrowserPreviewDemo />}
+        examples={{
+            withTitleAndCustomTooltip: <BrowserPreviewWithTitleAndDescriptionDemo title="Custom title and tooltip" />,
+            withOverflowingContent: <BrowserPreviewOverflowDemo title="Overflowing content" />,
+        }}
     />
 );

--- a/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
@@ -20,7 +20,7 @@ export const BrowserPreviewDemos = () => (
         description="A browser preview shows the result of configuration changes in a simplified representation of a browser interface."
         sourcePath="/packages/react/src/components/browserPreview/BrowserPreview.tsx"
         propsMetadata={BrowserPreviewLegacyMetadata}
-        demo={<BrowserPreviewDemo maxHeight="none" />}
+        demo={<BrowserPreviewDemo />}
         examples={{
             withError: (
                 <Suspense fallback={<PlasmaLoading />}>

--- a/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
@@ -1,4 +1,4 @@
-import {BrowserPreviewMetadata} from '@coveord/plasma-components-props-analyzer';
+import {BrowserPreviewMantineMetadata} from '@coveord/plasma-components-props-analyzer';
 import BrowserPreviewDemo from '@examples/legacy/layout/BrowserPreview/BrowserPreview.demo?demo';
 import BrowserPreviewWithEmptyStateDemo from '@examples/legacy/layout/BrowserPreview/BrowserPreviewWithEmptyState.demo?demo';
 import dynamic from 'next/dynamic';
@@ -19,7 +19,7 @@ export const BrowserPreviewDemos = () => (
         thumbnail="placeholder"
         description="A browser preview shows the result of configuration changes in a simplified representation of a browser interface."
         sourcePath="/packages/react/src/components/browserPreview/BrowserPreview.tsx"
-        propsMetadata={BrowserPreviewMetadata}
+        propsMetadata={BrowserPreviewMantineMetadata}
         demo={<BrowserPreviewDemo />}
         examples={{
             withError: (

--- a/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
@@ -20,7 +20,7 @@ export const BrowserPreviewDemos = () => (
         description="A browser preview shows the result of configuration changes in a simplified representation of a browser interface."
         sourcePath="/packages/react/src/components/browserPreview/BrowserPreview.tsx"
         propsMetadata={BrowserPreviewLegacyMetadata}
-        demo={<BrowserPreviewDemo />}
+        demo={<BrowserPreviewDemo maxHeight="none" />}
         examples={{
             withError: (
                 <Suspense fallback={<PlasmaLoading />}>

--- a/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
+++ b/packages/website/src/pages/legacy/layout/BrowserPreview.tsx
@@ -1,4 +1,3 @@
-import {BrowserPreviewMantineMetadata} from '@coveord/plasma-components-props-analyzer';
 import BrowserPreviewDemo from '@examples/legacy/layout/BrowserPreview/BrowserPreview.demo?demo';
 import BrowserPreviewWithEmptyStateDemo from '@examples/legacy/layout/BrowserPreview/BrowserPreviewWithEmptyState.demo?demo';
 import dynamic from 'next/dynamic';
@@ -8,6 +7,7 @@ const BrowserPreviewWithErrorDemo = dynamic(
 );
 import {Suspense} from 'react';
 
+import {BrowserPreviewLegacyMetadata} from '@coveord/plasma-components-props-analyzer';
 import {PageLayout} from '../../../building-blocs/PageLayout';
 import {PlasmaLoading} from '../../../building-blocs/PlasmaLoading';
 
@@ -19,7 +19,7 @@ export const BrowserPreviewDemos = () => (
         thumbnail="placeholder"
         description="A browser preview shows the result of configuration changes in a simplified representation of a browser interface."
         sourcePath="/packages/react/src/components/browserPreview/BrowserPreview.tsx"
-        propsMetadata={BrowserPreviewMantineMetadata}
+        propsMetadata={BrowserPreviewLegacyMetadata}
         demo={<BrowserPreviewDemo />}
         examples={{
             withError: (

--- a/packages/website/types/custom/index.d.ts
+++ b/packages/website/types/custom/index.d.ts
@@ -17,6 +17,9 @@ interface DemoComponentProps {
     title?: string;
     noPadding?: boolean;
     layout?: 'horizontal' | 'vertical';
+    /**
+     * Will render in a flex container with the specified max-height instead of a scroll area.
+     */
     maxHeight?: number | 'none';
 }
 

--- a/packages/website/types/custom/index.d.ts
+++ b/packages/website/types/custom/index.d.ts
@@ -17,6 +17,7 @@ interface DemoComponentProps {
     title?: string;
     noPadding?: boolean;
     layout?: 'horizontal' | 'vertical';
+    maxHeight?: number | 'none';
 }
 
 declare module '*?demo' {


### PR DESCRIPTION
### Proposed Changes

[SEARCHAPI-8834](https://coveord.atlassian.net/browse/SEARCHAPI-8834)

#### New Mantine `BrowserPreview`

🆕 Adding a new `BrowserPreview` component using Mantine. 🆕 

![Screenshot 2023-10-04 at 11 16 04 AM](https://github.com/coveo/plasma/assets/133259861/2b9baf32-e143-4538-979b-84dce711e37c)

![Screenshot 2023-10-04 at 11 16 28 AM](https://github.com/coveo/plasma/assets/133259861/7989c323-78b6-4f0d-88ec-eaed0715d8bf)

![Screenshot 2023-10-04 at 11 16 33 AM](https://github.com/coveo/plasma/assets/133259861/c202ff5b-164f-4803-a73d-3863292f2f07)

🗝️ This component is based off the [current](https://plasma.coveo.com/legacy/layout/BrowserPreview) `BrowserPreview` component from the `plasma-react` package. 🗝️ 

<img width="575" alt="Screenshot 2023-10-03 at 4 06 57 PM" src="https://github.com/coveo/plasma/assets/133259861/691ee641-e577-4e8f-9572-0f900bc13bcb">

See it in [Figma](https://www.figma.com/file/5g877KNr4rJOle1dpCBJJn/Preview?node-id=1%3A2&mode=dev).🎨 

#### Add `maxHeight` prop to `Demo`

Since all the demo components were rendered in a `ScrollArea`, I found it hard to showcase the height adjustments  and overflow behaviour of a component. So, I added a `maxHeight` prop which will render the demo component in a flex container with the specified max height.

### Potential Breaking Changes

🟢 No breaking changes. This PR adds a new component that is yet to be used anywhere. 🟢 

### Test

You see the new component in action [here](https://plasma.coveo.com/feature/SEARCHAPI-8834/mantine-browser-preview/layout/BrowserPreview). 🧪 

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[SEARCHAPI-8834]: https://coveord.atlassian.net/browse/SEARCHAPI-8834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ