### PR TITLE
feat(mantine): improve error rendering of code editor : CTCORE-9443

### DIFF
--- a/packages/website/src/examples/form/code-editor/CodeEditorError.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorError.demo.tsx
@@ -1,0 +1,35 @@
+import {CodeEditor, useForm} from '@coveord/plasma-mantine';
+
+const Demo = () => {
+    const form = useForm({
+        initialValues: {
+            config: '{"emptyKey":}',
+        },
+        validate: {
+            config: (jsonValue) => {
+                try {
+                    const config = JSON.parse(jsonValue);
+                    if (!config.key) {
+                        return 'The key must have a value';
+                    }
+                } catch {
+                    return 'Invalid JSON';
+                }
+                return null;
+            },
+        },
+        validateInputOnBlur: true,
+        validateInputOnChange: true,
+    });
+
+    return (
+        <CodeEditor
+            language="json"
+            label="Error"
+            description="Indicates when the code is invalid"
+            monacoLoader="cdn"
+            {...form.getInputProps('config')}
+        />
+    );
+};
+export default Demo;

--- a/packages/website/src/pages/form/CodeEditor.tsx
+++ b/packages/website/src/pages/form/CodeEditor.tsx
@@ -1,5 +1,6 @@
 import {CodeEditorMetadata} from '@coveord/plasma-components-props-analyzer';
 import CodeEditorDemo from '@examples/form/code-editor/CodeEditor.demo?demo';
+import CodeEditorErrorDemo from '@examples/form/code-editor/CodeEditorError.demo?demo';
 import CodeEditorPythonDemo from '@examples/form/code-editor/CodeEditorPython.demo?demo';
 import CodeEditorXMLDemo from '@examples/form/code-editor/CodeEditorXML.demo?demo';
 
@@ -18,6 +19,7 @@ const CodeEditorPage = () => (
         examples={{
             python: <CodeEditorPythonDemo grow title="Python language" />,
             xml: <CodeEditorXMLDemo grow title="XML language" />,
+            error: <CodeEditorErrorDemo grow title="Validation" />,
         }}
     />
 );


### PR DESCRIPTION
[CTCORE-9443](https://coveord.atlassian.net/browse/CTCORE-9404)

### Proposed Changes

Improved the rendering of error in the CodeEditor component to be more visible.

Before: 
![Screenshot from 2023-10-03 13-49-14](https://github.com/coveo/plasma/assets/143550080/08f47773-4328-434b-a004-0dac09227ddf)

After:
![Screenshot from 2023-10-04 11-41-49](https://github.com/coveo/plasma/assets/143550080/b73a8f80-19f6-4d20-9c47-3949e6124a3f)


Added an example in CodeEditor page as well

### How to test

[Go to this link](https://plasma-website-eexd5b6cq-adui-core.vercel.app/form/CodeEditor) and verify that the red outline correctly shows on the last example whenever there's an error.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[CTCORE-9443]: https://coveord.atlassian.net/browse/CTCORE-9443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ