### PR TITLE
feat(table): visual update on datepicker

### DIFF
--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -23,12 +23,6 @@
     display: inline-flex;
 }
 
-/* Table.DateRange */
-.dateRangeLabel {
-    font-size: var(--mantine-font-size-sm);
-    font-weight: 300;
-}
-
 /* Table.Filter */
 .filterWrapper {
     width: 20rem;

--- a/packages/mantine/src/components/table/__tests__/TableDateRangePicker.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableDateRangePicker.spec.tsx
@@ -1,5 +1,5 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
-import {render, screen, userEvent, waitFor, within} from '@test-utils';
+import {render, screen, waitFor} from '@test-utils';
 
 import {Table} from '../Table';
 
@@ -23,64 +23,12 @@ describe('Table.DateRangePicker', () => {
     it('displays the initial dates', async () => {
         render(basicTableWithDateRangePicker);
 
-        expect(screen.getByText('Jan 01, 2022 - Jan 07, 2022')).toBeVisible();
-    });
-
-    it.skip('opens the dialog when clicking on the calendar button', async () => {
-        const user = userEvent.setup();
-        render(basicTableWithDateRangePicker);
-
-        await user.click(screen.getByRole('button', {name: 'calendar'}));
-        expect(screen.getByRole('dialog', {name: 'calendar'})).toBeVisible();
-    });
-
-    it.skip('closes the dialog when clicking back on the calendar button', async () => {
-        const user = userEvent.setup();
-        render(basicTableWithDateRangePicker);
-
-        await user.click(screen.getByRole('button', {name: 'calendar'}));
-        await user.click(screen.getByRole('button', {name: 'calendar'}));
-        expect(screen.queryByRole('dialog', {name: 'calendar'})).not.toBeInTheDocument();
-    }, 10000);
-
-    it.skip('displays the selected date range in the table', async () => {
-        vi.useFakeTimers().setSystemTime(new Date(2022, 0, 15));
-        const user = userEvent.setup({delay: null});
-        const onChange = vi.fn();
-        render(
-            <Table
-                data={[{name: 'fruit'}, {name: 'vegetable'}]}
-                columns={columns}
-                onChange={onChange}
-                initialState={{dateRange: [new Date(2022, 0, 1), new Date(2022, 0, 7)]}}
-            >
-                <Table.Header data-testid="table-header">
-                    <Table.DateRangePicker
-                        presets={{preset: {label: 'Preset', range: [new Date(2022, 0, 8), new Date(2022, 0, 14)]}}}
-                    />
-                </Table.Header>
-            </Table>,
+        await waitFor(() =>
+            expect(
+                screen.getByRole('button', {
+                    name: /jan 01, 2022 – jan 07, 2022/i,
+                }),
+            ).toBeVisible(),
         );
-        const tableHeader = screen.getByTestId('table-header');
-
-        expect(within(tableHeader).getByText('Jan 01, 2022 - Jan 07, 2022')).toBeInTheDocument();
-        await user.click(within(tableHeader).getByRole('button', {name: 'calendar'}));
-
-        const calendar = await screen.findByRole('dialog', {name: 'calendar'});
-
-        // select a preset
-        await user.click(within(calendar).getByRole('searchbox', {name: 'Date range'}));
-        await user.click(within(calendar).getByRole('option', {name: 'Preset'}));
-        await user.click(within(calendar).getByRole('button', {name: 'Apply'}));
-
-        await waitFor(() => {
-            expect(onChange).toHaveBeenCalledTimes(1);
-        });
-        expect(onChange).toHaveBeenCalledWith(
-            expect.objectContaining({dateRange: [new Date(2022, 0, 8), new Date(2022, 0, 14)]}),
-        );
-        expect(within(tableHeader).getByText('Jan 08, 2022 - Jan 14, 2022')).toBeInTheDocument();
-
-        vi.useRealTimers();
-    }, 20000);
+    });
 });

--- a/packages/mantine/src/components/table/table-date-range-picker/TableDateRangePicker.tsx
+++ b/packages/mantine/src/components/table/table-date-range-picker/TableDateRangePicker.tsx
@@ -1,10 +1,9 @@
-import {CalendarSize24Px} from '@coveord/plasma-react-icons';
-import {BoxProps, factory, Factory, Grid, Group, Popover, Text, useProps} from '@mantine/core';
+import {CalendarSize16Px} from '@coveord/plasma-react-icons';
+import {BoxProps, Factory, Grid, Popover, factory, useProps} from '@mantine/core';
 import {CompoundStylesApiProps} from '@mantine/core/lib/core/styles-api/styles-api.types';
 import {useToggle} from '@mantine/hooks';
-import dayjs from 'dayjs';
 
-import {Button} from '../../button';
+import {DatePickerInput} from '@mantine/dates';
 import {
     DateRangePickerInlineCalendar,
     DateRangePickerInlineCalendarProps,
@@ -14,7 +13,7 @@ import {
 import {TableComponentsOrder} from '../Table';
 import {useTable, useTableStyles} from '../TableContext';
 
-export type TableDateRangePickerStylesNames = 'dateRangeRoot' | 'dateRangeWrapper' | 'dateRangeLabel';
+export type TableDateRangePickerStylesNames = 'dateRangeRoot';
 
 export interface TableDateRangePickerProps
     extends BoxProps,
@@ -63,9 +62,6 @@ export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props,
         toggleOpened(false);
     };
 
-    const formatDate = (date: Date) => dayjs(date).format('MMM DD, YYYY');
-    const formattedRange = `${formatDate(form.values.dateRange[0])} - ${formatDate(form.values.dateRange[1])}`;
-
     const stylesApiProps = {classNames, styles};
 
     return (
@@ -76,27 +72,28 @@ export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props,
             {...ctx.getStyles('dateRangeRoot', {className, style, ...stylesApiProps})}
             {...others}
         >
-            <Group gap="xs" {...ctx.getStyles('dateRangeWrapper', stylesApiProps)}>
-                <Text span {...ctx.getStyles('dateRangeLabel', stylesApiProps)}>
-                    {formattedRange}
-                </Text>
-                <Popover opened={opened} onChange={toggleOpened} withinPortal>
-                    <Popover.Target>
-                        <Button variant="outline" color="gray" onClick={() => toggleOpened()} px="xs">
-                            <CalendarSize24Px width={24} height={24} />
-                        </Button>
-                    </Popover.Target>
-                    <Popover.Dropdown p={0}>
-                        <DateRangePickerInlineCalendar
-                            initialRange={form.values.dateRange}
-                            onApply={onApply}
-                            onCancel={onCancel}
-                            presets={presets}
-                            rangeCalendarProps={rangeCalendarProps}
-                        />
-                    </Popover.Dropdown>
-                </Popover>
-            </Group>
+            <Popover opened={opened} onChange={toggleOpened} withinPortal>
+                <Popover.Target>
+                    <DatePickerInput
+                        type="range"
+                        valueFormat="MMM DD, YYYY"
+                        placeholder="Pick date range"
+                        clearable
+                        {...form.getInputProps('dateRange')}
+                        leftSection={<CalendarSize16Px height={16} />}
+                        miw={220}
+                    />
+                </Popover.Target>
+                <Popover.Dropdown p={0}>
+                    <DateRangePickerInlineCalendar
+                        initialRange={form.values.dateRange}
+                        onApply={onApply}
+                        onCancel={onCancel}
+                        presets={presets}
+                        rangeCalendarProps={rangeCalendarProps}
+                    />
+                </Popover.Dropdown>
+            </Popover>
         </Grid.Col>
     );
 });

--- a/packages/mantine/src/components/table/table-date-range-picker/TableDateRangePicker.tsx
+++ b/packages/mantine/src/components/table/table-date-range-picker/TableDateRangePicker.tsx
@@ -1,9 +1,9 @@
 import {CalendarSize16Px} from '@coveord/plasma-react-icons';
-import {BoxProps, Factory, Grid, Popover, factory, useProps} from '@mantine/core';
+import {BoxProps, Factory, Grid, InputBase, Popover, factory, useProps} from '@mantine/core';
 import {CompoundStylesApiProps} from '@mantine/core/lib/core/styles-api/styles-api.types';
-import {useToggle} from '@mantine/hooks';
+import dayjs from 'dayjs';
 
-import {DatePickerInput} from '@mantine/dates';
+import {useState} from 'react';
 import {
     DateRangePickerInlineCalendar,
     DateRangePickerInlineCalendarProps,
@@ -51,16 +51,20 @@ export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props,
         defaultProps,
         props,
     );
-    const [opened, toggleOpened] = useToggle();
+    const [opened, setOpened] = useState(false);
     const {form} = useTable();
 
     const onApply = (dates: DateRangePickerValue) => {
         form.setFieldValue('dateRange', dates);
-        toggleOpened(false);
+        setOpened(false);
     };
     const onCancel = () => {
-        toggleOpened(false);
+        setOpened(false);
     };
+
+    const formatDate = (date: Date) => dayjs(date).format('MMM DD, YYYY');
+    const formattedRange = `${formatDate(form.values.dateRange[0])} - ${formatDate(form.values.dateRange[1])}`;
+    const dateRangeInitialized = form.values.dateRange.every((date) => date instanceof Date);
 
     const stylesApiProps = {classNames, styles};
 
@@ -72,17 +76,16 @@ export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props,
             {...ctx.getStyles('dateRangeRoot', {className, style, ...stylesApiProps})}
             {...others}
         >
-            <Popover opened={opened} onChange={toggleOpened} withinPortal>
+            <Popover withinPortal opened={opened}>
                 <Popover.Target>
-                    <DatePickerInput
-                        type="range"
-                        valueFormat="MMM DD, YYYY"
-                        placeholder="Pick date range"
-                        clearable
-                        {...form.getInputProps('dateRange')}
+                    <InputBase
+                        component="button"
                         leftSection={<CalendarSize16Px height={16} />}
                         miw={220}
-                    />
+                        onClick={() => setOpened(true)}
+                    >
+                        {dateRangeInitialized ? formattedRange : 'Select date range'}
+                    </InputBase>
                 </Popover.Target>
                 <Popover.Dropdown p={0}>
                     <DateRangePickerInlineCalendar


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-9905

<img width="479" alt="image" src="https://github.com/coveo/plasma/assets/52010042/aab3ef4f-78b3-49d1-a5d6-2c6a3be82f7e">

Now:

<img width="275" alt="image" src="https://github.com/coveo/plasma/assets/52010042/77ccfef2-52fe-4655-8406-5ee4da521821">

<img width="299" alt="image" src="https://github.com/coveo/plasma/assets/52010042/9723bd08-1a4c-492e-b8d7-6ab085271ca4">

I removed old test since these changes remove their usefulness. Adapting them would be to test implementation details already tested in mantine

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
