### PR TITLE
Fix ad UI 9588 disabled style pagination plasma react table

### DIFF
--- a/packages/style/scss/tables/pagination.scss
+++ b/packages/style/scss/tables/pagination.scss
@@ -74,6 +74,16 @@
             .icon {
                 fill: currentcolor;
             }
+
+            &.disabled {
+                color: var(--deprecated-medium-grey);
+                cursor: default;
+                pointer-events: none;
+
+                .icon {
+                    fill: var(--deprecated-medium-grey);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Proposed Changes

The disabled pagination  style of the plasma react table was not applied on the correct element classes. The effect is, when a user gets to the last page, the `next` is not grayed out. 

Duplicating the rules already applied on the `.change-page-link.disabled` to also apply on `.flat-select .flat-select-option.mod-link.disabled` fixes the situation.

TODO: I Will paste a proper destination in the demo to test the changes 

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
