### PR TITLE
[MHUB-613] feat: add an extended multi-select

### DIFF
--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -42,6 +42,7 @@
         "@dnd-kit/modifiers": "7.0.0",
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.1",
+        "@mantine/styles": "6.0.19",
         "@mantine/utils": "6.0.19",
         "@monaco-editor/react": "4.5.1",
         "@swc/helpers": "0.5.1",

--- a/packages/mantine/src/components/extended-multi-select/DefaultItem.tsx
+++ b/packages/mantine/src/components/extended-multi-select/DefaultItem.tsx
@@ -1,0 +1,16 @@
+import React, {forwardRef} from 'react';
+
+export interface SelectItemProps extends Omit<React.ComponentPropsWithoutRef<'div'>, 'value'> {
+    label: React.ReactNode;
+    value?: string;
+}
+
+export const DefaultItem = forwardRef<HTMLDivElement, SelectItemProps>(
+    ({label, value, ...others}: SelectItemProps, ref) => (
+        <div ref={ref} {...others}>
+            {label || value}
+        </div>
+    ),
+);
+
+DefaultItem.displayName = '@mantine/core/DefaultItem';

--- a/packages/mantine/src/components/extended-multi-select/DefaultValue/DefaultValue.styles.ts
+++ b/packages/mantine/src/components/extended-multi-select/DefaultValue/DefaultValue.styles.ts
@@ -1,0 +1,69 @@
+import { createStyles, MantineNumberSize, rem, getSize } from '@mantine/styles';
+
+interface DefaultLabelStyles {
+  radius: MantineNumberSize;
+  disabled: boolean;
+  readOnly: boolean;
+}
+
+export const sizes = {
+  xs: rem(16),
+  sm: rem(22),
+  md: rem(26),
+  lg: rem(30),
+  xl: rem(36),
+};
+
+const fontSizes = {
+  xs: rem(10),
+  sm: rem(12),
+  md: rem(14),
+  lg: rem(16),
+  xl: rem(18),
+};
+
+export default createStyles(
+  (theme, { disabled, radius, readOnly }: DefaultLabelStyles, { size, variant }) => ({
+    defaultValue: {
+      display: 'flex',
+      alignItems: 'center',
+      backgroundColor: disabled
+        ? theme.colorScheme === 'dark'
+          ? theme.colors.dark[5]
+          : theme.colors.gray[3]
+        : theme.colorScheme === 'dark'
+        ? theme.colors.dark[7]
+        : variant === 'filled'
+        ? theme.white
+        : theme.colors.gray[1],
+      color: disabled
+        ? theme.colorScheme === 'dark'
+          ? theme.colors.dark[1]
+          : theme.colors.gray[7]
+        : theme.colorScheme === 'dark'
+        ? theme.colors.dark[0]
+        : theme.colors.gray[7],
+      height: getSize({ size, sizes }),
+      paddingLeft: `calc(${getSize({ size, sizes: theme.spacing })} / 1.5)`,
+      paddingRight: disabled || readOnly ? getSize({ size, sizes: theme.spacing }) : 0,
+      fontWeight: 500,
+      fontSize: getSize({ size, sizes: fontSizes }),
+      borderRadius: getSize({ size: radius, sizes: theme.radius }),
+      cursor: disabled ? 'not-allowed' : 'default',
+      userSelect: 'none',
+      maxWidth: `calc(100% - ${rem(10)})`,
+    },
+
+    defaultValueRemove: {
+      color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.colors.gray[7],
+      marginLeft: `calc(${getSize({ size, sizes: theme.spacing })} / 6)`,
+    },
+
+    defaultValueLabel: {
+      display: 'block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+  })
+);

--- a/packages/mantine/src/components/extended-multi-select/DefaultValue/DefaultValue.tsx
+++ b/packages/mantine/src/components/extended-multi-select/DefaultValue/DefaultValue.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {DefaultProps, MantineSize, MantineNumberSize, Selectors} from '@mantine/styles';
+import {CloseButton} from '@mantine/core';
+import useStyles from './DefaultValue.styles';
+
+export type DefaultValueStylesNames = Selectors<typeof useStyles>;
+
+export interface ExtendedMultiSelectValueProps
+    extends DefaultProps<DefaultValueStylesNames>,
+        React.ComponentPropsWithoutRef<'div'> {
+    label: string;
+    onRemove(): void;
+    disabled: boolean;
+    readOnly: boolean;
+    size: MantineSize;
+    radius: MantineNumberSize;
+    variant: string;
+}
+
+const buttonSizes = {
+    xs: 16,
+    sm: 22,
+    md: 24,
+    lg: 26,
+    xl: 30,
+};
+
+export const DefaultValue = ({
+    label,
+    classNames,
+    styles,
+    className,
+    onRemove,
+    disabled,
+    readOnly,
+    size,
+    radius = 'sm',
+    variant,
+    unstyled,
+    ...others
+}: ExtendedMultiSelectValueProps) => {
+    const {classes, cx} = useStyles(
+        {disabled, readOnly, radius},
+        {name: 'MultiSelect', classNames, styles, unstyled, size, variant},
+    );
+
+    return (
+        <div className={cx(classes.defaultValue, className)} {...others}>
+            <span className={classes.defaultValueLabel}>{label}</span>
+
+            {!disabled && !readOnly && (
+                <CloseButton
+                    aria-hidden
+                    onMouseDown={onRemove}
+                    size={buttonSizes[size as 'xs' | 'sm' | 'md' | 'lg' | 'xl']}
+                    radius={2}
+                    color="blue"
+                    variant="transparent"
+                    iconSize="70%"
+                    className={classes.defaultValueRemove}
+                    tabIndex={-1}
+                    unstyled={unstyled}
+                />
+            )}
+        </div>
+    );
+};
+
+DefaultValue.displayName = '@mantine/core/MultiSelect/DefaultValue';

--- a/packages/mantine/src/components/extended-multi-select/ExtendedMultiSelect.styles.ts
+++ b/packages/mantine/src/components/extended-multi-select/ExtendedMultiSelect.styles.ts
@@ -1,0 +1,109 @@
+import {createStyles, rem, getSize} from '@mantine/styles';
+import {INPUT_SIZES} from '@mantine/core';
+import {sizes as DEFAULT_VALUE_SIZES} from './DefaultValue/DefaultValue.styles';
+
+export interface ExtendedMultiSelectStylesParams {
+    invalid: boolean;
+}
+
+export default createStyles((theme, {invalid}: ExtendedMultiSelectStylesParams, {size}) => ({
+    wrapper: {
+        position: 'relative',
+
+        '&:has(input:disabled)': {
+            cursor: 'not-allowed',
+            pointerEvents: 'none',
+
+            '& .mantine-ExtendedMultiSelect-input': {
+                backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[1],
+                color: theme.colors.dark[2],
+                opacity: 0.6,
+
+                '&::placeholder': {
+                    color: theme.colors.dark[2],
+                },
+            },
+
+            '& .mantine-ExtendedMultiSelect-defaultValue': {
+                backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[3],
+                color: theme.colorScheme === 'dark' ? theme.colors.dark[1] : theme.colors.gray[7],
+            },
+        },
+    },
+
+    values: {
+        minHeight: `calc(${getSize({size, sizes: INPUT_SIZES})} - ${rem(2)})`,
+        display: 'flex',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        marginLeft: `calc(-${theme.spacing.xs} / 2)`,
+        boxSizing: 'border-box',
+
+        '&[data-clearable]': {
+            marginRight: getSize({size, sizes: INPUT_SIZES}),
+        },
+    },
+
+    value: {
+        margin: `calc(${theme.spacing.xs} / 2 - ${rem(2)}) calc(${theme.spacing.xs} / 2)`,
+    },
+
+    searchInput: {
+        ...theme.fn.fontStyles(),
+        flex: 1,
+        minWidth: rem(60),
+        backgroundColor: 'transparent',
+        border: 0,
+        outline: 0,
+        fontSize: getSize({size, sizes: theme.fontSizes}),
+        padding: 0,
+        marginLeft: `calc(${theme.spacing.xs} / 2)`,
+        appearance: 'none',
+        color: 'inherit',
+        maxHeight: getSize({size, sizes: DEFAULT_VALUE_SIZES}),
+
+        '&::placeholder': {
+            opacity: 1,
+            color: invalid
+                ? theme.colors.red[theme.fn.primaryShade()]
+                : theme.colorScheme === 'dark'
+                ? theme.colors.dark[3]
+                : theme.colors.gray[5],
+        },
+
+        '&:disabled': {
+            cursor: 'not-allowed',
+            pointerEvents: 'none',
+        },
+    },
+
+    searchInputEmpty: {
+        width: '100%',
+    },
+
+    searchInputInputHidden: {
+        flex: 0,
+        width: 0,
+        minWidth: 0,
+        margin: 0,
+        overflow: 'hidden',
+    },
+
+    searchInputPointer: {
+        cursor: 'pointer',
+
+        '&:disabled': {
+            cursor: 'not-allowed',
+            pointerEvents: 'none',
+        },
+    },
+
+    input: {
+        cursor: 'pointer',
+
+        '&:disabled': {
+            cursor: 'not-allowed',
+            pointerEvents: 'none',
+        },
+    },
+}));

--- a/packages/mantine/src/components/extended-multi-select/ExtendedMultiSelect.tsx
+++ b/packages/mantine/src/components/extended-multi-select/ExtendedMultiSelect.tsx
@@ -1,0 +1,794 @@
+import React, {useState, useRef, forwardRef} from 'react';
+import {useUncontrolled, useMergedRef, useDidUpdate, useScrollIntoView, useId} from '@mantine/hooks';
+import {DefaultProps, Selectors, getDefaultZIndex, useComponentDefaultProps} from '@mantine/styles';
+import {groupOptions} from '@mantine/utils';
+import {Input, extractSystemStyles, TransitionOverride, MantineSize, MantineShadow, PortalProps} from '@mantine/core';
+
+import {DefaultItem} from './DefaultItem';
+import {DefaultValue, DefaultValueStylesNames} from './DefaultValue/DefaultValue';
+import {filterData} from './filter-data/filter-data';
+import {getSelectRightSectionProps} from './SelectRightSection/get-select-right-section-props';
+import {SelectScrollArea} from './SelectScrollArea/SelectScrollArea';
+import {SelectPopover} from './SelectPopover/SelectPopover';
+import {SelectItem, BaseSelectProps, BaseSelectStylesNames} from './types';
+import {SelectItems} from './SelectItems/SelectItems';
+import useStyles from './ExtendedMultiSelect.styles';
+export interface SelectSharedProps<Item, Value> {
+    /** Select data used to render items in dropdown */
+    data: ReadonlyArray<string | Item>;
+
+    /** Controlled input value */
+    value?: Value;
+
+    /** Uncontrolled input defaultValue */
+    defaultValue?: Value;
+
+    /** Controlled input onChange handler */
+    onChange?(value: Value): void;
+
+    /** Function based on which items in dropdown are filtered */
+    filter?(value: string, item: Item): boolean;
+
+    /** Input size */
+    size?: MantineSize;
+
+    /** Props added to Transition component that used to animate dropdown presence, use to configure duration and animation type, { duration: 0, transition: 'fade' } by default */
+    transitionProps?: TransitionOverride;
+
+    /** Dropdown shadow from theme or any value to set box-shadow */
+    shadow?: MantineShadow;
+
+    /** Initial dropdown opened state */
+    initiallyOpened?: boolean;
+
+    /** Change item renderer */
+    itemComponent?: React.FC<any>;
+
+    /** Called when dropdown is opened */
+    onDropdownOpen?(): void;
+
+    /** Called when dropdown is closed */
+    onDropdownClose?(): void;
+
+    /** Whether to render the dropdown in a Portal */
+    withinPortal?: boolean;
+
+    /** Props to pass down to the portal when withinPortal is true */
+    portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
+
+    /** Limit amount of items displayed at a time for searchable select */
+    limit?: number;
+
+    /** Nothing found label */
+    nothingFound?: React.ReactNode;
+
+    /** Dropdown z-index */
+    zIndex?: React.CSSProperties['zIndex'];
+
+    /** Dropdown positioning behavior */
+    dropdownPosition?: 'bottom' | 'top' | 'flip';
+
+    /** Whether to switch item order and keyboard navigation on dropdown position flip */
+    switchDirectionOnFlip?: boolean;
+
+    /** useEffect dependencies to force update dropdown position */
+    positionDependencies?: any[];
+}
+
+export type ExtendedMultiSelectStylesNames =
+    | DefaultValueStylesNames
+    | Exclude<Selectors<typeof useStyles>, 'searchInputEmpty' | 'searchInputInputHidden' | 'searchInputPointer'>
+    | Exclude<BaseSelectStylesNames, 'selected'>;
+
+export interface ExtendedMultiSelectProps
+    extends DefaultProps<ExtendedMultiSelectStylesNames>,
+        BaseSelectProps,
+        Omit<SelectSharedProps<SelectItem, string[]>, 'filter'> {
+    /** Component used to render values */
+    valueComponent?: React.FC<any>;
+
+    /** Maximum dropdown height */
+    maxDropdownHeight?: number | string;
+
+    /** Enable items searching */
+    searchable?: boolean;
+
+    /** Function based on which items in dropdown are filtered */
+    filter?(value: string, selected: boolean, item: SelectItem): boolean;
+
+    /** Clear search value when item is selected */
+    clearSearchOnChange?: boolean;
+
+    /** Allow to clear item */
+    clearable?: boolean;
+
+    /** Disable removing selected items from the list */
+    disableSelectedItemFiltering?: boolean;
+
+    /** Clear search field value on blur */
+    clearSearchOnBlur?: boolean;
+
+    /** Called each time search query changes */
+    onSearchChange?(query: string): void;
+
+    /** Controlled search input value */
+    searchValue?: string;
+
+    /** Hovers the first result when search query changes */
+    hoverOnSearchChange?: boolean;
+
+    /** Allow creatable option  */
+    creatable?: boolean;
+
+    /** Function to get create Label */
+    getCreateLabel?(query: string): React.ReactNode;
+
+    /** Function to determine if create label should be displayed */
+    shouldCreate?(query: string, data: SelectItem[]): boolean;
+
+    /** Called when create option is selected */
+    onCreate?(query: string): SelectItem | string | null | undefined;
+
+    /** Change dropdown component, can be used to add custom scrollbars */
+    dropdownComponent?: any;
+
+    /** Limit amount of items selected */
+    maxSelectedValues?: number;
+
+    /** Select highlighted item on blur */
+    selectOnBlur?: boolean;
+
+    /** Props added to clear button */
+    clearButtonProps?: React.ComponentPropsWithoutRef<'button'>;
+}
+
+export const defaultFilter = (value: string, selected: boolean, item: SelectItem) => {
+    if (selected) {
+        return false;
+    }
+    return item.label.toLowerCase().trim().includes(value.toLowerCase().trim());
+};
+
+export const defaultShouldCreate = (query: string, data: SelectItem[]) =>
+    !!query && !data.some((item) => item.value.toLowerCase() === query.toLowerCase());
+
+const filterValue = (value: string[], data: ReadonlyArray<string | SelectItem>): string[] => {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+
+    if (data.length === 0) {
+        return [];
+    }
+
+    const flatData: string[] = data.map((item) => {
+        if (typeof item === 'object') {
+            return item.value;
+        }
+        return item;
+    });
+    return value.filter((val) => flatData.includes(val));
+};
+
+const defaultProps: Partial<ExtendedMultiSelectProps> = {
+    size: 'sm',
+    valueComponent: DefaultValue,
+    itemComponent: DefaultItem,
+    transitionProps: {transition: 'fade', duration: 0},
+    maxDropdownHeight: 220,
+    shadow: 'sm',
+    searchable: false,
+    filter: defaultFilter,
+    limit: Infinity,
+    clearSearchOnChange: true,
+    clearable: false,
+    clearSearchOnBlur: false,
+    disabled: false,
+    initiallyOpened: false,
+    creatable: false,
+    shouldCreate: defaultShouldCreate,
+    switchDirectionOnFlip: false,
+    zIndex: getDefaultZIndex('popover'),
+    selectOnBlur: false,
+    positionDependencies: [],
+    dropdownPosition: 'flip',
+};
+
+export const ExtendedMultiSelect = forwardRef<HTMLInputElement, ExtendedMultiSelectProps>((props, ref) => {
+    const {
+        className,
+        style,
+        required,
+        label,
+        description,
+        size,
+        error,
+        classNames,
+        styles,
+        wrapperProps,
+        value,
+        defaultValue,
+        data,
+        onChange,
+        valueComponent: Value,
+        itemComponent,
+        id,
+        transitionProps,
+        maxDropdownHeight,
+        shadow,
+        nothingFound,
+        onFocus,
+        onBlur,
+        searchable,
+        placeholder,
+        filter,
+        limit,
+        clearSearchOnChange,
+        clearable,
+        clearSearchOnBlur,
+        variant,
+        onSearchChange,
+        searchValue,
+        disabled,
+        initiallyOpened,
+        radius,
+        icon,
+        rightSection,
+        rightSectionWidth,
+        creatable,
+        getCreateLabel,
+        shouldCreate,
+        onCreate,
+        sx,
+        dropdownComponent,
+        onDropdownClose,
+        onDropdownOpen,
+        maxSelectedValues,
+        withinPortal,
+        portalProps,
+        switchDirectionOnFlip,
+        zIndex,
+        selectOnBlur,
+        name,
+        dropdownPosition,
+        errorProps,
+        labelProps,
+        descriptionProps,
+        form,
+        positionDependencies,
+        onKeyDown,
+        unstyled,
+        inputContainer,
+        inputWrapperOrder,
+        readOnly,
+        withAsterisk,
+        clearButtonProps,
+        hoverOnSearchChange,
+        disableSelectedItemFiltering,
+        ...others
+    } = useComponentDefaultProps('MultiSelect', defaultProps, props);
+
+    const {classes, cx, theme} = useStyles(
+        {invalid: !!error},
+        {name: 'MultiSelect', classNames, styles, unstyled, size, variant},
+    );
+    const {systemStyles, rest} = extractSystemStyles(others);
+    const inputRef = useRef<HTMLInputElement>();
+    const itemsRefs = useRef<Record<string, HTMLDivElement>>({});
+    const uuid = useId(id);
+    const [dropdownOpened, setDropdownOpened] = useState(initiallyOpened);
+    const [_hovered, setHovered] = useState(-1);
+    const [direction, setDirection] = useState<React.CSSProperties['flexDirection']>('column');
+    const [_searchValue, handleSearchChange] = useUncontrolled({
+        value: searchValue,
+        defaultValue: '',
+        finalValue: undefined,
+        onChange: onSearchChange,
+    });
+    const [IMEOpen, setIMEOpen] = useState(false);
+
+    const {scrollIntoView, targetRef, scrollableRef} = useScrollIntoView({
+        duration: 0,
+        offset: 5,
+        cancelable: false,
+        isList: true,
+    });
+
+    const isCreatable = creatable && typeof getCreateLabel === 'function';
+    let createLabel = null;
+
+    const formattedData = data.map((item) => (typeof item === 'string' ? {label: item, value: item} : item));
+
+    const sortedData = groupOptions({data: formattedData});
+
+    const [_value, setValue] = useUncontrolled({
+        value: filterValue(value, data),
+        defaultValue: filterValue(defaultValue, data),
+        finalValue: [],
+        onChange,
+    });
+
+    const valuesOverflow = useRef(!!maxSelectedValues && maxSelectedValues < _value.length);
+
+    const handleValueRemove = (_val: string) => {
+        if (!readOnly) {
+            const newValue = _value.filter((val) => val !== _val);
+            setValue(newValue);
+
+            if (!!maxSelectedValues && newValue.length < maxSelectedValues) {
+                valuesOverflow.current = false;
+            }
+        }
+    };
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        handleSearchChange(event.currentTarget.value);
+        !disabled && !valuesOverflow.current && searchable && setDropdownOpened(true);
+    };
+
+    const handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+        typeof onFocus === 'function' && onFocus(event);
+        !disabled && !valuesOverflow.current && searchable && setDropdownOpened(true);
+    };
+
+    const filteredData = filterData({
+        data: sortedData,
+        searchable,
+        searchValue: _searchValue,
+        limit,
+        filter,
+        value: _value,
+        disableSelectedItemFiltering,
+    });
+
+    if (isCreatable && shouldCreate(_searchValue, sortedData)) {
+        createLabel = getCreateLabel(_searchValue);
+        filteredData.push({label: _searchValue, value: _searchValue, creatable: true});
+    }
+
+    const hovered = Math.min(_hovered, filteredData.length - 1);
+
+    const getNextIndex = (
+        index: number,
+        nextItem: (index: number) => number,
+        compareFn: (index: number) => boolean,
+    ) => {
+        let i = index;
+        while (compareFn(i)) {
+            i = nextItem(i);
+            if (!filteredData[i].disabled) {
+                return i;
+            }
+        }
+        return index;
+    };
+
+    useDidUpdate(() => {
+        if (hoverOnSearchChange && _searchValue) {
+            setHovered(0);
+        } else {
+            setHovered(-1);
+        }
+    }, [_searchValue, hoverOnSearchChange]);
+
+    useDidUpdate(() => {
+        if (!disabled && _value.length > data.length) {
+            setDropdownOpened(false);
+        }
+
+        if (!!maxSelectedValues && _value.length < maxSelectedValues) {
+            valuesOverflow.current = false;
+        }
+
+        if (!!maxSelectedValues && _value.length >= maxSelectedValues) {
+            valuesOverflow.current = true;
+            setDropdownOpened(false);
+        }
+    }, [_value]);
+
+    const handleItemSelect = (item: SelectItem) => {
+        if (!readOnly) {
+            clearSearchOnChange && handleSearchChange('');
+
+            if (_value.includes(item.value)) {
+                handleValueRemove(item.value);
+            } else {
+                if (item.creatable && typeof onCreate === 'function') {
+                    const createdItem = onCreate(item.value);
+                    if (typeof createdItem !== 'undefined' && createdItem !== null) {
+                        if (typeof createdItem === 'string') {
+                            setValue([..._value, createdItem]);
+                        } else {
+                            setValue([..._value, createdItem.value]);
+                        }
+                    }
+                } else {
+                    setValue([..._value, item.value]);
+                }
+
+                if (_value.length === maxSelectedValues - 1) {
+                    valuesOverflow.current = true;
+                    setDropdownOpened(false);
+                }
+                if (filteredData.length === 1) {
+                    setDropdownOpened(false);
+                }
+            }
+        }
+    };
+
+    const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+        typeof onBlur === 'function' && onBlur(event);
+        if (selectOnBlur && filteredData[hovered] && dropdownOpened) {
+            handleItemSelect(filteredData[hovered]);
+        }
+        clearSearchOnBlur && handleSearchChange('');
+        setDropdownOpened(false);
+    };
+
+    const handleInputKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (IMEOpen) {
+            return;
+        }
+
+        onKeyDown?.(event);
+
+        if (readOnly) {
+            return;
+        }
+
+        if (event.key !== 'Backspace' && !!maxSelectedValues && valuesOverflow.current) {
+            return;
+        }
+
+        const isColumn = direction === 'column';
+
+        const handleNext = () => {
+            setHovered((current) => {
+                const nextIndex = getNextIndex(
+                    current,
+                    (index) => index + 1,
+                    (index) => index < filteredData.length - 1,
+                );
+
+                if (dropdownOpened) {
+                    targetRef.current = itemsRefs.current[filteredData[nextIndex]?.value];
+
+                    scrollIntoView({
+                        alignment: isColumn ? 'end' : 'start',
+                    });
+                }
+
+                return nextIndex;
+            });
+        };
+
+        const handlePrevious = () => {
+            setHovered((current) => {
+                const nextIndex = getNextIndex(
+                    current,
+                    (index) => index - 1,
+                    (index) => index > 0,
+                );
+
+                if (dropdownOpened) {
+                    targetRef.current = itemsRefs.current[filteredData[nextIndex]?.value];
+
+                    scrollIntoView({
+                        alignment: isColumn ? 'start' : 'end',
+                    });
+                }
+
+                return nextIndex;
+            });
+        };
+
+        // eslint-disable-next-line default-case
+        switch (event.key) {
+            case 'ArrowUp': {
+                event.preventDefault();
+                setDropdownOpened(true);
+
+                isColumn ? handlePrevious() : handleNext();
+
+                break;
+            }
+
+            case 'ArrowDown': {
+                event.preventDefault();
+                setDropdownOpened(true);
+
+                isColumn ? handleNext() : handlePrevious();
+
+                break;
+            }
+
+            case 'Enter': {
+                event.preventDefault();
+
+                if (filteredData[hovered] && dropdownOpened) {
+                    handleItemSelect(filteredData[hovered]);
+                } else {
+                    setDropdownOpened(true);
+                }
+
+                break;
+            }
+
+            case ' ': {
+                if (!searchable) {
+                    event.preventDefault();
+                    if (filteredData[hovered] && dropdownOpened) {
+                        handleItemSelect(filteredData[hovered]);
+                    } else {
+                        setDropdownOpened(true);
+                    }
+                }
+
+                break;
+            }
+
+            case 'Backspace': {
+                if (_value.length > 0 && _searchValue.length === 0) {
+                    setValue(_value.slice(0, -1));
+                    setDropdownOpened(true);
+                    if (maxSelectedValues) {
+                        valuesOverflow.current = false;
+                    }
+                }
+
+                break;
+            }
+
+            case 'Home': {
+                if (!searchable) {
+                    event.preventDefault();
+
+                    if (!dropdownOpened) {
+                        setDropdownOpened(true);
+                    }
+
+                    const firstItemIndex = filteredData.findIndex((item) => !item.disabled);
+                    setHovered(firstItemIndex);
+                    scrollIntoView({
+                        alignment: isColumn ? 'end' : 'start',
+                    });
+                }
+                break;
+            }
+
+            case 'End': {
+                if (!searchable) {
+                    event.preventDefault();
+
+                    if (!dropdownOpened) {
+                        setDropdownOpened(true);
+                    }
+
+                    const lastItemIndex = filteredData.map((item) => !!item.disabled).lastIndexOf(false);
+                    setHovered(lastItemIndex);
+                    scrollIntoView({
+                        alignment: isColumn ? 'end' : 'start',
+                    });
+                }
+                break;
+            }
+
+            case 'Escape': {
+                setDropdownOpened(false);
+            }
+        }
+    };
+
+    const selectedItems = _value
+        .map((val) => {
+            let selectedItem = sortedData.find((item) => item.value === val && !item.disabled);
+            if (!selectedItem && isCreatable) {
+                selectedItem = {
+                    value: val,
+                    label: val,
+                };
+            }
+            return selectedItem;
+        })
+        .filter((val) => !!val)
+        .map((item, index) => (
+            <Value
+                {...item}
+                variant={variant}
+                disabled={disabled}
+                className={classes.value}
+                readOnly={readOnly}
+                onRemove={(event: React.MouseEvent<HTMLButtonElement>) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    handleValueRemove(item.value);
+                }}
+                key={item.value}
+                size={size}
+                styles={styles}
+                classNames={classNames}
+                radius={radius}
+                index={index}
+            />
+        ));
+
+    const isItemSelected = (itemValue: string) => _value.includes(itemValue);
+
+    const handleClear = () => {
+        handleSearchChange('');
+        setValue([]);
+        inputRef.current?.focus();
+        if (maxSelectedValues) {
+            valuesOverflow.current = false;
+        }
+    };
+
+    const shouldRenderDropdown =
+        !readOnly && (filteredData.length > 0 ? dropdownOpened : dropdownOpened && !!nothingFound);
+
+    useDidUpdate(() => {
+        const handler = shouldRenderDropdown ? onDropdownOpen : onDropdownClose;
+        typeof handler === 'function' && handler();
+    }, [shouldRenderDropdown]);
+
+    return (
+        <Input.Wrapper
+            required={required}
+            id={uuid}
+            label={label}
+            error={error}
+            description={description}
+            size={size}
+            className={className}
+            style={style}
+            classNames={classNames}
+            styles={styles}
+            __staticSelector="MultiSelect"
+            sx={sx}
+            errorProps={errorProps}
+            descriptionProps={descriptionProps}
+            labelProps={labelProps}
+            inputContainer={inputContainer}
+            inputWrapperOrder={inputWrapperOrder}
+            unstyled={unstyled}
+            withAsterisk={withAsterisk}
+            variant={variant}
+            {...systemStyles}
+            {...wrapperProps}
+        >
+            <SelectPopover
+                opened={shouldRenderDropdown}
+                transitionProps={transitionProps}
+                shadow="sm"
+                withinPortal={withinPortal}
+                portalProps={portalProps}
+                __staticSelector="MultiSelect"
+                onDirectionChange={setDirection}
+                switchDirectionOnFlip={switchDirectionOnFlip}
+                zIndex={zIndex}
+                dropdownPosition={dropdownPosition}
+                positionDependencies={[...positionDependencies, _searchValue]}
+                classNames={classNames}
+                styles={styles}
+                unstyled={unstyled}
+                variant={variant}
+            >
+                <SelectPopover.Target>
+                    <div
+                        className={classes.wrapper}
+                        role="combobox"
+                        aria-haspopup="listbox"
+                        aria-owns={dropdownOpened && shouldRenderDropdown ? `${uuid}-items` : null}
+                        aria-controls={uuid}
+                        aria-expanded={dropdownOpened}
+                        onMouseLeave={() => setHovered(-1)}
+                        tabIndex={-1}
+                    >
+                        <input type="hidden" name={name} value={_value.join(',')} form={form} disabled={disabled} />
+
+                        <Input<'div'>
+                            __staticSelector="MultiSelect"
+                            style={{overflow: 'hidden'}}
+                            component="div"
+                            multiline
+                            size={size}
+                            variant={variant}
+                            disabled={disabled}
+                            error={error}
+                            required={required}
+                            radius={radius}
+                            icon={icon}
+                            unstyled={unstyled}
+                            onMouseDown={(event) => {
+                                event.preventDefault();
+                                !disabled && !valuesOverflow.current && setDropdownOpened(!dropdownOpened);
+                                inputRef.current?.focus();
+                            }}
+                            classNames={{
+                                ...classNames,
+                                input: cx({[classes.input]: !searchable}, classNames?.input),
+                            }}
+                            {...getSelectRightSectionProps({
+                                theme,
+                                rightSection,
+                                rightSectionWidth,
+                                styles,
+                                size,
+                                shouldClear: clearable && _value.length > 0,
+                                onClear: handleClear,
+                                error,
+                                disabled,
+                                clearButtonProps,
+                                readOnly,
+                            })}
+                        >
+                            <div className={classes.values} data-clearable={clearable || undefined}>
+                                {selectedItems}
+
+                                <input
+                                    ref={useMergedRef(ref, inputRef)}
+                                    type="search"
+                                    id={uuid}
+                                    className={cx(classes.searchInput, {
+                                        [classes.searchInputPointer]: !searchable,
+                                        [classes.searchInputInputHidden]:
+                                            (!dropdownOpened && _value.length > 0) ||
+                                            (!searchable && _value.length > 0),
+                                        [classes.searchInputEmpty]: _value.length === 0,
+                                    })}
+                                    onKeyDown={handleInputKeydown}
+                                    value={_searchValue}
+                                    onChange={handleInputChange}
+                                    onFocus={handleInputFocus}
+                                    onBlur={handleInputBlur}
+                                    readOnly={!searchable || valuesOverflow.current || readOnly}
+                                    placeholder={_value.length === 0 ? placeholder : undefined}
+                                    disabled={disabled}
+                                    data-mantine-stop-propagation={dropdownOpened}
+                                    autoComplete="off"
+                                    onCompositionStart={() => setIMEOpen(true)}
+                                    onCompositionEnd={() => setIMEOpen(false)}
+                                    {...rest}
+                                />
+                            </div>
+                        </Input>
+                    </div>
+                </SelectPopover.Target>
+
+                <SelectPopover.Dropdown
+                    component={dropdownComponent || SelectScrollArea}
+                    maxHeight={maxDropdownHeight}
+                    direction={direction}
+                    id={uuid}
+                    innerRef={scrollableRef}
+                    __staticSelector="MultiSelect"
+                    classNames={classNames}
+                    styles={styles}
+                >
+                    <SelectItems
+                        data={filteredData}
+                        hovered={hovered}
+                        classNames={classNames}
+                        styles={styles}
+                        uuid={uuid}
+                        __staticSelector="MultiSelect"
+                        onItemHover={setHovered}
+                        onItemSelect={handleItemSelect}
+                        itemsRefs={itemsRefs}
+                        itemComponent={itemComponent}
+                        size={size}
+                        nothingFound={nothingFound}
+                        isItemSelected={isItemSelected}
+                        creatable={creatable && !!createLabel}
+                        createLabel={createLabel}
+                        unstyled={unstyled}
+                        variant={variant}
+                    />
+                </SelectPopover.Dropdown>
+            </SelectPopover>
+        </Input.Wrapper>
+    );
+});
+
+ExtendedMultiSelect.displayName = '@mantine/core/ExtendedMultiSelect';

--- a/packages/mantine/src/components/extended-multi-select/SelectItems/SelectItems.styles.ts
+++ b/packages/mantine/src/components/extended-multi-select/SelectItems/SelectItems.styles.ts
@@ -1,0 +1,56 @@
+import { createStyles, getSize } from '@mantine/styles';
+
+export default createStyles((theme, _params, { size }) => ({
+  item: {
+    ...theme.fn.fontStyles(),
+    boxSizing: 'border-box',
+    wordBreak: 'break-all',
+    textAlign: 'left',
+    width: '100%',
+    padding: `calc(${getSize({ size, sizes: theme.spacing })} / 1.5) ${getSize({
+      size,
+      sizes: theme.spacing,
+    })}`,
+    cursor: 'pointer',
+    fontSize: getSize({ size, sizes: theme.fontSizes }),
+    color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
+    borderRadius: theme.fn.radius(),
+
+    '&[data-hovered]': {
+      backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[1],
+    },
+
+    '&[data-selected]': {
+      backgroundColor: theme.fn.variant({ variant: 'filled' }).background,
+      color: theme.fn.variant({ variant: 'filled' }).color,
+      ...theme.fn.hover({ backgroundColor: theme.fn.variant({ variant: 'filled' }).hover }),
+    },
+
+    '&[data-disabled]': {
+      cursor: 'default',
+      color: theme.colors.dark[2],
+    },
+  },
+
+  nothingFound: {
+    boxSizing: 'border-box',
+    color: theme.colors.gray[6],
+    paddingTop: `calc(${getSize({ size, sizes: theme.spacing })} / 2)`,
+    paddingBottom: `calc(${getSize({ size, sizes: theme.spacing })} / 2)`,
+    textAlign: 'center',
+  },
+
+  separator: {
+    boxSizing: 'border-box',
+    textAlign: 'left',
+    width: '100%',
+    padding: `calc(${getSize({ size, sizes: theme.spacing })} / 1.5) ${getSize({
+      size,
+      sizes: theme.spacing,
+    })}`,
+  },
+
+  separatorLabel: {
+    color: theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[5],
+  },
+}));

--- a/packages/mantine/src/components/extended-multi-select/SelectItems/SelectItems.tsx
+++ b/packages/mantine/src/components/extended-multi-select/SelectItems/SelectItems.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import {DefaultProps, MantineSize, Selectors} from '@mantine/styles';
+import {randomId} from '@mantine/hooks';
+import {Text} from '@mantine/core';
+import {Divider} from '@mantine/core';
+import {SelectItem} from '../types';
+import useStyles from './SelectItems.styles';
+
+export type SelectItemsStylesNames = Selectors<typeof useStyles>;
+
+export interface SelectItemsProps extends DefaultProps<SelectItemsStylesNames> {
+    data: SelectItem[];
+    hovered: number;
+    __staticSelector: string;
+    isItemSelected?(itemValue: string): boolean;
+    uuid: string;
+    itemsRefs?: React.MutableRefObject<Record<string, HTMLDivElement>>;
+    onItemHover(index: number): void;
+    onItemSelect(item: SelectItem): void;
+    size: MantineSize;
+    itemComponent: React.FC<any>;
+    nothingFound?: React.ReactNode;
+    creatable?: boolean;
+    createLabel?: React.ReactNode;
+    variant: string;
+}
+
+export const SelectItems = ({
+    data,
+    hovered,
+    classNames,
+    styles,
+    isItemSelected,
+    uuid,
+    __staticSelector,
+    onItemHover,
+    onItemSelect,
+    itemsRefs,
+    itemComponent: Item,
+    size,
+    nothingFound,
+    creatable,
+    createLabel,
+    unstyled,
+    variant,
+}: SelectItemsProps) => {
+    const {classes} = useStyles(null, {
+        classNames,
+        styles,
+        unstyled,
+        name: __staticSelector,
+        variant,
+        size,
+    });
+
+    const unGroupedItems: Array<React.ReactElement<any>> = [];
+    const groupedItems: Array<React.ReactElement<any>> = [];
+    let creatableDataIndex: number | null = null;
+
+    const constructItemComponent = (item: SelectItem, index: number) => {
+        const selected = typeof isItemSelected === 'function' ? isItemSelected(item.value) : false;
+        return (
+            <Item
+                key={item.value}
+                className={classes.item}
+                data-disabled={item.disabled || undefined}
+                data-hovered={(!item.disabled && hovered === index) || undefined}
+                data-selected={(!item.disabled && selected) || undefined}
+                selected={selected}
+                onMouseEnter={() => onItemHover(index)}
+                id={`${uuid}-${index}`}
+                role="option"
+                // data-ignore-outside-clicks
+                tabIndex={-1}
+                aria-selected={hovered === index}
+                ref={(node: HTMLDivElement) => {
+                    if (itemsRefs && itemsRefs.current) {
+                        // eslint-disable-next-line no-param-reassign
+                        itemsRefs.current[item.value] = node;
+                    }
+                }}
+                onMouseDown={
+                    !item.disabled
+                        ? (event: React.MouseEvent<HTMLDivElement>) => {
+                              event.preventDefault();
+                              onItemSelect(item);
+                          }
+                        : null
+                }
+                disabled={item.disabled}
+                variant={variant}
+                {...item}
+            />
+        );
+    };
+
+    let groupName: string | null = null;
+    data.forEach((item, index) => {
+        if (item.creatable) {
+            creatableDataIndex = index;
+        } else if (!item.group) {
+            unGroupedItems.push(constructItemComponent(item, index));
+        } else {
+            if (groupName !== item.group) {
+                groupName = item.group;
+                groupedItems.push(
+                    <div className={classes.separator} key={`__mantine-divider-${index}`}>
+                        <Divider classNames={{label: classes.separatorLabel}} label={item.group} />
+                    </div>,
+                );
+            }
+            groupedItems.push(constructItemComponent(item, index));
+        }
+    });
+
+    if (creatable) {
+        const creatableDataItem = data[creatableDataIndex];
+        unGroupedItems.unshift(
+            <div
+                key={randomId()}
+                className={classes.item}
+                data-hovered={hovered === creatableDataIndex || undefined}
+                onMouseEnter={() => onItemHover(creatableDataIndex)}
+                onMouseDown={(event: React.MouseEvent<HTMLDivElement>) => {
+                    event.preventDefault();
+                    onItemSelect(creatableDataItem);
+                }}
+                tabIndex={-1}
+                ref={(node: HTMLDivElement) => {
+                    if (itemsRefs && itemsRefs.current) {
+                        // eslint-disable-next-line no-param-reassign
+                        itemsRefs.current[creatableDataItem.value] = node;
+                    }
+                }}
+            >
+                {createLabel}
+            </div>,
+        );
+    }
+
+    if (groupedItems.length > 0 && unGroupedItems.length > 0) {
+        unGroupedItems.unshift(
+            <div className={classes.separator} key="empty-group-separator">
+                <Divider />
+            </div>,
+        );
+    }
+
+    return groupedItems.length > 0 || unGroupedItems.length > 0 ? (
+        <>
+            {groupedItems}
+            {unGroupedItems}
+        </>
+    ) : (
+        <Text size={size} unstyled={unstyled} className={classes.nothingFound}>
+            {nothingFound}
+        </Text>
+    );
+};
+
+SelectItems.displayName = '@mantine/core/SelectItems';

--- a/packages/mantine/src/components/extended-multi-select/SelectPopover/SelectPopover.styles.ts
+++ b/packages/mantine/src/components/extended-multi-select/SelectPopover/SelectPopover.styles.ts
@@ -1,0 +1,12 @@
+import { createStyles, rem } from '@mantine/styles';
+
+export default createStyles(() => ({
+  dropdown: {},
+
+  itemsWrapper: {
+    padding: rem(4),
+    display: 'flex',
+    width: '100%',
+    boxSizing: 'border-box',
+  },
+}));

--- a/packages/mantine/src/components/extended-multi-select/SelectPopover/SelectPopover.tsx
+++ b/packages/mantine/src/components/extended-multi-select/SelectPopover/SelectPopover.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import {ClassNames, MantineShadow, Styles, Selectors, DefaultProps, rem} from '@mantine/styles';
+import {Popover} from '@mantine/core';
+import {PortalProps} from '@mantine/core';
+import {Box} from '@mantine/core';
+import {TransitionOverride} from '@mantine/core';
+import {SelectScrollArea} from '../SelectScrollArea/SelectScrollArea';
+import useStyles from './SelectPopover.styles';
+
+export type SelectPopoverStylesNames = Selectors<typeof useStyles>;
+
+interface SelectPopoverDropdownProps extends DefaultProps<SelectPopoverStylesNames> {
+    children: React.ReactNode;
+    id: string;
+    component?: any;
+    maxHeight?: number | string;
+    direction?: React.CSSProperties['flexDirection'];
+    innerRef?: React.MutableRefObject<HTMLDivElement>;
+    __staticSelector?: string;
+}
+
+const SelectPopoverDropdown = ({
+    children,
+    component = 'div',
+    maxHeight = 220,
+    direction = 'column',
+    id,
+    innerRef,
+    __staticSelector,
+    styles,
+    classNames,
+    unstyled,
+    ...others
+}: SelectPopoverDropdownProps) => {
+    const {classes} = useStyles(null, {name: __staticSelector, styles, classNames, unstyled});
+
+    return (
+        <Popover.Dropdown p={0} onMouseDown={(event) => event.preventDefault()} {...others}>
+            <div style={{maxHeight: rem(maxHeight), display: 'flex'}}>
+                <Box<'div'>
+                    component={(component || 'div') as any}
+                    id={`${id}-items`}
+                    aria-labelledby={`${id}-label`}
+                    role="listbox"
+                    onMouseDown={(event) => event.preventDefault()}
+                    style={{flex: 1, overflowY: component !== SelectScrollArea ? 'auto' : undefined}}
+                    data-combobox-popover
+                    tabIndex={-1}
+                    ref={innerRef}
+                >
+                    <div className={classes.itemsWrapper} style={{flexDirection: direction}}>
+                        {children}
+                    </div>
+                </Box>
+            </div>
+        </Popover.Dropdown>
+    );
+};
+
+interface SelectPopoverProps {
+    opened: boolean;
+    transitionProps: TransitionOverride;
+    shadow?: MantineShadow;
+    withinPortal?: boolean;
+    portalProps?: Omit<PortalProps, 'children' | 'withinPortal'>;
+    children: React.ReactNode;
+    __staticSelector?: string;
+    onDirectionChange?(direction: React.CSSProperties['flexDirection']): void;
+    switchDirectionOnFlip?: boolean;
+    zIndex?: React.CSSProperties['zIndex'];
+    dropdownPosition?: 'bottom' | 'top' | 'flip';
+    positionDependencies?: any[];
+    classNames?: ClassNames<SelectPopoverStylesNames>;
+    styles?: Styles<SelectPopoverStylesNames>;
+    unstyled?: boolean;
+    readOnly?: boolean;
+    variant: string;
+}
+
+export const SelectPopover = ({
+    opened,
+    transitionProps = {transition: 'fade', duration: 0},
+    shadow,
+    withinPortal,
+    portalProps,
+    children,
+    __staticSelector,
+    onDirectionChange,
+    switchDirectionOnFlip,
+    zIndex,
+    dropdownPosition,
+    positionDependencies = [],
+    classNames,
+    styles,
+    unstyled,
+    readOnly,
+    variant,
+}: SelectPopoverProps) => (
+    <Popover
+        unstyled={unstyled}
+        classNames={classNames}
+        styles={styles}
+        width="target"
+        withRoles={false}
+        opened={opened}
+        middlewares={{flip: dropdownPosition === 'flip', shift: false}}
+        position={dropdownPosition === 'flip' ? 'bottom' : dropdownPosition}
+        positionDependencies={positionDependencies}
+        zIndex={zIndex}
+        __staticSelector={__staticSelector}
+        withinPortal={withinPortal}
+        portalProps={portalProps}
+        transitionProps={transitionProps}
+        shadow={shadow}
+        disabled={readOnly}
+        onPositionChange={(nextPosition) =>
+            switchDirectionOnFlip && onDirectionChange?.(nextPosition === 'top' ? 'column-reverse' : 'column')
+        }
+        variant={variant}
+    >
+        {children}
+    </Popover>
+);
+
+SelectPopover.Target = Popover.Target;
+SelectPopover.Dropdown = SelectPopoverDropdown;

--- a/packages/mantine/src/components/extended-multi-select/SelectRightSection/ChevronIcon.tsx
+++ b/packages/mantine/src/components/extended-multi-select/SelectRightSection/ChevronIcon.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {useMantineTheme, MantineSize, getSize, rem} from '@mantine/styles';
+
+interface ChevronIconProps extends React.ComponentPropsWithoutRef<'svg'> {
+    size: MantineSize;
+    error: any;
+}
+
+const iconSizes = {
+    xs: rem(14),
+    sm: rem(18),
+    md: rem(20),
+    lg: rem(24),
+    xl: rem(28),
+};
+
+export const ChevronIcon = ({size, error, style, ...others}: ChevronIconProps) => {
+    const theme = useMantineTheme();
+    const _size = getSize({size, sizes: iconSizes});
+
+    return (
+        <svg
+            viewBox="0 0 15 15"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{
+                color: error ? theme.colors.red[6] : theme.colors.gray[6],
+                width: _size,
+                height: _size,
+                ...style,
+            }}
+            data-chevron
+            {...others}
+        >
+            <path
+                d="M4.93179 5.43179C4.75605 5.60753 4.75605 5.89245 4.93179 6.06819C5.10753 6.24392 5.39245 6.24392 5.56819 6.06819L7.49999 4.13638L9.43179 6.06819C9.60753 6.24392 9.89245 6.24392 10.0682 6.06819C10.2439 5.89245 10.2439 5.60753 10.0682 5.43179L7.81819 3.18179C7.73379 3.0974 7.61933 3.04999 7.49999 3.04999C7.38064 3.04999 7.26618 3.0974 7.18179 3.18179L4.93179 5.43179ZM10.0682 9.56819C10.2439 9.39245 10.2439 9.10753 10.0682 8.93179C9.89245 8.75606 9.60753 8.75606 9.43179 8.93179L7.49999 10.8636L5.56819 8.93179C5.39245 8.75606 5.10753 8.75606 4.93179 8.93179C4.75605 9.10753 4.75605 9.39245 4.93179 9.56819L7.18179 11.8182C7.35753 11.9939 7.64245 11.9939 7.81819 11.8182L10.0682 9.56819Z"
+                fill="currentColor"
+                fillRule="evenodd"
+                clipRule="evenodd"
+            />
+        </svg>
+    );
+};

--- a/packages/mantine/src/components/extended-multi-select/SelectRightSection/SelectRightSection.tsx
+++ b/packages/mantine/src/components/extended-multi-select/SelectRightSection/SelectRightSection.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {MantineSize} from '@mantine/styles';
+import {CloseButton} from '@mantine/core';
+import {ChevronIcon} from './ChevronIcon';
+
+export interface SelectRightSectionProps {
+    shouldClear: boolean;
+    clearButtonProps?: React.ComponentPropsWithoutRef<'button'>;
+    onClear?: () => void;
+    size: MantineSize;
+    error?: any;
+    // eslint-disable-next-line react/no-unused-prop-types
+    disabled?: boolean;
+}
+
+export const SelectRightSection = ({shouldClear, clearButtonProps, onClear, size, error}: SelectRightSectionProps) =>
+    shouldClear ? (
+        <CloseButton
+            {...clearButtonProps}
+            variant="transparent"
+            onClick={onClear}
+            size={size}
+            onMouseDown={(event) => event.preventDefault()}
+        />
+    ) : (
+        <ChevronIcon error={error} size={size} />
+    );
+
+SelectRightSection.displayName = '@mantine/core/SelectRightSection';

--- a/packages/mantine/src/components/extended-multi-select/SelectRightSection/get-select-right-section-props.tsx
+++ b/packages/mantine/src/components/extended-multi-select/SelectRightSection/get-select-right-section-props.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {MantineTheme} from '@mantine/styles';
+import {SelectRightSection, SelectRightSectionProps} from './SelectRightSection';
+
+interface GetRightSectionProps extends SelectRightSectionProps {
+    rightSection?: React.ReactNode;
+    rightSectionWidth?: string | number;
+    styles: Record<string, any>;
+    theme: MantineTheme;
+    readOnly: boolean;
+}
+
+export const getSelectRightSectionProps = ({
+    styles,
+    rightSection,
+    rightSectionWidth,
+    theme,
+    ...props
+}: GetRightSectionProps) => {
+    if (rightSection) {
+        return {rightSection, rightSectionWidth, styles};
+    }
+
+    const _styles = typeof styles === 'function' ? styles(theme) : styles;
+
+    return {
+        rightSection: !props.readOnly && !(props.disabled && props.shouldClear) && <SelectRightSection {...props} />,
+        styles: {
+            ..._styles,
+            rightSection: {
+                ..._styles?.rightSection,
+                pointerEvents: props.shouldClear ? undefined : 'none',
+            },
+        },
+    };
+};

--- a/packages/mantine/src/components/extended-multi-select/SelectScrollArea/SelectScrollArea.tsx
+++ b/packages/mantine/src/components/extended-multi-select/SelectScrollArea/SelectScrollArea.tsx
@@ -1,0 +1,12 @@
+import {forwardRef} from 'react';
+import {ScrollArea, ScrollAreaProps} from '@mantine/core';
+
+export const SelectScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
+    ({style, ...others}: ScrollAreaProps, ref) => (
+        <ScrollArea {...others} style={{width: '100%', ...style}} viewportProps={{tabIndex: -1}} viewportRef={ref}>
+            {others.children}
+        </ScrollArea>
+    ),
+);
+
+SelectScrollArea.displayName = '@mantine/core/SelectScrollArea';

--- a/packages/mantine/src/components/extended-multi-select/filter-data/filter-data.ts
+++ b/packages/mantine/src/components/extended-multi-select/filter-data/filter-data.ts
@@ -1,0 +1,55 @@
+import type {SelectItem} from '../types';
+
+interface FilterData {
+    data: SelectItem[];
+    limit: number;
+    searchable: boolean;
+    searchValue: string;
+    filter(value: string, selected: boolean, item: SelectItem): boolean;
+    value: string[];
+    disableSelectedItemFiltering?: boolean;
+}
+
+export const filterData = ({
+    data,
+    searchable,
+    limit,
+    searchValue,
+    filter,
+    value,
+    disableSelectedItemFiltering,
+}: FilterData) => {
+    if (!searchable && value.length === 0) {
+        return data;
+    }
+
+    if (!searchable) {
+        const result = [];
+        for (let i = 0; i < data.length; i += 1) {
+            if (!!disableSelectedItemFiltering || !value.some((val) => val === data[i].value && !data[i].disabled)) {
+                result.push(data[i]);
+            }
+        }
+
+        return result;
+    }
+
+    const result = [];
+    for (let i = 0; i < data.length; i += 1) {
+        if (
+            filter(
+                searchValue,
+                !disableSelectedItemFiltering && value.some((val) => val === data[i].value && !data[i].disabled),
+                data[i],
+            )
+        ) {
+            result.push(data[i]);
+        }
+
+        if (result.length >= limit) {
+            break;
+        }
+    }
+
+    return result;
+};

--- a/packages/mantine/src/components/extended-multi-select/index.ts
+++ b/packages/mantine/src/components/extended-multi-select/index.ts
@@ -1,0 +1,4 @@
+export {ExtendedMultiSelect} from './ExtendedMultiSelect';
+export type {ExtendedMultiSelectProps, ExtendedMultiSelectStylesNames} from './ExtendedMultiSelect';
+export type {ExtendedMultiSelectValueProps} from './DefaultValue/DefaultValue';
+export type {ExtendedMultiSelectStylesParams} from './ExtendedMultiSelect.styles';

--- a/packages/mantine/src/components/extended-multi-select/types.ts
+++ b/packages/mantine/src/components/extended-multi-select/types.ts
@@ -1,0 +1,22 @@
+import type {InputStylesNames, InputSharedProps, InputWrapperStylesNames, InputWrapperBaseProps} from '@mantine/core';
+import type {SelectItemsStylesNames} from './SelectItems/SelectItems';
+import type {SelectPopoverStylesNames} from './SelectPopover/SelectPopover';
+
+export interface SelectItem {
+    value: string;
+    label?: string;
+    selected?: boolean;
+    disabled?: boolean;
+    group?: string;
+    [key: string]: any;
+}
+
+export type BaseSelectStylesNames =
+    | InputStylesNames
+    | InputWrapperStylesNames
+    | SelectItemsStylesNames
+    | SelectPopoverStylesNames;
+
+export type BaseSelectProps = InputWrapperBaseProps &
+    InputSharedProps &
+    Omit<React.ComponentPropsWithoutRef<'input'>, 'value' | 'onChange' | 'size' | 'defaultValue'>;

--- a/packages/mantine/src/components/index.ts
+++ b/packages/mantine/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './browser-preview';
 export * from './code-editor';
 export * from './collection';
 export * from './date-range-picker';
+export * from './extended-multi-select';
 export * from './sticky-footer';
 export * from './header';
 export * from './inline-confirm';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: 3.2.1
         version: 3.2.1(react@18.2.0)
+      '@mantine/styles':
+        specifier: 6.0.19
+        version: 6.0.19(@emotion/react@11.11.1)(react-dom@18.2.0)(react@18.2.0)
       '@mantine/utils':
         specifier: 6.0.19
         version: 6.0.19(react@18.2.0)
@@ -223,6 +226,9 @@ importers:
       fast-deep-equal:
         specifier: 3.1.3
         version: 3.1.3
+      jest-axe:
+        specifier: ^8.0.0
+        version: 8.0.0
       lodash.debounce:
         specifier: 4.0.8
         version: 4.0.8
@@ -6834,6 +6840,11 @@ packages:
       xml2js: 0.5.0
     dev: true
 
+  /axe-core@4.7.2:
+    resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==}
+    engines: {node: '>=4'}
+    dev: false
+
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
@@ -8840,7 +8851,6 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
 
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -11923,6 +11933,16 @@ packages:
       '@pkgjs/parseargs': 0.11.0
     dev: true
 
+  /jest-axe@8.0.0:
+    resolution: {integrity: sha512-4kNcNn7J0jPO4jANEYZOHeQ/tSBvkXS+MxTbX1CKbXGd0+ZbRGDn/v/8IYWI/MmYX15iLVyYRnRev9X3ksePWA==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      axe-core: 4.7.2
+      chalk: 4.1.2
+      jest-matcher-utils: 29.2.2
+      lodash.merge: 4.6.2
+    dev: false
+
   /jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -12077,7 +12097,6 @@ packages:
       diff-sequences: 29.6.3
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
-    dev: true
 
   /jest-docblock@29.7.0:
     resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
@@ -12171,6 +12190,16 @@ packages:
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
     dev: true
+
+  /jest-matcher-utils@29.2.2:
+    resolution: {integrity: sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+    dev: false
 
   /jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,9 +226,6 @@ importers:
       fast-deep-equal:
         specifier: 3.1.3
         version: 3.1.3
-      jest-axe:
-        specifier: ^8.0.0
-        version: 8.0.0
       lodash.debounce:
         specifier: 4.0.8
         version: 4.0.8
@@ -6840,11 +6837,6 @@ packages:
       xml2js: 0.5.0
     dev: true
 
-  /axe-core@4.7.2:
-    resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==}
-    engines: {node: '>=4'}
-    dev: false
-
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
@@ -8851,6 +8843,7 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
 
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -11933,16 +11926,6 @@ packages:
       '@pkgjs/parseargs': 0.11.0
     dev: true
 
-  /jest-axe@8.0.0:
-    resolution: {integrity: sha512-4kNcNn7J0jPO4jANEYZOHeQ/tSBvkXS+MxTbX1CKbXGd0+ZbRGDn/v/8IYWI/MmYX15iLVyYRnRev9X3ksePWA==}
-    engines: {node: '>= 14.0.0'}
-    dependencies:
-      axe-core: 4.7.2
-      chalk: 4.1.2
-      jest-matcher-utils: 29.2.2
-      lodash.merge: 4.6.2
-    dev: false
-
   /jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -12097,6 +12080,7 @@ packages:
       diff-sequences: 29.6.3
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
+    dev: true
 
   /jest-docblock@29.7.0:
     resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
@@ -12190,16 +12174,6 @@ packages:
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
     dev: true
-
-  /jest-matcher-utils@29.2.2:
-    resolution: {integrity: sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 29.7.0
-      jest-get-type: 29.6.3
-      pretty-format: 29.7.0
-    dev: false
 
   /jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}


### PR DESCRIPTION
### Proposed Changes

Jira: [MHUB-613](https://coveord.atlassian.net/browse/MHUB-613)

<!-- Explain what are your changes. -->

Before:

![multiselect where the create button is at the bottom of the dropdown menu](https://github.com/coveo/plasma/assets/10165959/6f855068-c4ce-49fd-8ba8-1444ece2f42d)


After:
<img width="1397" alt="multiselect where the create button is at the top of the dropdown menu" src="https://github.com/coveo/plasma/assets/10165959/b6eca49b-b698-401c-b5ff-d240aa099506">

I've added an extended multi-select that copies the `Multiselect`  from mantine 6.0.19, but changes one thing: it sorts creatable elements to the top of the list. Otherwise, the code is just from mantine.

This is to fulfil a requirement for MHUB-613. I think this is ok because mantine 6.X is in maintenance mode, and this bridges the gap while we wait for mantine 7 to get upgraded.

One thing I'd prefer not to do is write extensive unit tests for this. Since the use-case is limited, I feel confident that the tests where the component is used will be sufficient.

### Potential Breaking Changes

None. This creates a new component that will be used in one place, rather than overwriting the base `Multiselect` component.

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[MHUB-613]: https://coveord.atlassian.net/browse/MHUB-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ