### PR TITLE
feat(mantine): set tooltip default max width of 300 px

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -161,9 +161,10 @@ export const plasmaTheme: MantineThemeOverride = {
         Tooltip: {
             defaultProps: {
                 color: 'navy',
+                maw: 300,
+                multiline: true,
                 withArrow: true,
                 withinPortal: true,
-                multiline: true,
                 zIndex: 10000,
             },
         },


### PR DESCRIPTION
### Proposed Changes

Setting a default max width of 300px on the plasma-mantine Tooltip via the Theme object. 

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
