### PR TITLE
feat(mantine, code editor): allow dev to use more language

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -44,7 +44,7 @@ interface CodeEditorProps
      *
      * @default 'plaintext'
      */
-    language?: 'plaintext' | 'json' | 'markdown' | 'python' | 'xml';
+    language?: 'plaintext' | 'json' | 'markdown' | 'python' | 'xml' | (string & unknown);
     /** Default value for uncontrolled input */
     defaultValue?: string;
     /** Value for controlled input */

--- a/packages/website/src/examples/form/code-editor/CodeEditorGraphQL.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorGraphQL.demo.tsx
@@ -1,0 +1,31 @@
+import {CodeEditor, useForm} from '@coveord/plasma-mantine';
+
+const initialQuery = `query TestGraphQl {
+  user(where: { email: { _eq: "user@example.com" } }) {
+    email
+    name
+    company {
+      name
+    }
+  }
+}
+`;
+
+const Demo = () => {
+    const form = useForm({
+        initialValues: {
+            config: initialQuery,
+        },
+    });
+
+    return (
+        <CodeEditor
+            language="graphql"
+            label="Query"
+            description="Write a GraphQL query, subscription, or mutation"
+            monacoLoader="cdn"
+            {...form.getInputProps('config')}
+        />
+    );
+};
+export default Demo;

--- a/packages/website/src/pages/form/CodeEditor.tsx
+++ b/packages/website/src/pages/form/CodeEditor.tsx
@@ -1,6 +1,7 @@
 import {CodeEditorMetadata} from '@coveord/plasma-components-props-analyzer';
 import CodeEditorDemo from '@examples/form/code-editor/CodeEditor.demo?demo';
 import CodeEditorErrorDemo from '@examples/form/code-editor/CodeEditorError.demo?demo';
+import CodeEditorGraphQLDemo from '@examples/form/code-editor/CodeEditorGraphQL.demo?demo';
 import CodeEditorPythonDemo from '@examples/form/code-editor/CodeEditorPython.demo?demo';
 import CodeEditorXMLDemo from '@examples/form/code-editor/CodeEditorXML.demo?demo';
 
@@ -19,6 +20,7 @@ const CodeEditorPage = () => (
         examples={{
             python: <CodeEditorPythonDemo grow title="Python language" />,
             xml: <CodeEditorXMLDemo grow title="XML language" />,
+            graphql: <CodeEditorGraphQLDemo grow title="GraphQL language" />,
             error: <CodeEditorErrorDemo grow title="Validation" />,
         }}
     />


### PR DESCRIPTION
### Proposed Changes

By using this nifty TypeScript trick `| (string & unknown)` in a string literal types we keep the autocomplete but allow custom values

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
