### PR TITLE
fix(mantine, code editor): scrollbar z-index

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.module.css
+++ b/packages/mantine/src/components/code-editor/CodeEditor.module.css
@@ -1,14 +1,16 @@
 .editor {
     border: 1px solid var(--mantine-color-gray-3);
     border-radius: var(--mantine-radius-default);
+    z-index: 1;
+    height: 100%;
+    outline-width: thin;
+
     @mixin light {
         background-color: var(--mantine-color-white);
     }
     @mixin dark {
         background-color: var(--mantine-color-black);
     }
-    height: 100%;
-    outline-width: thin;
 }
 
 .valid {


### PR DESCRIPTION
### Proposed Changes

Changed the z-index of the CodeEditor

Before:
<img width="588" alt="image" src="https://github.com/coveo/plasma/assets/260007/925c3ec2-f712-471c-b4b4-71e5c63c4622">

After:
<img width="581" alt="image" src="https://github.com/coveo/plasma/assets/260007/48496c3c-abef-4eca-bef6-30746ebc9c96">


### Potential Breaking Changes

None