### PR TITLE
fix(mantine): fix disabled tooltips for inline confim buttons

### DIFF
--- a/packages/mantine/src/components/inline-confirm/InlineConfirmButton.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirmButton.tsx
@@ -1,7 +1,6 @@
-import {Button} from '@mantine/core';
 import {forwardRef, MouseEventHandler} from 'react';
+import {Button, ButtonProps} from '../button';
 
-import {ButtonProps} from '../button';
 import {useInlineConfirm} from './useInlineConfirm';
 
 export interface InlineConfirmButtonProps extends ButtonProps {

--- a/packages/mantine/src/components/inline-confirm/__tests__/InlineConfirm.spec.tsx
+++ b/packages/mantine/src/components/inline-confirm/__tests__/InlineConfirm.spec.tsx
@@ -120,4 +120,24 @@ describe('InlineConfirm', () => {
         expect(screen.queryByText('Delete X?')).not.toBeInTheDocument();
         expect(screen.getByText('Print?')).toBeVisible();
     });
+
+    it('shows tooltip when button is disabled', async () => {
+        const user = userEvent.setup();
+        const onClickSpy = vi.fn();
+        render(
+            <InlineConfirm>
+                <InlineConfirm.Button id="delete" onClick={onClickSpy} disabled disabledTooltip="You shall not pass">
+                    Delete
+                </InlineConfirm.Button>
+            </InlineConfirm>,
+        );
+
+        const deleteButton = screen.getByRole('button', {name: 'Delete'});
+        expect(deleteButton).toBeDisabled();
+        expect(screen.queryByRole('tooltip', {name: /You shall not pass/i})).not.toBeInTheDocument();
+
+        await user.hover(deleteButton.parentElement);
+
+        expect(screen.getByRole('tooltip', {name: /You shall not pass/i})).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
### Proposed Changes

- Import button from plasma/mantine instead of mantine core. 

- Origin https://github.com/coveo/plasma/pull/3022/files#diff-76e149949bcb2228e7851d523510603b2ee856c7da95aaf1e5267069ce8a0eb7R1-R2
- Added test to cover the case

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
