### PR TITLE
Fix mantine table header margin problem

### DIFF
--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -59,6 +59,7 @@
 .headerGridInner {
     flex-direction: row-reverse;
     flex-wrap: wrap-reverse;
+    margin: 0;
 }
 
 .headerCol {

--- a/packages/website/src/styles/main.scss
+++ b/packages/website/src/styles/main.scss
@@ -4,8 +4,8 @@
 @import './_syntax-highlighting.css';
 
 body {
-    font-size: 16px;
-    line-height: 1.25rem;
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 300;
 }
 
 .sentence-case {


### PR DESCRIPTION
### Proposed Changes

Somehow, Mantine 7 now sets a negative margin on the Grid component, which breaks the visuals of the table:
<img width="406" alt="image" src="https://github.com/coveo/plasma/assets/35579930/f055d370-c271-45f3-aad8-c8be2bb97c9c">
<img width="524" alt="image" src="https://github.com/coveo/plasma/assets/35579930/63260dfb-1b5c-42c8-8d5c-0d37ad19ed56">

By setting this margin to `0`, it fixes the issue.

Before
<img width="1254" alt="image" src="https://github.com/coveo/plasma/assets/35579930/cda06b8a-6696-4ab6-81f1-876b551515ed">

After
<img width="1248" alt="image" src="https://github.com/coveo/plasma/assets/35579930/9a0538e6-18d1-4e81-9db8-a172b95fb90e">



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
