### PR TITLE
feat(mantine): replace search icon with filter

### DIFF
--- a/packages/mantine/src/components/table/table-filter/TableFilter.tsx
+++ b/packages/mantine/src/components/table/table-filter/TableFilter.tsx
@@ -1,4 +1,4 @@
-import {CrossSize16Px, SearchSize16Px} from '@coveord/plasma-react-icons';
+import {CrossSize16Px, FilterSize16Px} from '@coveord/plasma-react-icons';
 import {ActionIcon, Grid, TextInput} from '@mantine/core';
 import {ChangeEventHandler, FunctionComponent, MouseEventHandler, useEffect, useState} from 'react';
 
@@ -57,7 +57,7 @@ export const TableFilter: FunctionComponent<TableFilterProps> = ({
                             <CrossSize16Px height={16} />
                         </ActionIcon>
                     ) : (
-                        <SearchSize16Px height={16} className={classes.empty} />
+                        <FilterSize16Px height={16} className={classes.empty} />
                     )
                 }
                 value={filter}


### PR DESCRIPTION
### Proposed Changes
Replaced "search" icon by the "filter" icon instead in the filter of the `Table` component.

|Before|After|
|--|--|
|<img width="823" alt="image" src="https://github.com/coveo/plasma/assets/105073504/e895dbe4-8d3b-4846-9c01-2bea79878207">|<img width="680" alt="image" src="https://github.com/coveo/plasma/assets/105073504/f89f1716-cc12-4635-ae68-1998a9bfd359">|


<!-- Explain what are your changes. -->

### Potential Breaking Changes
None

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
