### PR TITLE
feat(loading handler): generic hook

### DIFF
--- a/packages/mantine/src/components/action-icon/ActionIcon.tsx
+++ b/packages/mantine/src/components/action-icon/ActionIcon.tsx
@@ -1,6 +1,7 @@
 import {ActionIcon as MantineActionIcon, type ActionIconProps as MantineActionIconProps} from '@mantine/core';
-import {forwardRef, MouseEvent, MouseEventHandler, useState} from 'react';
+import {MouseEventHandler, forwardRef} from 'react';
 
+import {useLoadingHandler} from '../../hooks';
 import {createPolymorphicComponent} from '../../utils';
 import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from '../button/ButtonWithDisabledTooltip';
 
@@ -8,26 +9,6 @@ export interface ActionIconProps extends MantineActionIconProps, ButtonWithDisab
     /* Handler executed on click */
     onClick?: MouseEventHandler<HTMLButtonElement>;
 }
-
-const useLoadingHandler = (handler?: MouseEventHandler<HTMLButtonElement>) => {
-    const [isLoading, setIsLoading] = useState(false);
-
-    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
-        const possiblePromise: unknown = handler?.(event);
-        try {
-            if (possiblePromise instanceof Promise) {
-                setIsLoading(true);
-                await possiblePromise;
-                setIsLoading(false);
-            }
-        } catch (err) {
-            setIsLoading(false);
-            console.error(err);
-        }
-    };
-
-    return {isLoading, handleClick};
-};
 
 const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
     ({disabledTooltip, disabled, disabledTooltipProps, loading, onClick, ...others}, ref) => {

--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -1,6 +1,7 @@
 import {Button as MantineButton, ButtonProps as MantineButtonProps} from '@mantine/core';
-import {forwardRef, MouseEvent, MouseEventHandler, useState} from 'react';
+import {MouseEventHandler, forwardRef} from 'react';
 
+import {useLoadingHandler} from '../../hooks';
 import {createPolymorphicComponent} from '../../utils';
 import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from './ButtonWithDisabledTooltip';
 
@@ -8,26 +9,6 @@ export interface ButtonProps extends MantineButtonProps, ButtonWithDisabledToolt
     /* Handler executed on click */
     onClick?: MouseEventHandler<HTMLButtonElement>;
 }
-
-const useLoadingHandler = (handler?: MouseEventHandler<HTMLButtonElement>) => {
-    const [isLoading, setIsLoading] = useState(false);
-
-    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
-        const possiblePromise: unknown = handler?.(event);
-        try {
-            if (possiblePromise instanceof Promise) {
-                setIsLoading(true);
-                await possiblePromise;
-                setIsLoading(false);
-            }
-        } catch (err) {
-            setIsLoading(false);
-            console.error(err);
-        }
-    };
-
-    return {isLoading, handleClick};
-};
 
 const _Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ({disabledTooltip, disabled, disabledTooltipProps, loading, onClick, ...others}, ref) => {

--- a/packages/mantine/src/hooks/index.ts
+++ b/packages/mantine/src/hooks/index.ts
@@ -1,2 +1,3 @@
-export * from './useParentHeight';
 export * from './useControlledList';
+export * from './useLoadingHandler';
+export * from './useParentHeight';

--- a/packages/mantine/src/hooks/useLoadingHandler.ts
+++ b/packages/mantine/src/hooks/useLoadingHandler.ts
@@ -1,0 +1,21 @@
+import {MouseEvent, MouseEventHandler, useState} from 'react';
+
+export const useLoadingHandler = (handler?: MouseEventHandler<HTMLButtonElement>) => {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+        const possiblePromise: unknown = handler?.(event);
+        try {
+            if (possiblePromise instanceof Promise) {
+                setIsLoading(true);
+                await possiblePromise;
+                setIsLoading(false);
+            }
+        } catch (err) {
+            setIsLoading(false);
+            console.error(err);
+        }
+    };
+
+    return {isLoading, handleClick};
+};


### PR DESCRIPTION
### Proposed Changes

Removed the duplication of the useLoadingHandler hook in the button and the action Icon in favor of a generic one.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
