### PR TITLE
feat(stickyFooter): adjust padding

### DIFF
--- a/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
@@ -5,5 +5,5 @@
     background-color: white;
 }
 .footer {
-    padding: var(--mantine-spacing-lg);
+    padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
 }


### PR DESCRIPTION
### Proposed Changes

Adjust StickyFooter padding to 32px horizontal, 24px vertical per the [new guideline.](https://coveord.atlassian.net/browse/MLX-1038?focusedCommentId=737551&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-737551) 
<img width="1049" alt="Screenshot 2024-02-26 at 11 40 02 AM" src="https://github.com/coveo/plasma/assets/113382897/fc18d560-0c60-49dc-bd87-6f9ff7920197">
<img width="668" alt="Screenshot 2024-02-26 at 11 39 54 AM" src="https://github.com/coveo/plasma/assets/113382897/008eaa61-7075-4b21-a416-566f3ece9352">

As this change is not urgent it is made in the next branch and [close this one ](https://github.com/coveo/plasma/pull/3627)
### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
