### PR TITLE
fix(button): prevent default onclick for link button

### DIFF
--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -1,8 +1,8 @@
 import {
-    Button as MantineButton,
     ButtonGroup,
-    ButtonProps as MantineButtonProps,
     Factory,
+    Button as MantineButton,
+    ButtonProps as MantineButtonProps,
     polymorphicFactory,
 } from '@mantine/core';
 import {ButtonCssVariables, ButtonStylesNames, ButtonVariant} from '@mantine/core/lib/components/Button/Button';
@@ -32,7 +32,7 @@ export const Button = polymorphicFactory<ButtonOverloadFactory>(
         const {isLoading, handleClick} = useClickWithLoading(onClick);
         return (
             <ButtonWithDisabledTooltip
-                disabled={disabled}
+                disabled={disabled || others['data-disabled']}
                 disabledTooltip={disabledTooltip}
                 disabledTooltipProps={disabledTooltipProps}
                 fullWidth={others.fullWidth}
@@ -41,7 +41,7 @@ export const Button = polymorphicFactory<ButtonOverloadFactory>(
                     loaderProps={{variant: 'oval'}}
                     ref={ref}
                     loading={isLoading || loading}
-                    onClick={handleClick}
+                    onClick={others['data-disabled'] ? (e) => e.preventDefault() : handleClick}
                     disabled={disabled}
                     data-loading={isLoading || loading || undefined}
                     {...others}

--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -28,11 +28,14 @@ type ButtonOverloadFactory = Factory<{
 }>;
 
 export const Button = polymorphicFactory<ButtonOverloadFactory>(
-    ({disabledTooltip, disabled, disabledTooltipProps, loading, onClick, ...others}, ref) => {
+    (
+        {disabledTooltip, disabled, disabledTooltipProps, loading, onClick, 'data-disabled': dataDisabled, ...others},
+        ref,
+    ) => {
         const {isLoading, handleClick} = useClickWithLoading(onClick);
         return (
             <ButtonWithDisabledTooltip
-                disabled={disabled || others['data-disabled']}
+                disabled={disabled || dataDisabled}
                 disabledTooltip={disabledTooltip}
                 disabledTooltipProps={disabledTooltipProps}
                 fullWidth={others.fullWidth}
@@ -41,7 +44,7 @@ export const Button = polymorphicFactory<ButtonOverloadFactory>(
                     loaderProps={{variant: 'oval'}}
                     ref={ref}
                     loading={isLoading || loading}
-                    onClick={others['data-disabled'] ? (e) => e.preventDefault() : handleClick}
+                    onClick={dataDisabled ? (e) => e.preventDefault() : handleClick}
                     disabled={disabled}
                     data-loading={isLoading || loading || undefined}
                     {...others}

--- a/packages/mantine/src/components/button/Button.tsx
+++ b/packages/mantine/src/components/button/Button.tsx
@@ -45,7 +45,7 @@ export const Button = polymorphicFactory<ButtonOverloadFactory>(
                     ref={ref}
                     loading={isLoading || loading}
                     onClick={dataDisabled ? (e) => e.preventDefault() : handleClick}
-                    disabled={disabled}
+                    disabled={disabled || dataDisabled}
                     data-loading={isLoading || loading || undefined}
                     {...others}
                 />


### PR DESCRIPTION
### Proposed Changes

When using the polymorphic component of button and using it as a Link, the ```onClick``` prop was still triggered and a redirection to the ```to``` link prop specified occurred even though the button was disabled. We `preventDefault()` when ```data-disabled === true```. this should fix a lot (all) of redirection disabled button.
### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
