### PR TITLE
Revert "fix(reset): line-height (#3648)"

### DIFF
--- a/packages/style/scss/lib/reset.scss
+++ b/packages/style/scss/lib/reset.scss
@@ -88,7 +88,6 @@ video {
     margin: 0;
     padding: 0;
     font: inherit;
-    line-height: 1.5;
     font-size: 100%;
     vertical-align: baseline;
     border: 0;


### PR DESCRIPTION
This reverts commit 4db52652a2d0767daeaa5ed3701411d01217c4b5.

### Proposed Changes

This change causes some issues with the old plasma-react table: the actions are not centered anymore.

Before the revert
![image](https://github.com/coveo/plasma/assets/35579930/ebcae680-bd5c-4edf-9eca-4a01c2c3a396)

After the revert
![image](https://github.com/coveo/plasma/assets/35579930/1780d8dc-da13-4f4d-9a8a-eb05e401f0b2)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
