### PR TITLE
feat(mantine): allow table column header customization

### DIFF
--- a/packages/mantine/src/components/table/__tests__/Th.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Th.spec.tsx
@@ -22,9 +22,7 @@ describe('Th', () => {
         ];
         render(<Table data={data} columns={columns} />);
 
-        const headers = screen.getAllByRole('button');
-        expect(headers.length).toBe(2);
-
+        const headers = screen.getAllByRole('columnheader');
         expect(headers[0]).toHaveAccessibleName(/name doubleArrowHead/i);
         expect(headers[1]).toHaveAccessibleName(/type doubleArrowHead/i);
     });
@@ -38,17 +36,17 @@ describe('Th', () => {
         const onChange = vi.fn();
         render(<Table data={data} columns={columns} onChange={onChange} />);
 
-        await user.click(screen.getByRole('button', {name: /name doubleArrowHead/i}));
+        await user.click(screen.getByRole('columnheader', {name: /name doubleArrowHead/i}));
         await waitFor(() => {
             expect(onChange).toHaveBeenCalledWith(expect.objectContaining({sorting: [{id: 'name', desc: false}]}));
         });
 
-        await user.click(screen.getByRole('button', {name: /name arrowUp/i}));
+        await user.click(screen.getByRole('columnheader', {name: /name arrowUp/i}));
         await waitFor(() => {
             expect(onChange).toHaveBeenCalledWith(expect.objectContaining({sorting: [{id: 'name', desc: true}]}));
         });
 
-        await user.click(screen.getByRole('button', {name: /name arrowDown/i}));
+        await user.click(screen.getByRole('columnheader', {name: /name arrowDown/i}));
         await waitFor(() => {
             expect(onChange).toHaveBeenCalledWith(expect.objectContaining({sorting: [{id: 'name', desc: false}]}));
         });

--- a/packages/mantine/src/components/table/layouts/RowLayout.styles.ts
+++ b/packages/mantine/src/components/table/layouts/RowLayout.styles.ts
@@ -10,10 +10,6 @@ export default createStyles<string, RowLayoutStylesParams>((theme, {multiRowSele
     const border = `${rem(1)} solid ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]}`;
     return {
         headerColumns: {
-            '& th:first-of-type > *': {
-                paddingLeft: '40px',
-            },
-
             '& input[type=checkbox]': {
                 backgroundColor: disableRowSelection ? `${theme.colors.gray[2]}` : undefined,
                 borderColor: disableRowSelection ? `${theme.colors.gray[3]}` : `${theme.colors.gray[4]}`,

--- a/packages/mantine/src/components/table/table-header/Th.styles.ts
+++ b/packages/mantine/src/components/table/table-header/Th.styles.ts
@@ -1,25 +1,36 @@
 import {createStyles} from '@mantine/core';
 
-export default createStyles((theme, columnSizing: {size: number; minSize: number; maxSize: number}) => ({
-    th: {
-        fontWeight: '400 !important' as any,
-        padding: '0 !important',
+export interface ThStyleParams {
+    size: number;
+    minSize: number;
+    maxSize: number;
+}
+
+export default createStyles((theme, {maxSize, minSize, size}: ThStyleParams) => ({
+    root: {
+        padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
         verticalAlign: 'middle',
         whiteSpace: 'nowrap',
         textAlign: 'left',
         color: theme.colors.gray[6],
         backgroundColor: theme.colorScheme === 'dark' ? theme.colors.gray[8] : theme.colors.gray[0],
-        width: columnSizing.size ?? 'auto',
-        minWidth: columnSizing.minSize,
-        maxWidth: columnSizing.maxSize,
+        height: theme.spacing.xl,
+        width: size ?? 'auto',
+        minWidth: minSize,
+        maxWidth: maxSize,
+        fontWeight: 500,
+        fontSize: theme.fontSizes.xs,
+
+        '&:first-of-type': {
+            paddingLeft: theme.spacing.xl,
+        },
+
+        '&:last-of-type': {
+            paddingRight: theme.spacing.xl,
+        },
     },
 
     control: {
-        color: 'inherit',
-        whiteSpace: 'inherit',
-        fontWeight: 'inherit',
-        width: '100%',
-        padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
         '&:hover': {
             backgroundColor: theme.colorScheme === 'dark' ? theme.colors.gray[7] : theme.colors.gray[1],
         },

--- a/packages/mantine/src/components/table/table-header/Th.types.ts
+++ b/packages/mantine/src/components/table/table-header/Th.types.ts
@@ -1,5 +1,11 @@
+import {DefaultProps, Selectors} from '@mantine/core';
 import {Header} from '@tanstack/react-table';
+import {ComponentType, SVGProps} from 'react';
+import useStyles from './Th.styles';
 
-export interface ThProps<T> {
+export type SortState = 'asc' | 'desc' | 'none';
+
+export interface ThProps<T = unknown> extends DefaultProps<Selectors<typeof useStyles>> {
     header: Header<T, unknown>;
+    sortingIcons?: Record<SortState, ComponentType<SVGProps<SVGSVGElement>>>;
 }


### PR DESCRIPTION
### Proposed Changes

Allow customization of table column headers through the theme.

Using the new customization capabilities, I was able to produce a table looking like this 🎉 
![image](https://github.com/coveo/plasma/assets/35579930/0a0ed580-b7a7-4d36-a3c0-43bcf24a8edc)

I think it also makes sense for the plasma table to move the sort icon closer to the column header label:

Before

![image](https://github.com/coveo/plasma/assets/35579930/91160908-6edb-42c1-9451-5fb806fe43ec)

After

![image](https://github.com/coveo/plasma/assets/35579930/42c2582d-2232-4597-8f16-cf6e9cdb8ad9)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
