### PR TITLE
fix(plasma-react,SingleSelect): memoize selectors

### DIFF
--- a/packages/mantine/src/components/table/table-loading/TableLoading.tsx
+++ b/packages/mantine/src/components/table/table-loading/TableLoading.tsx
@@ -2,7 +2,7 @@ import {Skeleton, SkeletonProps} from '@mantine/core';
 import {FunctionComponent} from 'react';
 
 export const TableLoading: FunctionComponent<SkeletonProps> = (props) => (
-    <Skeleton style={{display: 'inline-block'}} {...props} sx={!props.visible ? {borderRadius: 0} : undefined}>
+    <Skeleton {...props} sx={!props.visible ? {borderRadius: 0} : undefined}>
         {props.children}
     </Skeleton>
 );

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -28,19 +28,21 @@ In a `.jsx` context:
 
 ```jsx
 const React = require('react');
-const ReactDom = require('react-dom');
+const createRoot = require('react-dom/client').createRoot;
 const Badge = require('@coveord/plasma-react').Badge;
 
-ReactDom.render(<Badge label="Hello Plasma!" />, document.getElementById('SomewhereInYourApp'));
+const root = createRoot(document.getElementById('SomewhereInYourApp'));
+root.render(<Badge label="Hello Plasma!" />);
 ```
 
 In a `.tsx` context:
 
 ```jsx
-import * as ReactDom from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import {Badge} from '@coveord/plasma-react';
 
-ReactDom.render(<Badge label="Hello Plasma!" />, document.getElementById('SomewhereInYourApp'));
+const root = createRoot(document.getElementById('SomewhereInYourApp'));
+root.render(<Badge label="Hello Plasma!" />);
 ```
 
 #### Dropdowns

--- a/packages/react/jest/utils.tsx
+++ b/packages/react/jest/utils.tsx
@@ -22,13 +22,6 @@ const setup = () => {
     Defaults.APP_ELEMENT = '#' + TEST_CONTAINER_ID;
     Defaults.MODAL_ROOT = '#' + MODAL_ROOT_ID;
     Defaults.MODAL_TIMEOUT = 0;
-    console.error = (...args) => {
-        if (/Warning: ReactDOM.render is no longer supported in React 18./.test(args[0])) {
-            return;
-        } else {
-            originalError.call(console, ...args);
-        }
-    };
 };
 
 const cleanup = () => {

--- a/packages/react/src/components/limit/Limit.tsx
+++ b/packages/react/src/components/limit/Limit.tsx
@@ -59,9 +59,9 @@ const isANumber = (n: any): n is number => typeof n === 'number' && !Number.isNa
  * @deprecated Use Mantine instead
  */
 export const Limit: FunctionComponent<LimitOwnProps> = (props) => {
-    const {currentLimit} = useSelector((state: PlasmaState) => ({
-        currentLimit: +InputSelectors.getValue(state, {id: props.id}) || props.limit,
-    }));
+    const currentLimit = useSelector(
+        (state: PlasmaState) => +InputSelectors.getValue(state, {id: props.id}) || props.limit,
+    );
 
     return (
         <div className={classNames('limit-box mb2', props.className)}>

--- a/packages/react/src/components/select/SelectSelector.ts
+++ b/packages/react/src/components/select/SelectSelector.ts
@@ -13,7 +13,10 @@ import {ISelectWithFilterOwnProps} from './hoc/SelectWithFilter';
 import {ISelectOwnProps} from './SelectConnected';
 import {SelectConstants} from './SelectConstants';
 
-const getListState = (state: PlasmaState, {id}: {id: string}): string[] => state?.selectWithFilter?.[id]?.list ?? [];
+const getListState = createSelector(
+    [(state: PlasmaState, {id}: {id: string}) => state?.selectWithFilter?.[id]?.list],
+    (list) => list ?? [],
+);
 
 const getListBox = (state: PlasmaState, {id}: {id: string}): Partial<IListBoxState> =>
     _.findWhere(state.listBoxes, {id}) || {};

--- a/packages/react/src/components/select/SingleSelectConnected.tsx
+++ b/packages/react/src/components/select/SingleSelectConnected.tsx
@@ -65,11 +65,8 @@ export const SingleSelectConnected: FunctionComponent<ISingleSelectProps> = ({
     ...props
 }) => {
     const dispatch: IDispatch = useDispatch();
-
-    const {customSelected, defaultSelected} = useSelector((state: PlasmaState) => ({
-        customSelected: SelectSelector.getListState(state, props),
-        defaultSelected: SelectSelector.getListBoxSelected(state, props)[0],
-    }));
+    const customSelected = useSelector((state: PlasmaState) => SelectSelector.getListState(state, {id: props.id}));
+    const defaultSelected = useSelector((state: PlasmaState) => SelectSelector.getListBoxSelected(state, props)[0]);
 
     const selectedOption = customSelected.length ? customSelected[customSelected.length - 1] : defaultSelected;
 


### PR DESCRIPTION
### Proposed Changes

Removing this warning:
![image](https://github.com/coveo/plasma/assets/35579930/b43a031a-c7f9-4893-9531-e45e5ffdd349)


<pre>
SingleSelectConnected.tsx:69 Selector unknown returned a different result when called with the same parameters. This can lead to unnecessary rerenders.Selectors that return a new reference (such as an object or an array) should be memoized: https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization {state: {…}, selected: {…}, selected2: {…}}     at SingleSelectConnected (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/react/dist/esm/components/select/SingleSelectConnected.js:21:37)    at WrappedComponent (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/react/dist/esm/components/select/hoc/SelectWithPredicate.js:35:30)    at ConnectFunction (http://localhost:3000/node_modules/.vite/deps/react-redux.js?v=6e0298f0:889:75)    at Demo    at div    at div    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7807:13    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8144:11    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7740:11    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7717:11    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7807:13    at Provider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7957:15)    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8091:11    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8952:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:9022:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:15886:14    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:28762:14    at div    at Demo (http://localhost:3000/src/building-blocs/Demo.tsx:60:17)    at WithPredicatesDemo    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:30244:14    at div    at Content (http://localhost:3000/src/building-blocs/PageLayout.tsx:148:26)    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31470:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:18407:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:30244:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at Provider (http://localhost:3000/node_modules/.vite/deps/chunk-32BD5JKZ.js?v=6e0298f0:147:23)    at TabsProvider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31715:3)    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31821:14    at PageLayout (http://localhost:3000/src/building-blocs/PageLayout.tsx:16:30)    at Page    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3330:5)    at RenderErrorBoundary (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3290:5)    at Outlet (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3711:26)    at main    at div    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7139:14    at ThemeProvider2 (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:2761:23)    at MantineProvider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:3519:3)    at Plasmantine (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/mantine/dist/esm/theme/Plasmantine.js:5:26)    at Provider (http://localhost:3000/node_modules/.vite/deps/react-redux.js?v=6e0298f0:1039:3)    at EngineProvider (http://localhost:3000/src/search/engine/EngineProvider.tsx:16:34)    at App    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3330:5)    at RenderErrorBoundary (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3290:5)    at DataRoutes (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3639:5)    at Router (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3718:15)    at RouterProvider (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3588:5)
overrideMethod @ console.js:213
overrideMethod @ console.js:267
(anonymous) @ useSelector.js:63
memoizedSelector @ with-selector.development.js:79
getSnapshotWithSelector @ with-selector.development.js:134
mountSyncExternalStore @ react-dom.development.js:16799
useSyncExternalStore @ react-dom.development.js:17727
useSyncExternalStore @ react.development.js:1676
useSyncExternalStoreWithSelector3 @ with-selector.development.js:145
useSelector2 @ useSelector.js:87
SingleSelectConnected @ SingleSelectConnected.tsx:69
renderWithHooks @ react-dom.development.js:16305
mountIndeterminateComponent @ react-dom.development.js:20145
beginWork @ react-dom.development.js:21587
beginWork$1 @ react-dom.development.js:27426
performUnitOfWork @ react-dom.development.js:26557
workLoopSync @ react-dom.development.js:26466
renderRootSync @ react-dom.development.js:26434
performConcurrentWorkOnRoot @ react-dom.development.js:25738
workLoop @ scheduler.development.js:266
flushWork @ scheduler.development.js:239
performWorkUntilDeadline @ scheduler.development.js:533
Show 21 more frames
Show less
SingleSelectConnected.tsx:69 Selector unknown returned a different result when called with the same parameters. This can lead to unnecessary rerenders.
Selectors that return a new reference (such as an object or an array) should be memoized: https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization {state: {…}, selected: {…}, selected2: {…}} 
    at SingleSelectConnected (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/react/dist/esm/components/select/SingleSelectConnected.js:21:37)
    at ComponentWithInfiniteScroll (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/react/dist/esm/components/select/hoc/SelectWithInfiniteScroll.js:17:39)
    at ConnectFunction (http://localhost:3000/node_modules/.vite/deps/react-redux.js?v=6e0298f0:889:75)
    at Wrapper (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/react/dist/esm/components/select/hoc/SelectWithFilter.js:59:13)
    at ConnectFunction (http://localhost:3000/node_modules/.vite/deps/react-redux.js?v=6e0298f0:889:75)
    at withServerSideProcessing(Connect(withFilter(Connect(withInfiniteScroll(undefined)))))
    at Demo (http://localhost:3000/src/examples/legacy/form/SingleSelect/withInfiniteScroll.demo.tsx?demo:20:25)
    at div
    at div
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7807:13
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8144:11
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7740:11
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7717:11
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7807:13
    at Provider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7957:15)
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8091:11
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8952:14
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:9022:14
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:15886:14
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:28762:14
    at div
    at Demo (http://localhost:3000/src/building-blocs/Demo.tsx:60:17)
    at WithInfiniteScrollDemo
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:30244:14
    at div
    at Content (http://localhost:3000/src/building-blocs/PageLayout.tsx:148:26)
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31470:14
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:18407:14
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:30244:14
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at Provider (http://localhost:3000/node_modules/.vite/deps/chunk-32BD5JKZ.js?v=6e0298f0:147:23)
    at TabsProvider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31715:3)
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31821:14
    at PageLayout (http://localhost:3000/src/building-blocs/PageLayout.tsx:16:30)
    at Page
    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3330:5)
    at RenderErrorBoundary (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3290:5)
    at Outlet (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3711:26)
    at main
    at div
    at div
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18
    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7139:14
    at ThemeProvider2 (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:2761:23)
    at MantineProvider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:3519:3)
    at Plasmantine (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/mantine/dist/esm/theme/Plasmantine.js:5:26)
    at Provider (http://localhost:3000/node_modules/.vite/deps/react-redux.js?v=6e0298f0:1039:3)
    at EngineProvider (http://localhost:3000/src/search/engine/EngineProvider.tsx:16:34)
    at App
    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3330:5)
    at RenderErrorBoundary (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3290:5)
    at DataRoutes (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3639:5)
    at Router (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3718:15)
    at RouterProvider (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3588:5)
overrideMethod @ console.js:213
(anonymous) @ useSelector.js:63
memoizedSelector @ with-selector.development.js:79
getSnapshotWithSelector @ with-selector.development.js:134
mountSyncExternalStore @ react-dom.development.js:16799
useSyncExternalStore @ react-dom.development.js:17727
useSyncExternalStore @ react.development.js:1676
useSyncExternalStoreWithSelector3 @ with-selector.development.js:145
useSelector2 @ useSelector.js:87
SingleSelectConnected @ SingleSelectConnected.tsx:69
renderWithHooks @ react-dom.development.js:16305
mountIndeterminateComponent @ react-dom.development.js:20074
beginWork @ react-dom.development.js:21587
beginWork$1 @ react-dom.development.js:27426
performUnitOfWork @ react-dom.development.js:26557
workLoopSync @ react-dom.development.js:26466
renderRootSync @ react-dom.development.js:26434
performConcurrentWorkOnRoot @ react-dom.development.js:25738
workLoop @ scheduler.development.js:266
flushWork @ scheduler.development.js:239
performWorkUntilDeadline @ scheduler.development.js:533
Show 20 more frames
Show less
SingleSelectConnected.tsx:69 Selector unknown returned a different result when called with the same parameters. This can lead to unnecessary rerenders.Selectors that return a new reference (such as an object or an array) should be memoized: https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization {state: {…}, selected: {…}, selected2: {…}}     at SingleSelectConnected (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/react/dist/esm/components/select/SingleSelectConnected.js:21:37)    at ComponentWithInfiniteScroll (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/react/dist/esm/components/select/hoc/SelectWithInfiniteScroll.js:17:39)    at ConnectFunction (http://localhost:3000/node_modules/.vite/deps/react-redux.js?v=6e0298f0:889:75)    at Wrapper (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/react/dist/esm/components/select/hoc/SelectWithFilter.js:59:13)    at ConnectFunction (http://localhost:3000/node_modules/.vite/deps/react-redux.js?v=6e0298f0:889:75)    at withServerSideProcessing(Connect(withFilter(Connect(withInfiniteScroll(undefined)))))    at Demo (http://localhost:3000/src/examples/legacy/form/SingleSelect/withInfiniteScroll.demo.tsx?demo:20:25)    at div    at div    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7807:13    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8144:11    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7740:11    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7717:11    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7807:13    at Provider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7957:15)    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8091:11    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:8952:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:9022:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:15886:14    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:28762:14    at div    at Demo (http://localhost:3000/src/building-blocs/Demo.tsx:60:17)    at WithInfiniteScrollDemo    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:30244:14    at div    at Content (http://localhost:3000/src/building-blocs/PageLayout.tsx:148:26)    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31470:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:18407:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:30244:14    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at Provider (http://localhost:3000/node_modules/.vite/deps/chunk-32BD5JKZ.js?v=6e0298f0:147:23)    at TabsProvider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31715:3)    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:31821:14    at PageLayout (http://localhost:3000/src/building-blocs/PageLayout.tsx:16:30)    at Page    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3330:5)    at RenderErrorBoundary (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3290:5)    at Outlet (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3711:26)    at main    at div    at div    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:4445:18    at http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:7139:14    at ThemeProvider2 (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:2761:23)    at MantineProvider (http://localhost:3000/node_modules/.vite/deps/chunk-M3ZB4MMP.js?v=6e0298f0:3519:3)    at Plasmantine (http://localhost:3000/@fs/Users/gdostie/Developper/coveo/plasma/packages/mantine/dist/esm/theme/Plasmantine.js:5:26)    at Provider (http://localhost:3000/node_modules/.vite/deps/react-redux.js?v=6e0298f0:1039:3)    at EngineProvider (http://localhost:3000/src/search/engine/EngineProvider.tsx:16:34)    at App    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3330:5)    at RenderErrorBoundary (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3290:5)    at DataRoutes (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3639:5)    at Router (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3718:15)    at RouterProvider (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=6e0298f0:3588:5)
overrideMethod @ console.js:213
overrideMethod @ console.js:267
(anonymous) @ useSelector.js:63
memoizedSelector @ with-selector.development.js:79
getSnapshotWithSelector @ with-selector.development.js:134
mountSyncExternalStore @ react-dom.development.js:16799
useSyncExternalStore @ react-dom.development.js:17727
useSyncExternalStore @ react.development.js:1676
useSyncExternalStoreWithSelector3 @ with-selector.development.js:145
useSelector2 @ useSelector.js:87
SingleSelectConnected @ SingleSelectConnected.tsx:69
renderWithHooks @ react-dom.development.js:16305
mountIndeterminateComponent @ react-dom.development.js:20145
beginWork @ react-dom.development.js:21587
beginWork$1 @ react-dom.development.js:27426
performUnitOfWork @ react-dom.development.js:26557
workLoopSync @ react-dom.development.js:26466
renderRootSync @ react-dom.development.js:26434
performConcurrentWorkOnRoot @ react-dom.development.js:25738
workLoop @ scheduler.development.js:266
flushWork @ scheduler.development.js:239
performWorkUntilDeadline @ scheduler.development.js:533
Show 21 more frames
Show less
scheduler.development.js:517 [Violation] 'message' handler took 166ms
</pre>

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
