### PR TITLE
chore(node): specified node-version in setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,7 @@ runs:
         - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
           with:
               registry-url: 'https://registry.npmjs.org'
+              node-version: 20.9.0
         - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
           with:
               version: 8


### PR DESCRIPTION
### Proposed Changes

same as https://github.com/coveo/admin-ui/pull/8833

I have explicitly specified the node-version in the action, since it's recommended from the documentation

```The node-version input is optional. If not supplied, the node version from PATH will be used. However, it is recommended to always specify Node.js version and don't rely on the system one.```

### Potential Breaking Changes

if green, good to go.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
