### PR TITLE
feat(MLX): allow possibility to override classnames in prompt v2

### DIFF
--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -47,6 +47,7 @@ interface PromptType {
 }
 
 export const Prompt: PromptType = ({children, variant = 'info', ...otherProps}) => {
+    const {classNames: classesProps, ...otherPropsWithoutClasses} = otherProps;
     const {classes, cx} = useStyles();
     const convertedChildren = Children.toArray(children) as ReactElement[];
 
@@ -65,9 +66,9 @@ export const Prompt: PromptType = ({children, variant = 'info', ...otherProps}) 
         <Modal
             variant="prompt"
             padding={0}
-            classNames={{...classNames, ...otherProps?.classNames}}
+            classNames={{...classNames, ...classesProps}}
             size={'sm'}
-            {...otherProps}
+            {...otherPropsWithoutClasses}
         >
             <div className={classes.innerBody}>{otherChildren}</div>
             {footer}


### PR DESCRIPTION
### Proposed Changes

Allow the possibility to override classNames for the prompt component.
For this task : [MLX-644](https://coveord.atlassian.net/browse/MLX-644)
I have a problem displaying the prompt over a modal, I need to change the zindex of the prompt overlay

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[MLX-644]: https://coveord.atlassian.net/browse/MLX-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ