### PR TITLE
Fix ad UI 9639 popover zindex

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -14,6 +14,7 @@ import {
     InputWrapper,
     List,
     Loader,
+    LoadingOverlay,
     MantineThemeOverride,
     MenuItem,
     Modal,
@@ -116,6 +117,9 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         Button: Button.extend({
             classNames: {root: ButtonClasses.root, label: ButtonClasses.label},
         }),
+        LoadingOverlay: LoadingOverlay.extend({
+            defaultProps: {zIndex: 1400},
+        }),
         Modal: Modal.extend({
             classNames: {
                 root: ModalClasses.root,
@@ -184,6 +188,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             defaultProps: {
                 shadow: 'md',
                 withArrow: true,
+                zIndex: 1300,
             },
         }),
         Badge: Badge.extend({


### PR DESCRIPTION
### Proposed Changes

bumping the Zindex of the popover manually in the default props since the actual style coming from the module is not used. Modifying the style there or with the variables have no effect.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
