### PR TITLE
fix(mantine): table selected row highlight

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -79,6 +79,10 @@ export type PlasmaTableFactory = Factory<{
 
 const defaultProps: Partial<TableProps<unknown>> = {
     layouts: [TableLayouts.Rows as TableLayout],
+    loading: false,
+    multiRowSelectionEnabled: false,
+    initialState: {},
+    options: {},
 };
 
 export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElement>}) => {
@@ -87,19 +91,19 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
         getRowId,
         noDataChildren,
         getExpandChildren,
-        initialState = {},
+        initialState,
         columns,
         layouts,
         onMount,
         onChange,
         children,
-        loading = false,
+        loading,
         doubleClickAction,
         multiRowSelectionEnabled,
         disableRowSelection,
         onRowSelectionChange,
         additionalRootNodes,
-        options = {},
+        options,
         ref,
 
         // Style props


### PR DESCRIPTION
### Proposed Changes
The table row layout style is like this:

```css
    &[data-selected='true'] {
        &[data-multi-selection='false'] { // <--- look here
            @mixin light {
                background-color: var(--mantine-color-gray-1);
            }
            @mixin dark {
                background-color: rgba(var(--mantine-primary-color-7), 0.2);
            }
        }
        &[data-multi-selection='true'] {
            background-color: transparent;
        }
    }
```

So it means that table where multi row selection is disabled are expected to have the attribute `data-multi-selection="false"`. Since there was no default value of `false` for the multi row selection it would never happen unless specified manually to false.

Before
<img width="1268" alt="image" src="https://github.com/coveo/plasma/assets/35579930/2f432509-864f-46fb-9f45-50735c6ef31b">


After
<img width="1257" alt="image" src="https://github.com/coveo/plasma/assets/35579930/17ff4505-69cd-48b1-b263-812bc7358d4f">


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
