### PR TITLE
fix(filterbox): do not trim end of string to avoid weird UX when typing

### DIFF
--- a/packages/react/src/components/filterBox/FilterBoxSelectors.ts
+++ b/packages/react/src/components/filterBox/FilterBoxSelectors.ts
@@ -10,7 +10,7 @@ export interface GetFilterTextProps {
 
 const getFilterText = (state: PlasmaState, props: GetFilterTextProps): string => {
     const filter: IFilterState = _.findWhere(state.filters, {id: props.id});
-    return (filter && filter.filterText.trim()) || '';
+    return (filter && filter.filterText.trimStart()) || '';
 };
 
 export interface GetMatchFilterTextProps {


### PR DESCRIPTION
### Proposed Changes

#### [SEARCHAPI-9494](https://coveord.atlassian.net/browse/SEARCHAPI-9494) 

The `FilterBox` was trimming the text while users were typing a value.

🎬 Some examples within the ADUI:

https://github.com/coveo/plasma/assets/133259861/327f68a8-54d5-432a-a34d-417a4831a306

https://github.com/coveo/plasma/assets/133259861/cef859ae-aedb-4b03-9cc8-d7864f86c68e


🎬 I also confirmed the unwanted behaviour in the demo in Plasma:


https://github.com/coveo/plasma/assets/133259861/56894e32-3e58-4ac3-b574-24827cd69f47

The culprit seemed to be the `trim()` call that was introduced in this [PR](https://github.com/coveo/plasma/pull/3396). It was meant as a UX fix regarding the organization picker in the ADUI. Indeed, if you copy/paste some text with leading or trailing whitespaces, the filtering probably won't find what you're looking for since it takes into account the whitespaces.

However, this fix introduced unwanted behaviour in all filter boxes. While you type, it can remove the space you just entered if you take too long to type the next letter.

I decided to replace the `trim` call with `trimStart` so we only remove leading whitespaces. This should prevent trailing whitespaces being trimmed mid-typing.

I know this fix is not ideal since it doesn't cover the case where you would have a trailing whitespace by mistake. However, it's more an annoyance then a true critical issue. Also, since we're dealing with legacy components, I didn't think it made sense to invest a lot of time refactoring the code to handle all use cases. Finally, I think the issue the clients are facing right now is more annoying then the original issue in the PR linked above. 

✅ With the fix

https://github.com/coveo/plasma/assets/133259861/eb4cd1bf-a582-4a7c-be70-a68ac4b1064e


### Potential Breaking Changes

No breaking changes.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[SEARCHAPI-9494]: https://coveord.atlassian.net/browse/SEARCHAPI-9494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ