### PR TITLE
fix(mantine): adjust default font styles

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -26,6 +26,14 @@ export const plasmaTheme: MantineThemeOverride = {
         lg: '32px',
         xl: '40px',
     },
+    globalStyles: (theme) => ({
+        body: {
+            ...theme.fn.fontStyles(),
+            fontSize: theme.fontSizes.sm,
+            lineHeight: theme.lineHeight,
+            fontWeight: 300,
+        },
+    }),
     primaryColor: 'action',
     headings: {
         fontFamily: 'canada-type-gibson, sans-serif',


### PR DESCRIPTION
### Proposed Changes

Changing the default font style of the body tag. This way when you render text out of any mantine component, the same default font style is still applied.

Before
![image](https://github.com/coveo/plasma/assets/35579930/f189450d-f232-4ab8-963a-09a1a5bf3e70)


After
![image](https://github.com/coveo/plasma/assets/35579930/c5e989b3-a657-4194-a157-9c444bd62d53)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
