### PR TITLE
feat(collection): use getStyles, fixed collection

### DIFF
--- a/packages/mantine/src/components/collection/Collection.module.css
+++ b/packages/mantine/src/components/collection/Collection.module.css
@@ -9,11 +9,12 @@
         background-color: var(--mantine-color-black);
     }
     align-items: baseline;
+    &[data-isdragging='true'] {
+        box-shadow: var(--mantine-shadow-md);
+        z-index: 2;
+    }
 }
-.itemDragging {
-    box-shadow: var(--mantine-shadow-md);
-    z-index: 2;
-}
+
 .dragHandle {
     cursor: move;
 }

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -11,6 +11,7 @@ import {
     InputDescriptionProps,
     InputErrorProps,
     InputLabelProps,
+    MantineComponent,
     MantineSpacing,
     Stack,
     StylesApiProps,
@@ -20,7 +21,7 @@ import {
 } from '@mantine/core';
 import {ReorderPayload} from '@mantine/form/lib/types';
 import {useDidUpdate} from '@mantine/hooks';
-import {ForwardedRef, ReactNode} from 'react';
+import {ForwardedRef, ReactNode, forwardRef} from 'react';
 
 import {Button} from '../button';
 import classes from './Collection.module.css';
@@ -175,7 +176,7 @@ const defaultProps: Partial<CollectionProps<unknown>> = {
     getItemId: ({id}: any) => id,
 };
 
-export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<HTMLDivElement>}) => {
+export const Collection = forwardRef(<T,>(props: CollectionProps<T> & {ref?: ForwardedRef<HTMLDivElement>}) => {
     const {
         value,
         onChange,
@@ -321,6 +322,6 @@ export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<H
             </DndContext>
         </CollectionProvider>
     );
-};
+}) as MantineComponent<CollectionFactory>;
 
 Collection.extend = <T,>(value: T) => value;

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -8,14 +8,12 @@ import {
     Factory,
     Group,
     Input,
-    InputDescriptionProps,
-    InputErrorProps,
-    InputLabelProps,
     MantineComponent,
     MantineSpacing,
     Stack,
     StylesApiProps,
     Tooltip,
+    __InputWrapperProps,
     useProps,
     useStyles,
 } from '@mantine/core';
@@ -28,7 +26,7 @@ import classes from './Collection.module.css';
 import {CollectionProvider} from './CollectionContext';
 import {CollectionItem} from './CollectionItem';
 
-interface CollectionProps<T> extends BoxProps, StylesApiProps<CollectionFactory> {
+interface CollectionProps<T> extends __InputWrapperProps, BoxProps, StylesApiProps<CollectionFactory> {
     /**
      * The default value each new item should have
      */
@@ -131,31 +129,6 @@ interface CollectionProps<T> extends BoxProps, StylesApiProps<CollectionFactory>
     /**
      * Input label, displayed above the collection. If not provided, the label will not be rendered
      */
-    label?: React.ReactNode;
-    /**
-     * Props passed down to the collection input label.
-     */
-    labelProps?: InputLabelProps;
-    /**
-     * Determines whether required asterisk should be rendered, overrides required prop, does not add required attribute to the input
-     */
-    withAsterisk?: boolean;
-    /**
-     * Input description, displayed below the collection. If not provided, the description will not be rendered
-     */
-    description?: string;
-    /**
-     * Props passed down to the collection description.
-     */
-    descriptionProps?: InputDescriptionProps;
-    /**
-     * Determines whether the input should have error styles and aria-invalid attribute
-     */
-    error?: React.ReactNode;
-    /**
-     * Props passed down to the collection error.
-     */
-    errorProps?: InputErrorProps;
 }
 
 export type CollectionStylesNames = 'root' | 'item' | 'itemDragging' | 'dragHandle';
@@ -176,152 +149,153 @@ const defaultProps: Partial<CollectionProps<unknown>> = {
     getItemId: ({id}: any) => id,
 };
 
-export const Collection = forwardRef(<T,>(props: CollectionProps<T> & {ref?: ForwardedRef<HTMLDivElement>}) => {
-    const {
-        value,
-        onChange,
-        onRemoveItem,
-        onReorderItem,
-        onInsertItem,
-        disabled,
-        draggable,
-        children,
-        gap,
-        required,
-        newItem,
-        addLabel,
-        addDisabledTooltip,
-        allowAdd,
-        label,
-        labelProps,
-        withAsterisk,
-        description,
-        descriptionProps,
-        error,
-        errorProps,
-        getItemId,
+export const Collection = forwardRef<HTMLDivElement, CollectionProps<unknown>>(
+    <T,>(props: CollectionProps<T>, ref: ForwardedRef<HTMLDivElement>) => {
+        const {
+            value,
+            onChange,
+            onRemoveItem,
+            onReorderItem,
+            onInsertItem,
+            disabled,
+            draggable,
+            children,
+            gap,
+            required,
+            newItem,
+            addLabel,
+            addDisabledTooltip,
+            allowAdd,
+            label,
+            labelProps,
+            withAsterisk,
+            description,
+            descriptionProps,
+            error,
+            errorProps,
+            getItemId,
 
-        // Style props
-        style,
-        className,
-        classNames,
-        styles,
-        unstyled,
-        ref,
-        ...others
-    } = useProps('Collection', defaultProps as CollectionProps<T>, props);
+            // Style props
+            style,
+            className,
+            classNames,
+            styles,
+            unstyled,
+            ...others
+        } = useProps('Collection', defaultProps as CollectionProps<T>, props);
 
-    const getStyles = useStyles<CollectionFactory>({
-        name: 'Collection',
-        classes,
-        props,
-        className,
-        style,
-        classNames,
-        styles,
-        unstyled,
-    });
-    const sensors = useSensors(
-        useSensor(PointerSensor),
-        useSensor(KeyboardSensor, {
-            coordinateGetter: sortableKeyboardCoordinates,
-        }),
-    );
+        const getStyles = useStyles<CollectionFactory>({
+            name: 'Collection',
+            classes,
+            props,
+            className,
+            style,
+            classNames,
+            styles,
+            unstyled,
+        });
+        const sensors = useSensors(
+            useSensor(PointerSensor),
+            useSensor(KeyboardSensor, {
+                coordinateGetter: sortableKeyboardCoordinates,
+            }),
+        );
 
-    const hasOnlyOneItem = value.length === 1;
+        const hasOnlyOneItem = value.length === 1;
 
-    /**
-     * Enforcing onChange when the value is modified will make sure the errors are carried through.
-     */
-    useDidUpdate(() => {
-        onChange?.(value);
-    }, [JSON.stringify(value)]);
+        /**
+         * Enforcing onChange when the value is modified will make sure the errors are carried through.
+         */
+        useDidUpdate(() => {
+            onChange?.(value);
+        }, [JSON.stringify(value)]);
 
-    const isRequired = typeof withAsterisk === 'boolean' ? withAsterisk : required;
-    const _label = label ? (
-        <Input.Label required={isRequired} {...labelProps}>
-            {label}
-        </Input.Label>
-    ) : null;
-
-    const _description = description ? (
-        <Input.Description {...descriptionProps}>{description}</Input.Description>
-    ) : null;
-    const _error = error ? <Input.Error {...errorProps}>{error}</Input.Error> : null;
-    const _header =
-        _label || _description ? (
-            <>
-                {_label}
-                {_description}
-            </>
+        const isRequired = typeof withAsterisk === 'boolean' ? withAsterisk : required;
+        const _label = label ? (
+            <Input.Label required={isRequired} {...labelProps}>
+                {label}
+            </Input.Label>
         ) : null;
 
-    const standardizedItems = value.map((item, index) => ({id: getItemId?.(item) ?? String(index), data: item}));
+        const _description = description ? (
+            <Input.Description {...descriptionProps}>{description}</Input.Description>
+        ) : null;
+        const _error = error ? <Input.Error {...errorProps}>{error}</Input.Error> : null;
+        const _header =
+            _label || _description ? (
+                <>
+                    {_label}
+                    {_description}
+                </>
+            ) : null;
 
-    const items = standardizedItems.map((item, index) => (
-        <CollectionItem
-            key={item.id}
-            id={item.id}
-            disabled={disabled}
-            draggable={draggable}
-            onRemove={() => onRemoveItem?.(index)}
-            removable={!(required && hasOnlyOneItem)}
-        >
-            {children(item.data, index)}
-        </CollectionItem>
-    ));
+        const standardizedItems = value.map((item, index) => ({id: getItemId?.(item) ?? String(index), data: item}));
 
-    const addAllowed = allowAdd?.(value) ?? true;
-
-    const _addButton = disabled ? null : (
-        <Group>
-            <Tooltip label={addDisabledTooltip} disabled={addAllowed}>
-                <Box>
-                    <Button
-                        variant="subtle"
-                        leftSection={<AddSize16Px height={16} />}
-                        onClick={() => onInsertItem(newItem, value?.length ?? 0)}
-                        disabled={!addAllowed}
-                    >
-                        {addLabel}
-                    </Button>
-                </Box>
-            </Tooltip>
-        </Group>
-    );
-
-    const getIndex = (id: string) => standardizedItems.findIndex((item) => item.id === id);
-
-    const handleDragEnd = ({over, active}: DragEndEvent): void => {
-        if (over) {
-            const activeIndex = getIndex(String(active.id));
-            const overIndex = getIndex(String(over.id));
-            if (activeIndex !== overIndex) {
-                onReorderItem?.({from: activeIndex, to: overIndex});
-            }
-        }
-    };
-
-    return (
-        <CollectionProvider value={{getStyles}}>
-            <DndContext
-                onDragEnd={handleDragEnd}
-                sensors={sensors}
-                modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+        const items = standardizedItems.map((item, index) => (
+            <CollectionItem
+                key={item.id}
+                id={item.id}
+                disabled={disabled}
+                draggable={draggable}
+                onRemove={() => onRemoveItem?.(index)}
+                removable={!(required && hasOnlyOneItem)}
             >
-                <SortableContext items={standardizedItems} strategy={verticalListSortingStrategy}>
-                    <Box ref={ref} {...others} {...getStyles('root')}>
-                        {_header}
-                        <Stack gap={gap}>
-                            {items}
-                            {_addButton}
-                            {_error}
-                        </Stack>
+                {children(item.data, index)}
+            </CollectionItem>
+        ));
+
+        const addAllowed = allowAdd?.(value) ?? true;
+
+        const _addButton = disabled ? null : (
+            <Group>
+                <Tooltip label={addDisabledTooltip} disabled={addAllowed}>
+                    <Box>
+                        <Button
+                            variant="subtle"
+                            leftSection={<AddSize16Px height={16} />}
+                            onClick={() => onInsertItem(newItem, value?.length ?? 0)}
+                            disabled={!addAllowed}
+                        >
+                            {addLabel}
+                        </Button>
                     </Box>
-                </SortableContext>
-            </DndContext>
-        </CollectionProvider>
-    );
-}) as MantineComponent<CollectionFactory>;
+                </Tooltip>
+            </Group>
+        );
+
+        const getIndex = (id: string) => standardizedItems.findIndex((item) => item.id === id);
+
+        const handleDragEnd = ({over, active}: DragEndEvent): void => {
+            if (over) {
+                const activeIndex = getIndex(String(active.id));
+                const overIndex = getIndex(String(over.id));
+                if (activeIndex !== overIndex) {
+                    onReorderItem?.({from: activeIndex, to: overIndex});
+                }
+            }
+        };
+
+        return (
+            <CollectionProvider value={{getStyles}}>
+                <DndContext
+                    onDragEnd={handleDragEnd}
+                    sensors={sensors}
+                    modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+                >
+                    <SortableContext items={standardizedItems} strategy={verticalListSortingStrategy}>
+                        <Box ref={ref} {...others} {...getStyles('root')}>
+                            {_header}
+                            <Stack gap={gap}>
+                                {items}
+                                {_addButton}
+                                {_error}
+                            </Stack>
+                        </Box>
+                    </SortableContext>
+                </DndContext>
+            </CollectionProvider>
+        );
+    },
+) as MantineComponent<CollectionFactory>;
 
 Collection.extend = <T,>(value: T) => value;

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -127,12 +127,33 @@ interface CollectionProps<T> extends BoxProps, StylesApiProps<CollectionFactory>
      * @default false
      */
     required?: boolean;
-    label: string;
+    /**
+     * Input label, displayed above the collection. If not provided, the label will not be rendered
+     */
+    label?: React.ReactNode;
+    /**
+     * Props passed down to the collection input label.
+     */
     labelProps?: InputLabelProps;
+    /**
+     * Determines whether required asterisk should be rendered, overrides required prop, does not add required attribute to the input
+     */
     withAsterisk?: boolean;
+    /**
+     * Input description, displayed below the collection. If not provided, the description will not be rendered
+     */
     description?: string;
+    /**
+     * Props passed down to the collection description.
+     */
     descriptionProps?: InputDescriptionProps;
-    error?: string;
+    /**
+     * Determines whether the input should have error styles and aria-invalid attribute
+     */
+    error?: React.ReactNode;
+    /**
+     * Props passed down to the collection error.
+     */
     errorProps?: InputErrorProps;
 }
 

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -126,9 +126,6 @@ interface CollectionProps<T> extends __InputWrapperProps, BoxProps, StylesApiPro
      * @default false
      */
     required?: boolean;
-    /**
-     * Input label, displayed above the collection. If not provided, the label will not be rendered
-     */
 }
 
 export type CollectionStylesNames = 'root' | 'item' | 'itemDragging' | 'dragHandle';

--- a/packages/mantine/src/components/collection/CollectionContext.ts
+++ b/packages/mantine/src/components/collection/CollectionContext.ts
@@ -1,0 +1,10 @@
+import {createSafeContext, type GetStylesApi} from '@mantine/core';
+import type {CollectionFactory} from './Collection';
+
+interface CollectionContextType {
+    getStyles: GetStylesApi<CollectionFactory>;
+}
+
+export const [CollectionProvider, useCollectionContext] = createSafeContext<CollectionContextType>(
+    'Collection component was not found in tree',
+);

--- a/packages/mantine/src/components/collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/collection/CollectionItem.tsx
@@ -59,7 +59,6 @@ const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionIte
     const {attributes, listeners, setNodeRef, transform, transition, isDragging, setActivatorNodeRef} = useSortable({
         id,
     });
-    console.log(isDragging, transform);
 
     return (
         <Group

--- a/packages/mantine/src/components/collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/collection/CollectionItem.tsx
@@ -2,10 +2,9 @@ import {DragAndDropSize24Px, RemoveSize16Px} from '@coveord/plasma-react-icons';
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
 import {ActionIcon, Group, GroupProps} from '@mantine/core';
-import cx from 'clsx';
 import {FunctionComponent, PropsWithChildren} from 'react';
 
-import CollectionClasses from './Collection.module.css';
+import {useCollectionContext} from './CollectionContext';
 
 interface CollectionItemProps extends CollectionItemSharedProps {
     draggable?: boolean;
@@ -33,19 +32,21 @@ const StaticCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSh
     removable = true,
     children,
 }) => {
+    const ctx = useCollectionContext();
     const removeButton = removable && onRemove ? <RemoveButton onClick={onRemove} /> : <RemoveButtonPlaceholder />;
 
     return (
-        <Group className={CollectionClasses.item}>
+        <Group {...ctx.getStyles('item')}>
             {children}
             {removeButton}
         </Group>
     );
 };
 
-const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({children}) => (
-    <Group className={CollectionClasses.item}>{children}</Group>
-);
+const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({children}) => {
+    const ctx = useCollectionContext();
+    return <Group {...ctx.getStyles('item')}>{children}</Group>;
+};
 
 const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
     id,
@@ -53,27 +54,27 @@ const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionIte
     removable = true,
     children,
 }) => {
+    const ctx = useCollectionContext();
     const removeButton = removable && onRemove ? <RemoveButton onClick={onRemove} /> : null;
     const {attributes, listeners, setNodeRef, transform, transition, isDragging, setActivatorNodeRef} = useSortable({
         id,
     });
+    console.log(isDragging, transform);
 
     return (
         <Group
             ref={setNodeRef}
-            className={cx(CollectionClasses.item, {[CollectionClasses.itemDragging]: isDragging})}
-            styles={
-                transform
+            {...ctx.getStyles('item', {
+                style: transform
                     ? {
-                          root: {
-                              transform: CSS.Transform.toString(transform),
-                              transition,
-                          },
+                          transform: CSS.Transform.toString(transform),
+                          transition,
                       }
-                    : undefined
-            }
+                    : undefined,
+            })}
+            data-isdragging={isDragging}
         >
-            <div ref={setActivatorNodeRef} {...listeners} {...attributes} className={CollectionClasses.dragHandle}>
+            <div ref={setActivatorNodeRef} {...listeners} {...attributes} {...ctx.getStyles('dragHandle')}>
                 <DragAndDropSize24Px height={16} />
             </div>
             {children}

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -15,8 +15,6 @@ export * from '@tanstack/table-core';
 export * from './components';
 export {noop};
 
-export {identity as customIdentity, type CustomComponentThemeExtend} from './utils';
-
 // explicitly overriding mantine components
 export {
     ActionIcon,

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -15,6 +15,8 @@ export * from '@tanstack/table-core';
 export * from './components';
 export {noop};
 
+export {identity as customIdentity, type CustomComponentThemeExtend} from './utils';
+
 // explicitly overriding mantine components
 export {
     ActionIcon,

--- a/packages/mantine/src/utils/createFactoryComponent.ts
+++ b/packages/mantine/src/utils/createFactoryComponent.ts
@@ -1,0 +1,6 @@
+import {ExtendComponent, FactoryPayload} from '@mantine/core';
+import {ThemeExtend} from '@mantine/core/lib/core/factory/factory';
+
+export const identity = <T>(value: T): T => value;
+
+export type CustomComponentThemeExtend<T extends FactoryPayload> = (props: ExtendComponent<T>) => ThemeExtend<T>;

--- a/packages/mantine/src/utils/index.ts
+++ b/packages/mantine/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './createFactoryComponent';
 export * from './createPolymorphicComponent';
 export * from './overrideComponent';


### PR DESCRIPTION
### Proposed Changes

this is a subtask of https://coveord.atlassian.net/browse/ADUI-9365 where a lot of components are using the plasma/mantine ```<Collection />``` component. When I did the migration from mantine 6 -> 7, I did not foresee that we would need to factorise this component so that devs could use it and access css selector, like so :

`<Collection styles={{root: {...}, item: {...}, otherSelector: {...}}}>{...}</Collection>`

With my migration, it was made so that the classes were directly used as an import, while now it's used with ```useStyles``` mantine hook.

With this new implementation, it is now possible to add style with styles prop and add custom style to ```'root' | 'item' | 'itemDragging' | 'dragHandle'``` selectors.

This should not break anything. In fact, it fixes a breaking behavior the first implementation did

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
