### PR TITLE
fix(mantine): table collapsible icon size and color

### DIFF
--- a/packages/mantine/src/components/table/table-column/TableCollapsibleColumn.tsx
+++ b/packages/mantine/src/components/table/table-column/TableCollapsibleColumn.tsx
@@ -1,4 +1,4 @@
-import {ArrowHeadDownSize24Px, ArrowHeadUpSize24Px} from '@coveord/plasma-react-icons';
+import {ArrowHeadDownSize16Px, ArrowHeadUpSize16Px} from '@coveord/plasma-react-icons';
 import {Factory, factory, useProps} from '@mantine/core';
 import {CellContext, ColumnDef} from '@tanstack/table-core';
 import {MouseEvent as ReactMouseEvent, ReactNode} from 'react';
@@ -54,8 +54,8 @@ type TableCollapsibleColumnFactory = Factory<{
 }>;
 
 const defaultProps: Partial<CollapsibleIconProps> = {
-    iconExpanded: <ArrowHeadUpSize24Px height={24} />,
-    iconCollapsed: <ArrowHeadDownSize24Px height={24} />,
+    iconExpanded: <ArrowHeadUpSize16Px height={16} />,
+    iconCollapsed: <ArrowHeadDownSize16Px height={16} />,
 };
 
 const CollapsibleIcon = factory<TableCollapsibleColumnFactory>((props, ref) => {
@@ -76,6 +76,7 @@ const CollapsibleIcon = factory<TableCollapsibleColumnFactory>((props, ref) => {
             ref={ref}
             onClick={onClick}
             variant="subtle"
+            color="gray"
             radius="sm"
             {...ctx.getStyles('collapsibleIcon', {className, classNames, styles, style})}
             {...others}


### PR DESCRIPTION
### Proposed Changes

| `master` | `next` | current branch |
| --- | --- | --- |
| <img width="108" alt="image" src="https://github.com/coveo/plasma/assets/35579930/a5dce0fa-3dbe-4ee8-88b5-4d2f36fa873f"> | <img width="97" alt="image" src="https://github.com/coveo/plasma/assets/35579930/9446360d-19a5-40b9-bcc8-724347f801f2"> | <img width="99" alt="image" src="https://github.com/coveo/plasma/assets/35579930/f8d82fa3-ea0d-4fb6-ab55-cc333bd3a1ca"> |


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
