### PR TITLE
feat(commerce-hub): make RowLayoutHeader respect Mantine theme MHUB-263

### DIFF
--- a/packages/mantine/src/components/table/Table.styles.ts
+++ b/packages/mantine/src/components/table/Table.styles.ts
@@ -21,6 +21,8 @@ const useStyles = createStyles<string>((theme) => ({
             borderBottom: `1px solid ${theme.colors.gray[3]}`,
         },
     },
+
+    body: {},
 }));
 
 export const TableComponentsOrder = {

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -49,6 +49,9 @@ export const Table: TableType = <T,>({
     disableRowSelection,
     onRowSelectionChange,
     additionalRootNodes,
+    classNames,
+    styles,
+    unstyled,
     options = {},
 }: TableProps<T>) => {
     const convertedChildren = Children.toArray(children) as ReactElement[];
@@ -65,7 +68,7 @@ export const Table: TableType = <T,>({
             layout: initialState?.layout ?? layouts[0].name,
         },
     });
-    const {classes} = useStyles();
+    const {classes} = useStyles(null, {name: 'PlasmaTable', classNames, styles, unstyled});
 
     const table = useReactTable({
         initialState: defaultsDeep(initialStateWithoutForm, {
@@ -184,7 +187,7 @@ export const Table: TableType = <T,>({
                                     loading={loading}
                                 />
                             </thead>
-                            <tbody>
+                            <tbody className={classes.body}>
                                 {hasRows ? (
                                     <Layout.Body
                                         table={table}

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -1,4 +1,5 @@
 import {Icon} from '@coveord/plasma-react-icons';
+import {DefaultProps, Selectors} from '@mantine/core';
 import {UseFormReturnType} from '@mantine/form';
 import {
     ColumnDef,
@@ -24,6 +25,7 @@ import {TableLoading} from './table-loading/TableLoading';
 import {TablePagination} from './table-pagination/TablePagination';
 import {TablePerPage} from './table-per-page/TablePerPage';
 import {TablePredicate} from './table-predicate/TablePredicate';
+import useStyles from './Table.styles';
 
 export type RowSelectionWithData<TData> = Record<string, TData>;
 export interface RowSelectionState<TData> {
@@ -143,7 +145,9 @@ export type TableContextType<TData> = {
     layouts: TableLayout[];
 };
 
-export interface TableProps<T> {
+type TableStylesNames = Selectors<typeof useStyles>;
+
+export interface TableProps<T> extends DefaultProps<TableStylesNames> {
     /**
      * Data to display in the table
      */

--- a/packages/mantine/src/components/table/layouts/RowLayout.tsx
+++ b/packages/mantine/src/components/table/layouts/RowLayout.tsx
@@ -12,9 +12,12 @@ import {TableLoading} from '../table-loading/TableLoading';
 import useStyles from './RowLayout.styles';
 import {TableLayoutProps} from './RowLayout.types'; // TODO https://coveord.atlassian.net/browse/ADUI-9182
 
-const RowLayoutHeader = <T,>({table}: TableLayoutProps<T>) => {
+const RowLayoutHeader = <T,>({table, classNames, styles, unstyled}: TableLayoutProps<T>) => {
     const {multiRowSelectionEnabled, disableRowSelection} = useTable();
-    const {classes} = useStyles({disableRowSelection, multiRowSelectionEnabled});
+    const {classes} = useStyles(
+        {disableRowSelection, multiRowSelectionEnabled},
+        {name: 'RowLayout', classNames, styles, unstyled},
+    );
     const headers = table.getHeaderGroups().map((headerGroup) => (
         <tr key={headerGroup.id} className={classes.headerColumns}>
             {headerGroup.headers.map((columnHeader) => (


### PR DESCRIPTION
### Proposed Changes

i was trying to make use of the changes from https://github.com/coveo/plasma/pull/3535

at the moment, you can only do style overrides to the RowLayoutBody component, not to the header

you can see this here, where the theme's RowLayout classes only get applied to the body, so you can't theme any of the header's styles. The `thead`'s `tr` components should have the `headerColumns` class

![image](https://github.com/coveo/plasma/assets/3920879/9c1e96f7-b052-4e5f-a5f5-32c6b7b9498a)


### Potential Breaking Changes

shouldnt affect anything else

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
