### PR TITLE
fix(website): pin mantine version when cloning examples

### DIFF
--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -27,6 +27,8 @@ export {
     type ButtonProps,
     type CopyToClipboardProps,
     type HeaderProps,
+    type HeaderStyleNames,
+    type HeaderVariant,
     type InitialTableState,
     type MenuItemProps,
     type TableProps,

--- a/packages/website/bin/index.ts
+++ b/packages/website/bin/index.ts
@@ -6,10 +6,11 @@ import {copyDemoFiles} from './copyDemoFiles';
 import {findTsxAndCssModule} from './findTsxAndCssModule';
 import {generatePage} from './generatePage';
 import {groupFilesByComponent} from './groupFilesByComponent';
+import packageJson from '../package.json';
 
 const cloneRepository = async (repoUrl: string, destinationFolder: string): Promise<void> => {
     const git: SimpleGit = simpleGit();
-    await git.clone(repoUrl, destinationFolder);
+    await git.clone(repoUrl, destinationFolder, ['-b', packageJson.dependencies['@mantine/core'], '--single-branch']);
 };
 
 const main = async (): Promise<void> => {


### PR DESCRIPTION
### Proposed Changes

Pinning the mantine package version when cloning the examples page, otherwise we can end up having demo pages of components that don't exist.

![image](https://github.com/coveo/plasma/assets/35579930/b87e87ef-daff-415c-a7c5-d44377a3b73b)
![image](https://github.com/coveo/plasma/assets/35579930/ceab7871-1791-42e5-9034-8c204b743b26)



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
