### PR TITLE
fix(mantine): button loading data attribute

### DIFF
--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -43,7 +43,7 @@ export const Button = polymorphicFactory<ButtonOverloadFactory>(
                     loading={isLoading || loading}
                     onClick={handleClick}
                     disabled={disabled}
-                    data-loading={isLoading || loading}
+                    data-loading={isLoading || loading || undefined}
                     {...others}
                 />
             </ButtonWithDisabledTooltip>


### PR DESCRIPTION
### Proposed Changes

When `data-loading="false"` is applied to the button, the loading style still applies which hides the button text. This is because Mantine uses the selector `:where([data-loading])` and not `:where([data-loading='true'])`. So when the loading is false, the attribute must be set to undefined.

Before
![image](https://github.com/coveo/plasma/assets/35579930/9a084452-330a-4e34-a0ea-bbfb288b3272)

After
![image](https://github.com/coveo/plasma/assets/35579930/c1d772bb-8b3c-46ca-ab16-614031bb0f49)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
