### PR TITLE
feat: change HeaderDocAnchor label type to align with mantine tooltip

### DIFF
--- a/packages/mantine/src/components/header/HeaderDocAnchor/HeaderDocAnchor.tsx
+++ b/packages/mantine/src/components/header/HeaderDocAnchor/HeaderDocAnchor.tsx
@@ -21,7 +21,7 @@ export interface HeaderDocAnchorProps
     /**
      * The tooltip text shown when hovering over the doc link icon
      */
-    label?: string;
+    label?: ReactNode;
     /**
      * React component to add the tooltip and anchor on
      */


### PR DESCRIPTION
### Proposed Changes

Change type of `label` from `string` to `ReactNode` in `HeaderDocAnchor` to align with `Tooltip`

### Potential Breaking Changes

`string` type is allowed in `ReactNode` still, so nothing will break


** This is needed for https://github.com/coveo/admin-ui/pull/9769 ** 