### PR TITLE
chore(mantine): button and action icon overridable via theme

### DIFF
--- a/packages/mantine/src/components/action-icon/ActionIcon.tsx
+++ b/packages/mantine/src/components/action-icon/ActionIcon.tsx
@@ -1,7 +1,15 @@
-import {ActionIcon as MantineActionIcon, type ActionIconProps as MantineActionIconProps} from '@mantine/core';
-import {MouseEvent, MouseEventHandler, forwardRef, useState} from 'react';
-
-import {createPolymorphicComponent} from '../../utils';
+import {
+    ActionIcon as MantineActionIcon,
+    ActionIconCssVariables,
+    ActionIconGroup,
+    type ActionIconProps as MantineActionIconProps,
+    ActionIconStylesNames,
+    ActionIconVariant,
+    Factory,
+    polymorphicFactory,
+} from '@mantine/core';
+import {MouseEventHandler} from 'react';
+import {useClickWithLoading} from '../../hooks/useClickWithLoading';
 import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from '../button/ButtonWithDisabledTooltip';
 
 export interface ActionIconProps extends MantineActionIconProps, ButtonWithDisabledTooltipProps {
@@ -9,29 +17,21 @@ export interface ActionIconProps extends MantineActionIconProps, ButtonWithDisab
     onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-const useLoadingHandler = (handler?: MouseEventHandler<HTMLButtonElement>) => {
-    const [isLoading, setIsLoading] = useState(false);
-
-    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
-        const possiblePromise: unknown = handler?.(event);
-        try {
-            if (possiblePromise instanceof Promise) {
-                setIsLoading(true);
-                await possiblePromise;
-                setIsLoading(false);
-            }
-        } catch (err) {
-            setIsLoading(false);
-            console.error(err);
-        }
+type ActionIconOverloadFactory = Factory<{
+    props: ActionIconProps;
+    defaultRef: HTMLButtonElement;
+    defaultComponent: 'button';
+    stylesNames: ActionIconStylesNames;
+    vars: ActionIconCssVariables;
+    variant: ActionIconVariant;
+    staticComponents: {
+        Group: typeof ActionIconGroup;
     };
+}>;
 
-    return {isLoading, handleClick};
-};
-
-const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
+export const ActionIcon = polymorphicFactory<ActionIconOverloadFactory>(
     ({disabledTooltip, disabled, disabledTooltipProps, loading, onClick, ...others}, ref) => {
-        const {isLoading, handleClick} = useLoadingHandler(onClick);
+        const {isLoading, handleClick} = useClickWithLoading(onClick);
         return (
             <ButtonWithDisabledTooltip
                 disabled={disabled}
@@ -51,10 +51,4 @@ const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
         );
     },
 );
-
-export const ActionIcon = createPolymorphicComponent<
-    'button',
-    ActionIconProps,
-    {Group: typeof MantineActionIcon.Group}
->(_ActionIcon);
 ActionIcon.Group = MantineActionIcon.Group;

--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -1,7 +1,13 @@
-import {Button as MantineButton, ButtonProps as MantineButtonProps} from '@mantine/core';
-import {MouseEvent, MouseEventHandler, forwardRef, useState} from 'react';
-
-import {createPolymorphicComponent} from '../../utils';
+import {
+    Button as MantineButton,
+    ButtonGroup,
+    ButtonProps as MantineButtonProps,
+    Factory,
+    polymorphicFactory,
+} from '@mantine/core';
+import {ButtonCssVariables, ButtonStylesNames, ButtonVariant} from '@mantine/core/lib/components/Button/Button';
+import {MouseEventHandler} from 'react';
+import {useClickWithLoading} from '../../hooks/useClickWithLoading';
 import {ButtonWithDisabledTooltip, ButtonWithDisabledTooltipProps} from './ButtonWithDisabledTooltip';
 
 export interface ButtonProps extends MantineButtonProps, ButtonWithDisabledTooltipProps {
@@ -9,29 +15,21 @@ export interface ButtonProps extends MantineButtonProps, ButtonWithDisabledToolt
     onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-const useLoadingHandler = (handler?: MouseEventHandler<HTMLButtonElement>) => {
-    const [isLoading, setIsLoading] = useState(false);
-
-    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
-        const possiblePromise: unknown = handler?.(event);
-        try {
-            if (possiblePromise instanceof Promise) {
-                setIsLoading(true);
-                await possiblePromise;
-                setIsLoading(false);
-            }
-        } catch (err) {
-            setIsLoading(false);
-            console.error(err);
-        }
+type ButtonOverloadFactory = Factory<{
+    props: ButtonProps;
+    defaultRef: HTMLButtonElement;
+    defaultComponent: 'button';
+    stylesNames: ButtonStylesNames;
+    vars: ButtonCssVariables;
+    variant: ButtonVariant;
+    staticComponents: {
+        Group: typeof ButtonGroup;
     };
+}>;
 
-    return {isLoading, handleClick};
-};
-
-const _Button = forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = polymorphicFactory<ButtonOverloadFactory>(
     ({disabledTooltip, disabled, disabledTooltipProps, loading, onClick, ...others}, ref) => {
-        const {isLoading, handleClick} = useLoadingHandler(onClick);
+        const {isLoading, handleClick} = useClickWithLoading(onClick);
         return (
             <ButtonWithDisabledTooltip
                 disabled={disabled}
@@ -52,6 +50,4 @@ const _Button = forwardRef<HTMLButtonElement, ButtonProps>(
         );
     },
 );
-
-export const Button = createPolymorphicComponent<'button', ButtonProps, {Group: typeof MantineButton.Group}>(_Button);
 Button.Group = MantineButton.Group;

--- a/packages/mantine/src/hooks/useClickWithLoading.ts
+++ b/packages/mantine/src/hooks/useClickWithLoading.ts
@@ -1,0 +1,21 @@
+import {MouseEvent, MouseEventHandler, useState} from 'react';
+
+export const useClickWithLoading = (handler?: MouseEventHandler<HTMLButtonElement>) => {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+        const possiblePromise: unknown = handler?.(event);
+        try {
+            if (possiblePromise instanceof Promise) {
+                setIsLoading(true);
+                await possiblePromise;
+                setIsLoading(false);
+            }
+        } catch (err) {
+            setIsLoading(false);
+            console.error(err);
+        }
+    };
+
+    return {isLoading, handleClick};
+};


### PR DESCRIPTION
### Proposed Changes

Made ActionIcon and Button theme-able via the factory
Extracted duplicated code between ActionIcon and Button to a shared hook

### Potential Breaking Changes

None?

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
