### PR TITLE
feat(header): +content variant +example

### DIFF
--- a/packages/mantine/src/components/header/Header.module.css
+++ b/packages/mantine/src/components/header/Header.module.css
@@ -1,5 +1,5 @@
 .root {
-    &[data-variant='page'] {
+    &[data-variant='primary'] {
         padding: var(--mantine-spacing-xl);
         padding-bottom: var(--mantine-spacing-lg);
     }
@@ -11,7 +11,7 @@
 
 .title {
     word-break: break-word;
-    &[data-variant='page'] {
+    &[data-variant='primary'] {
         color: var(--mantine-color-gray-5);
     }
     line-height: var(--mantine-line-height-md);

--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -12,11 +12,11 @@ import {
     useStyles,
 } from '@mantine/core';
 import {Children, ReactElement, ReactNode} from 'react';
+import {HeaderProvider} from './Header.context';
 import classes from './Header.module.css';
 import {HeaderActions, HeaderActionsStyleNames} from './HeaderActions/HeaderActions';
 import {HeaderBreadcrumbs, HeaderBreadcrumbsStyleNames} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
 import {HeaderDocAnchor, HeaderDocAnchorStyleNames} from './HeaderDocAnchor/HeaderDocAnchor';
-import {HeaderProvider} from './Header.context';
 
 export type {HeaderActionsProps} from './HeaderActions/HeaderActions';
 export type {HeaderBreadcrumbsProps} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
@@ -46,7 +46,7 @@ export interface HeaderProps extends StylesApiProps<HeaderFactory>, Omit<GroupPr
      *
      * @default 'page'
      */
-    variant?: 'page' | 'modal';
+    variant?: 'page' | 'modal' | 'content';
     /**
      * The title of the header.
      */

--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -42,7 +42,7 @@ export interface HeaderProps extends StylesApiProps<HeaderFactory>, Omit<GroupPr
      */
     borderBottom?: boolean;
     /**
-     * Use the modal variant when displaying the header inside a modal
+     * Use the secondary variant when displaying the header not at the top of the page
      *
      * @default 'primary'
      */

--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -22,7 +22,7 @@ export type {HeaderActionsProps} from './HeaderActions/HeaderActions';
 export type {HeaderBreadcrumbsProps} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
 export type {HeaderDocAnchorProps} from './HeaderDocAnchor/HeaderDocAnchor';
 
-export type HeaderVariant = 'page' | 'modal';
+export type HeaderVariant = 'primary' | 'secondary';
 export type HeaderStyleNames =
     | 'root'
     | 'title'
@@ -44,9 +44,9 @@ export interface HeaderProps extends StylesApiProps<HeaderFactory>, Omit<GroupPr
     /**
      * Use the modal variant when displaying the header inside a modal
      *
-     * @default 'page'
+     * @default 'primary'
      */
-    variant?: 'page' | 'modal' | 'content';
+    variant?: 'primary' | 'secondary';
     /**
      * The title of the header.
      */
@@ -66,7 +66,7 @@ export type HeaderFactory = Factory<{
 }>;
 
 const defaultProps: Partial<HeaderProps> = {
-    variant: 'page',
+    variant: 'primary',
     justify: 'space-between',
     wrap: 'nowrap',
 };
@@ -111,11 +111,15 @@ export const Header = factory<HeaderFactory>((_props, ref) => {
             <Group ref={ref} variant={variant} {...getStyles('root')} {...others}>
                 <Stack gap={0}>
                     {breadcrumbs}
-                    <Title variant={variant} order={variant === 'page' ? 1 : 3} {...getStyles('title', stylesApiProps)}>
+                    <Title
+                        variant={variant}
+                        order={variant === 'primary' ? 1 : 3}
+                        {...getStyles('title', stylesApiProps)}
+                    >
                         {otherChildren}
                         {docAnchor}
                     </Title>
-                    <Text {...getStyles('description', stylesApiProps)} size={variant === 'page' ? 'md' : 'sm'}>
+                    <Text {...getStyles('description', stylesApiProps)} size={variant === 'primary' ? 'md' : 'sm'}>
                         {description}
                     </Text>
                 </Stack>

--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -42,7 +42,7 @@ export interface HeaderProps extends StylesApiProps<HeaderFactory>, Omit<GroupPr
      */
     borderBottom?: boolean;
     /**
-     * Use the secondary variant when displaying the header not at the top of the page
+     * Use the primary variant for page header and secondary variant elsewhere
      *
      * @default 'primary'
      */

--- a/packages/mantine/src/components/header/__tests__/Header.spec.tsx
+++ b/packages/mantine/src/components/header/__tests__/Header.spec.tsx
@@ -12,7 +12,7 @@ describe('Header', () => {
           <h1
             class="_root_4eabcc _title_69e643 mantine-PlasmaHeader-title m-8a5d1357 mantine-Title-root"
             data-order="1"
-            data-variant="page"
+            data-variant="primary"
             style="--title-fw: var(--mantine-h1-font-weight); --title-lh: var(--mantine-h1-line-height); --title-fz: var(--mantine-h1-font-size);"
           >
             child

--- a/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/mantine/src/components/header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`Header > renders the specified breadcrumbs above the title 1`] = `
   </style>
   <div
     class="_root_69e643 mantine-PlasmaHeader-root m-4081bf90 mantine-Group-root"
-    data-variant="page"
+    data-variant="primary"
     style="--group-gap: var(--mantine-spacing-md); --group-align: center; --group-justify: space-between; --group-wrap: nowrap;"
   >
     <div
@@ -62,7 +62,7 @@ exports[`Header > renders the specified breadcrumbs above the title 1`] = `
       <h1
         class="_root_4eabcc _title_69e643 mantine-PlasmaHeader-title m-8a5d1357 mantine-Title-root"
         data-order="1"
-        data-variant="page"
+        data-variant="primary"
         style="--title-fw: var(--mantine-h1-font-weight); --title-lh: var(--mantine-h1-line-height); --title-fz: var(--mantine-h1-font-size);"
       >
         Title

--- a/packages/website/src/examples/layout/Header/HeaderContent.demo.tsx
+++ b/packages/website/src/examples/layout/Header/HeaderContent.demo.tsx
@@ -1,0 +1,9 @@
+import {Header} from '@coveord/plasma-mantine';
+
+const Demo = () => (
+    <Header variant="content" description="This is a description">
+        Title
+        <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
+    </Header>
+);
+export default Demo;

--- a/packages/website/src/examples/layout/Header/HeaderContent.demo.tsx
+++ b/packages/website/src/examples/layout/Header/HeaderContent.demo.tsx
@@ -1,9 +1,0 @@
-import {Header} from '@coveord/plasma-mantine';
-
-const Demo = () => (
-    <Header variant="content" description="This is a description">
-        Title
-        <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
-    </Header>
-);
-export default Demo;

--- a/packages/website/src/examples/layout/Header/HeaderSecondary.demo.tsx
+++ b/packages/website/src/examples/layout/Header/HeaderSecondary.demo.tsx
@@ -1,7 +1,7 @@
 import {CloseButton, Header} from '@coveord/plasma-mantine';
 
 const Demo = () => (
-    <Header variant="modal">
+    <Header variant="secondary">
         Title
         <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
         <Header.Actions>

--- a/packages/website/src/examples/layout/Modal/Modal.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/Modal.demo.tsx
@@ -10,7 +10,7 @@ const Demo = () => {
                 size="md"
                 opened={opened}
                 title={
-                    <Header variant="modal" description="Modal description">
+                    <Header variant="primary" description="Modal description">
                         Modal Title
                         <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
                     </Header>

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
@@ -10,7 +10,7 @@ const Demo = () => {
                 <Modal.Content>
                     <Modal.Header style={{borderBottom: 'none'}}>
                         <Modal.Title>
-                            <Header variant="modal" description="Modal description">
+                            <Header variant="secondary" description="Modal description">
                                 Modal Title
                                 <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
                             </Header>

--- a/packages/website/src/pages/layout/Header.tsx
+++ b/packages/website/src/pages/layout/Header.tsx
@@ -1,7 +1,5 @@
 import {HeaderMetadata} from '@coveord/plasma-components-props-analyzer';
 import HeaderDemo from '@examples/layout/Header/Header.demo?demo';
-import HeaderContentDemo from '@examples/layout/Header/HeaderContent.demo?demo';
-import HeaderModalDemo from '@examples/layout/Header/HeaderModal.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -16,8 +14,7 @@ export default () => (
         propsMetadata={HeaderMetadata}
         demo={<HeaderDemo />}
         examples={{
-            modalVariant: <HeaderModalDemo grow title="Modal variant" />,
-            contentVariant: <HeaderContentDemo grow title="Content variant" />,
+            secondaryVariant: <HeaderSecondaryDemo grow title="Secondary variant" />,
         }}
     />
 );

--- a/packages/website/src/pages/layout/Header.tsx
+++ b/packages/website/src/pages/layout/Header.tsx
@@ -1,5 +1,6 @@
 import {HeaderMetadata} from '@coveord/plasma-components-props-analyzer';
 import HeaderDemo from '@examples/layout/Header/Header.demo?demo';
+import HeaderSecondaryDemo from '@examples/layout/Header/HeaderSecondary.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 

--- a/packages/website/src/pages/layout/Header.tsx
+++ b/packages/website/src/pages/layout/Header.tsx
@@ -1,5 +1,6 @@
 import {HeaderMetadata} from '@coveord/plasma-components-props-analyzer';
 import HeaderDemo from '@examples/layout/Header/Header.demo?demo';
+import HeaderContentDemo from '@examples/layout/Header/HeaderContent.demo?demo';
 import HeaderModalDemo from '@examples/layout/Header/HeaderModal.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -16,6 +17,7 @@ export default () => (
         demo={<HeaderDemo />}
         examples={{
             modalVariant: <HeaderModalDemo grow title="Modal variant" />,
+            contentVariant: <HeaderContentDemo grow title="Content variant" />,
         }}
     />
 );


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-9094

This just adds another variant to the Header component. For now it is really dry, in fact the same as the modal variant, but now from within our code, we will use a relevant variant name + if we want to change the content variant visual, we could do so with module.css or other way, separating modal and content variants.

Also, nothing prevents the dev from putting any actions or breadcrumbs in that content variant, opening the possibility of creating a pretty intense header loop of stuff. (more an FYI than actual warning)

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
