### PR TITLE
Ad UI 9312 filter input in table component not clearing upon calling clear filter

### DIFF
--- a/packages/mantine/src/components/table/__tests__/TableFilter.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableFilter.spec.tsx
@@ -1,7 +1,9 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
 import {act, render, screen, userEvent, within} from '@test-utils';
 
+import {Button} from '@mantine/core';
 import {Table} from '../Table';
+import {useTable} from '../TableContext';
 
 type RowData = {name: string};
 
@@ -94,6 +96,29 @@ describe('Table.Filter', () => {
         );
         expect(screen.getByRole('textbox')).toHaveValue('foo');
         await user.click(screen.getByRole('button', {name: /cross/i}));
+        expect(screen.getByRole('textbox')).toHaveValue('');
+    });
+
+    it('clear the filter if the global state filter is cleared', async () => {
+        const user = userEvent.setup({delay: null});
+
+        const Fixture = () => {
+            const {clearFilters} = useTable();
+            return <Button data-testId="clear-button" onClick={clearFilters} />;
+        };
+
+        await render(
+            <Table data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns} initialState={{globalFilter: 'foo'}}>
+                <Table.Header>
+                    <Table.Consumer>
+                        <Fixture />
+                    </Table.Consumer>
+                    <Table.Filter />
+                </Table.Header>
+            </Table>,
+        );
+        expect(screen.getByRole('textbox')).toHaveValue('foo');
+        await user.click(screen.getByTestId('clear-button'));
         expect(screen.getByRole('textbox')).toHaveValue('');
     });
 

--- a/packages/mantine/src/components/table/__tests__/TableFilter.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableFilter.spec.tsx
@@ -107,7 +107,7 @@ describe('Table.Filter', () => {
             return <Button data-testId="clear-button" onClick={clearFilters} />;
         };
 
-        await render(
+        render(
             <Table data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns} initialState={{globalFilter: 'foo'}}>
                 <Table.Header>
                     <Table.Consumer>

--- a/packages/mantine/src/components/table/table-filter/TableFilter.tsx
+++ b/packages/mantine/src/components/table/table-filter/TableFilter.tsx
@@ -42,7 +42,7 @@ export const TableFilter: FunctionComponent<TableFilterProps> = ({
 
     useEffect(() => {
         setFilter(state.globalFilter);
-    }, [state]);
+    }, [state.globalFilter]);
 
     return (
         <Grid.Col span="content" order={TableComponentsOrder.Filter} py="sm" className={classes.root}>

--- a/packages/mantine/src/components/table/table-filter/TableFilter.tsx
+++ b/packages/mantine/src/components/table/table-filter/TableFilter.tsx
@@ -1,6 +1,6 @@
 import {CrossSize16Px, SearchSize16Px} from '@coveord/plasma-react-icons';
 import {ActionIcon, Grid, TextInput} from '@mantine/core';
-import {ChangeEventHandler, FunctionComponent, MouseEventHandler, useState} from 'react';
+import {ChangeEventHandler, FunctionComponent, MouseEventHandler, useEffect, useState} from 'react';
 
 import {useDebouncedValue, useDidUpdate} from '@mantine/hooks';
 import {TableComponentsOrder} from '../Table.styles';
@@ -39,6 +39,10 @@ export const TableFilter: FunctionComponent<TableFilterProps> = ({
     const handleClear: MouseEventHandler<HTMLButtonElement> = () => {
         setFilter('');
     };
+
+    useEffect(() => {
+        setFilter(state.globalFilter);
+    }, [state]);
 
     return (
         <Grid.Col span="content" order={TableComponentsOrder.Filter} py="sm" className={classes.root}>


### PR DESCRIPTION
### Proposed Changes

There was a disconnect between the `Table` and the `Table.Filter` when clearing the filters. When calling `clearFilter` from the `useTable` hook, the global filter was clearer, but the textbox of the filter didn't.

More info in the jira ticket --> https://coveord.atlassian.net/browse/ADUI-9312

### Potential Breaking Changes

 none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
