### PR TITLE
ci(website): remove slashes from demo branch name URLs

### DIFF
--- a/.github/actions/cleanup-demo/cleanup-demo.sh
+++ b/.github/actions/cleanup-demo/cleanup-demo.sh
@@ -3,10 +3,11 @@
 set -e
 
 BRANCH="$1"
+CLEAN_BRANCH_NAME=${BRANCH//\//-} # replaces all / by -
 BUCKET="$2"
 DESTINATION=react-vapor/feature
 
-echo "Deleting demo of ${BRANCH} in ${BUCKET}/${DESTINATION}/${BRANCH}."
-aws s3 rm --recursive s3://${BUCKET}/${DESTINATION}/${BRANCH}
+echo "Deleting demo of ${BRANCH} in ${BUCKET}/${DESTINATION}/${CLEAN_BRANCH_NAME}."
+aws s3 rm --recursive s3://${BUCKET}/${DESTINATION}/${CLEAN_BRANCH_NAME}
 
 echo "Demo successfully deleted"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -7,6 +7,10 @@ inputs:
         description: The AWS region in which to deploy the website.
     AWS_BUCKET:
         description: The AWS S3 bucket in which to deploy the website.
+outputs:
+    demo-output-path:
+        description: 'Path to the directory where the website was deployed'
+        value: ${{ steps.s3-push.outputs.demo-output-path }}
 runs:
     using: composite
     steps:
@@ -16,5 +20,6 @@ runs:
               role-to-assume: ${{ inputs.AWS_ROLE }}
               aws-region: ${{ inputs.AWS_REGION }}
         - name: Push distribution code to s3 demo folder
+          id: s3-push
           shell: bash
           run: bash ./.github/actions/deploy/deploy.sh ${{ github.head_ref || github.ref_name }} ${{ inputs.AWS_BUCKET }}

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -12,7 +12,9 @@ then
     aws s3 sync ./packages/website/dist s3://${BUCKET}/${DESTINATION}
     echo "master branch successfully deployed to https://plasma.coveo.com/"
 else
+    CLEAN_BRANCH_NAME=${BRANCH//\//-} # replaces all / by -
     echo "Deploying new demo of branch ${BRANCH}."
-    aws s3 sync ./packages/website/dist s3://${BUCKET}/${DESTINATION}/feature/${BRANCH}
-    echo "Branch ${BRANCH} successfully deployed to https://plasma.coveo.com/feature/${BRANCH}/"
+    aws s3 sync ./packages/website/dist s3://${BUCKET}/${DESTINATION}/feature/${CLEAN_BRANCH_NAME}
+    echo "demo-output-path=$CLEAN_BRANCH_NAME" >> $GITHUB_OUTPUT
+    echo "Branch ${BRANCH} successfully deployed to https://plasma.coveo.com/feature/${CLEAN_BRANCH_NAME}/"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
             - uses: ./.github/actions/setup
             - uses: ./.github/actions/build
             - uses: ./.github/actions/deploy
+              id: deploy-demo
               with:
                   AWS_ROLE: ${{ secrets.AWS_ROLE }}
                   AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -42,5 +43,5 @@ jobs:
             - name: Add demo link as a commment on the PR
               uses: ./.github/actions/comment-on-pr
               with:
-                  message: ':heavy_check_mark: [Live demo of your latest successful build available here](https://plasma.coveo.com/feature/${{ github.head_ref }}/).'
+                  message: ':heavy_check_mark: [Live demo of your latest successful build available here](https://plasma.coveo.com/feature/${{ steps.deploy-demo.outputs.demo-output-path }}/).'
                   avoidRepostsWith: Live demo of your latest successful build available here

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
 node_modules/*
-.github
 CHANGELOG.md
 .ultra.cache.json

--- a/packages/website/build/getBasePath.ts
+++ b/packages/website/build/getBasePath.ts
@@ -3,7 +3,7 @@ const branchName = process.env.BRANCH_NAME || process.env.GITHUB_HEAD_REF || pro
 
 let basePath = '/';
 if (isCI && branchName !== 'master') {
-    basePath = `/feature/${branchName}/`;
+    basePath = `/feature/${branchName.replace('/', '-')}/`;
 }
 
 export default basePath;

--- a/packages/website/build/getBasePath.ts
+++ b/packages/website/build/getBasePath.ts
@@ -3,7 +3,7 @@ const branchName = process.env.BRANCH_NAME || process.env.GITHUB_HEAD_REF || pro
 
 let basePath = '/';
 if (isCI && branchName !== 'master') {
-    basePath = `/feature/${branchName.replace('/', '-')}/`;
+    basePath = `/feature/${branchName.replaceAll('/', '-')}/`;
 }
 
 export default basePath;


### PR DESCRIPTION
### Proposed Changes

Branch names containing a slash (`/`) in their names should now deploy a demo at a location that does not contain a slash.

For example the current branch is named `ADUI-9282/remove-slashes-in-branch-name`. But the demo is deployed at https://plasma.coveo.com/feature/ADUI-9282-remove-slashes-in-branch-name/. As you can see the `/` is getting replaced by a `-`.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
