### PR TITLE
fix(mantine, combobox): add small margin under Combobox.Search

### DIFF
--- a/packages/mantine/src/styles/Combobox.module.css
+++ b/packages/mantine/src/styles/Combobox.module.css
@@ -1,6 +1,6 @@
 .search {
-    margin: 0;
-    border-radius: 8px;
+    margin: 0 0 var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-md);
     border: 1px solid;
     width: 100%;
     border-color: var(--mantine-color-gray-4);


### PR DESCRIPTION
### Proposed Changes

Added a small margin under the Combobox.Search component

<img width="537" alt="image" src="https://github.com/coveo/plasma/assets/260007/b9a82caf-0a14-4ba9-b237-97ac58101cd7">


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
