### PR TITLE
fix(mantine): add null to table data prop type

### DIFF
--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -155,9 +155,9 @@ type TableStylesNames = Selectors<typeof useStyles>;
 
 export interface TableProps<T> extends DefaultProps<TableStylesNames> {
     /**
-     * Data to display in the table
+     * Data to display in the table. Use `null` when the table is initially loading.
      */
-    data: T[];
+    data: T[] | null;
     /**
      * Defines how each row is uniquely identified. It is highly recommended that you specify this prop to an ID that makes sense.
      */


### PR DESCRIPTION
### Proposed Changes

Changing the Table data prop type from `data: T[];` to `data: T[] | null;`.

The Table component already expects a `null` value when it is initially loading.


```tsx
    if (!data) {
        return (
            <Center sx={{flexGrow: 1}}>
                <Loader />
            </Center>
        );
    }
```
https://github.com/coveo/plasma/blob/master/packages/mantine/src/components/table/Table.tsx#L141-L147

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
