### PR TITLE
fix(WEB-6600): add error outline in CodeEditor when form is in error and fix windows build process

### DIFF
--- a/packages/components-props-analyzer/package.json
+++ b/packages/components-props-analyzer/package.json
@@ -20,7 +20,7 @@
         "compile": "node ../../scripts/build",
         "gen:props": "ts-node --project ./bin/tsconfig.json ./bin/index.ts",
         "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint -c ./.eslintrc.js \"src/**/*.{ts,tsx}\" --fix",
-        "prettify": "prettier --write 'src/components/*.ts'",
+        "prettify": "prettier --write \"src/components/*.ts\"",
         "start": "nodemon"
     },
     "dependencies": {

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -85,7 +85,7 @@ interface CodeEditorProps
 
 const defaultProps: Partial<CodeEditorProps> = {
     language: 'plaintext',
-    monacoLoader: 'cdn',
+    monacoLoader: 'local',
     defaultValue: '',
     minHeight: 300,
 };

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -16,7 +16,7 @@ import {
 import {useUncontrolled} from '@mantine/hooks';
 import {editor as monacoEditor} from 'monaco-editor';
 import Editor, {loader, Monaco} from '@monaco-editor/react';
-import {FunctionComponent, useEffect, useRef, useState} from 'react';
+import {FunctionComponent, useEffect, useMemo, useRef, useState} from 'react';
 
 import {useParentHeight} from '../../hooks';
 import {XML} from './languages/xml';
@@ -85,7 +85,7 @@ interface CodeEditorProps
 
 const defaultProps: Partial<CodeEditorProps> = {
     language: 'plaintext',
-    monacoLoader: 'local',
+    monacoLoader: 'cdn',
     defaultValue: '',
     minHeight: 300,
 };
@@ -113,8 +113,6 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         ...others
     } = useComponentDefaultProps('CodeEditor', defaultProps, props);
     const [loaded, setLoaded] = useState(false);
-    const [containsError, setContainsError] = useState(false);
-    const {classes, theme} = useStyles({error: containsError});
     const [_value, handleChange] = useUncontrolled<string>({
         value,
         defaultValue,
@@ -143,6 +141,10 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         }
     };
 
+    const [hasMonacoError, setHasMonacoError] = useState(false);
+    const renderErrorOutline = useMemo(() => !!error || hasMonacoError, [hasMonacoError, error]);
+    const {classes, theme} = useStyles({error: renderErrorOutline});
+
     useEffect(() => {
         if (monacoLoader === 'local') {
             loadLocalMonaco();
@@ -152,7 +154,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     }, []);
 
     const handleValidate = (markers: monacoEditor.IMarker[]) => {
-        setContainsError(
+        setHasMonacoError(
             markers.some((marker) => marker.severity === loader.__getMonacoInstance().MarkerSeverity.Error),
         );
     };

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -16,7 +16,7 @@ import {
 import {useUncontrolled} from '@mantine/hooks';
 import {editor as monacoEditor} from 'monaco-editor';
 import Editor, {loader, Monaco} from '@monaco-editor/react';
-import {FunctionComponent, useEffect, useMemo, useRef, useState} from 'react';
+import {FunctionComponent, useEffect, useRef, useState} from 'react';
 
 import {useParentHeight} from '../../hooks';
 import {XML} from './languages/xml';

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -142,8 +142,8 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     };
 
     const [hasMonacoError, setHasMonacoError] = useState(false);
-    const renderErrorOutline = useMemo(() => !!error || hasMonacoError, [hasMonacoError, error]);
-    const {classes, theme} = useStyles({error: renderErrorOutline});
+    const renderErrorOutline = !!error || hasMonacoError;
+    const {classes, theme} = useStyles({error: renderErrorOutline}, {name: 'CodeEditor'});
 
     useEffect(() => {
         if (monacoLoader === 'local') {

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -193,7 +193,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     );
 
     const _editor = loaded ? (
-        <Box p="md" pl="xs" className={classes.editor}>
+        <Box p="md" pl="xs" className={classes.editor} data-testid="editor-wrapper">
             <Editor
                 onValidate={handleValidate}
                 defaultLanguage={language}

--- a/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
+++ b/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
@@ -41,6 +41,7 @@ describe('CodeEditor', () => {
         await waitForElementToBeRemoved(screen.queryByRole('presentation'));
 
         expect(screen.getByText(/invalid configuration/i)).toBeInTheDocument();
+        expect(screen.getByTestId('editor-wrapper')).toHaveStyle('outline-color: #cd2113');
     });
 
     it('loads the monaco editor files from node_modules when monacoLoader prop is "local"', async () => {
@@ -79,6 +80,7 @@ describe('CodeEditor', () => {
 
         expect(onCopySpy).toHaveBeenCalledTimes(1);
     });
+
     it('calls the onSearch callback when clicking on the search button', async () => {
         const user = userEvent.setup();
         const onSearchSpy = vi.fn();

--- a/packages/react-icons/bin/index.js
+++ b/packages/react-icons/bin/index.js
@@ -6,6 +6,7 @@ const svgr = require('@svgr/core');
 const groupBy = require('lodash.groupby');
 const upperFirst = require('lodash.upperfirst');
 const {rmSync} = require('fs-extra');
+const path = require('path');
 const template = require('./template');
 
 const iconsSourceDirPath = 'node_modules/@coveord/plasma-tokens/icons';
@@ -87,5 +88,5 @@ rmSync(outDirPath, {recursive: true, force: true});
 rmSync('./dist', {recursive: true, force: true});
 fs.ensureDirSync(outDirPath);
 
-const svgs = globSync(`${iconsSourceDirPath}/**/*.svg`);
+const svgs = globSync(`${iconsSourceDirPath}/**/*.svg`).map((svgPath) => svgPath.split(path.sep).join(path.posix.sep));
 handleSvgFiles(svgs);


### PR DESCRIPTION
### Proposed Changes

- In the `CodeEditor`, now also display the error outline when there is an `error` coming from the form
- Fix some things along the way that were breaking when I tried to build the plasma repo on my Windows machine

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
