### PR TITLE
fix(mantine): header props type

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -1,4 +1,16 @@
-import {Divider, Factory, Group, GroupProps, Stack, Text, Title, factory, useProps, useStyles} from '@mantine/core';
+import {
+    Divider,
+    Factory,
+    Group,
+    GroupProps,
+    Stack,
+    StylesApiProps,
+    Text,
+    Title,
+    factory,
+    useProps,
+    useStyles,
+} from '@mantine/core';
 import {Children, ReactElement, ReactNode} from 'react';
 import classes from './Header.module.css';
 import {HeaderActions, HeaderActionsStyleNames} from './HeaderActions/HeaderActions';
@@ -20,7 +32,7 @@ export type HeaderStyleNames =
     | HeaderBreadcrumbsStyleNames
     | HeaderActionsStyleNames;
 
-export interface HeaderProps extends GroupProps {
+export interface HeaderProps extends StylesApiProps<HeaderFactory>, Omit<GroupProps, 'classNames' | 'styles' | 'vars'> {
     /**
      * The description text displayed inside the header underneath the title
      */

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -27,8 +27,6 @@ export {
     type ButtonProps,
     type CopyToClipboardProps,
     type HeaderProps,
-    type HeaderStyleNames,
-    type HeaderVariant,
     type InitialTableState,
     type MenuItemProps,
     type TableProps,


### PR DESCRIPTION
### Proposed Changes

Make the HeaderProps extend StylesAPIProps

<img width="1250" alt="image" src="https://github.com/coveo/plasma/assets/35579930/213d734f-76f0-4da5-afc0-5a42d02c6c8a">


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
