### PR TITLE
fix(mantine): add back modal body padding top

### DIFF
--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -34,9 +34,7 @@ export const Prompt: PromptType = ({children, ...otherProps}) => {
 
     return (
         <Modal variant="prompt" classNames={{...classNames, ...classesProps}} size="sm" {...otherPropsWithoutClasses}>
-            <Box py="md" className={PromptClasses.innerBody}>
-                {otherChildren}
-            </Box>
+            <Box className={PromptClasses.innerBody}>{otherChildren}</Box>
             {footer}
         </Modal>
     );

--- a/packages/mantine/src/components/prompt/PromptFooter.tsx
+++ b/packages/mantine/src/components/prompt/PromptFooter.tsx
@@ -4,7 +4,7 @@ import {StickyFooter, StickyFooterProps} from '../sticky-footer';
 export interface PromptFooterProps extends StickyFooterProps {}
 
 export const PromptFooter: FunctionComponent<PropsWithChildren<PromptFooterProps>> = ({children, ...otherProps}) => (
-    <StickyFooter p={0} {...otherProps}>
+    <StickyFooter p={0} pt="lg" {...otherProps}>
         {children}
     </StickyFooter>
 );

--- a/packages/mantine/src/styles/Modal.module.css
+++ b/packages/mantine/src/styles/Modal.module.css
@@ -51,3 +51,9 @@
     line-height: var(--mantine-h3-line-height);
     font-weight: 500;
 }
+
+.body {
+    &:where(:not(:only-child)) {
+        padding-top: var(--mb-padding, var(--mantine-spacing-md));
+    }
+}

--- a/packages/website/src/examples/layout/Modal/Modal.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/Modal.demo.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Header, Modal, StickyFooter} from '@coveord/plasma-mantine';
+import {Button, Header, Modal, StickyFooter} from '@coveord/plasma-mantine';
 import {useState} from 'react';
 
 const Demo = () => {
@@ -17,14 +17,11 @@ const Demo = () => {
                 }
                 onClose={() => setOpened(false)}
             >
-                <Box py="lg">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada
-                    id sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
-                    Phasellus lacinia sem nunc, vel dapibus odio suscipit id. Aenean lobortis sollicitudin suscipit.
-                    Cras vitae ipsum sit amet nibh efficitur imperdiet. Praesent scelerisque erat est. Cras dictum
-                    sodales tellus sed pretium
-                </Box>
-                <StickyFooter p={0}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
+                sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim. Phasellus
+                lacinia sem nunc, vel dapibus odio suscipit id. Aenean lobortis sollicitudin suscipit. Cras vitae ipsum
+                sit amet nibh efficitur imperdiet. Praesent scelerisque erat est. Cras dictum sodales tellus sed pretium
+                <StickyFooter p={0} pt="lg">
                     <Button variant="outline" onClick={() => setOpened(false)}>
                         Cancel
                     </Button>

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
@@ -23,7 +23,7 @@ const Demo = () => {
                             <Tabs.Tab value="tab-2">Tab 2</Tabs.Tab>
                             <Tabs.Tab value="tab-3">Tab 3</Tabs.Tab>
                         </Tabs.List>
-                        <Modal.Body mih={500} pt="lg">
+                        <Modal.Body mih={500}>
                             <Tabs.Panel value="tab-1">Tab 1 content</Tabs.Panel>
                             <Tabs.Panel value="tab-2">Tab 2 content</Tabs.Panel>
                             <Tabs.Panel value="tab-3">Tab 3 content</Tabs.Panel>

--- a/packages/website/src/examples/layout/ModalWizard/ModalWizard.demo.tsx
+++ b/packages/website/src/examples/layout/ModalWizard/ModalWizard.demo.tsx
@@ -6,7 +6,7 @@ const Demo = () => {
 
     return (
         <>
-            <Button onClick={() => setOpened(true)}> Open ModalWizard </Button>
+            <Button onClick={() => setOpened(true)}>Open ModalWizard</Button>
             <ModalWizard onClose={() => setOpened(false)} opened={opened} onFinish={() => setOpened(false)}>
                 <ModalWizard.Step
                     docLink="https://coveo.com"

--- a/packages/website/src/pages/layout/ModalWizard.tsx
+++ b/packages/website/src/pages/layout/ModalWizard.tsx
@@ -1,11 +1,11 @@
 import {ModalWizardMetadata} from '@coveord/plasma-components-props-analyzer';
-import ModalWizardDemo from '@examples/layout/ModalWizard/ModalWizard.demo';
+import ModalWizardDemo from '@examples/layout/ModalWizard/ModalWizard.demo?demo';
 import ModalWizardWithFormValidation from '@examples/layout/ModalWizard/ModalWizardWithFormValidation.demo?demo';
 import ModalWizardWithTooltip from '@examples/layout/ModalWizard/ModalWizardWithTooltip.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
-export default () => (
+const DemoPage = () => (
     <PageLayout
         section="Layout"
         title="ModalWizard"
@@ -20,3 +20,5 @@ export default () => (
         }}
     />
 );
+
+export default DemoPage;


### PR DESCRIPTION
### Proposed Changes

In my [previous PR](https://github.com/coveo/plasma/pull/3647) to fix the Mantine Modal after the update to version 7, I overlooked the padding top on the modal body.

In mantine 7 version a css rule was added to remove the padding top on the modal body. 

```css
.body {
  padding: var(--mb-padding, var(--mantine-spacing-md));
  padding-top: var(--mb-padding, var(--mantine-spacing-md));

  &:where(:not(:only-child)) {
    padding-top: 0; // this is annoying
  }
}
```

https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/core/src/components/ModalBase/ModalBase.module.css

It makes sense for when the header does not have a border bottom, but all our modals do. So I added an override to put it back.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
