### PR TITLE
fix(wpc-154): add numeric input buttons type

### DIFF
--- a/packages/react/src/components/numericInput/NumericInputConnected.tsx
+++ b/packages/react/src/components/numericInput/NumericInputConnected.tsx
@@ -119,6 +119,7 @@ export class NumericInputConnected extends PureComponent<NumericInputProps & HTM
             <div className="numeric-input flex flex-column">
                 <div className="flex flex-row">
                     <button
+                        type="button"
                         className="js-decrement mr1"
                         disabled={!decrementEnabled || this.props.disabled}
                         onClick={this.onDecrement}
@@ -144,6 +145,7 @@ export class NumericInputConnected extends PureComponent<NumericInputProps & HTM
                         />
                     </div>
                     <button
+                        type="button"
                         className="js-increment ml1"
                         disabled={!incrementEnabled || this.props.disabled}
                         onClick={this.onIncrement}


### PR DESCRIPTION
### Proposed Changes

Adds the button types to the plus and minus numeric input buttons. This avoids premature default validations on the form when clicking on those buttons. Currently the default type of the button is submit and triggers validations on every button press. This behavior manifests itself by showing a `Please fill out this field` alert on every button press on forms where empty inputs are present in the form. Here's a [stack overflow post ](https://stackoverflow.com/a/28340579)describing the issue

![image](https://github.com/coveo/plasma/assets/142046102/44d60b3e-89c4-4c40-9de7-82d5d2edd2a5)