### PR TITLE
fix(style): add missing reset rules to reset.css

### DIFF
--- a/packages/mantine/src/components/table/__tests__/TableDateRangePicker.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableDateRangePicker.spec.tsx
@@ -1,5 +1,5 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
-import {render, screen, waitFor} from '@test-utils';
+import {render, screen} from '@test-utils';
 
 import {Table} from '../Table';
 
@@ -23,12 +23,10 @@ describe('Table.DateRangePicker', () => {
     it('displays the initial dates', async () => {
         render(basicTableWithDateRangePicker);
 
-        await waitFor(() =>
-            expect(
-                screen.getByRole('button', {
-                    name: /jan 01, 2022 – jan 07, 2022/i,
-                }),
-            ).toBeVisible(),
-        );
+        expect(
+            screen.getByRole('button', {
+                name: /jan 01, 2022 \- jan 07, 2022/i,
+            }),
+        ).toBeVisible();
     });
 });

--- a/packages/style/scss/lib/reset.scss
+++ b/packages/style/scss/lib/reset.scss
@@ -159,3 +159,60 @@ button {
     border: none;
     border-radius: 0;
 }
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+pre {
+    font-family: monospace; /* 1 */
+    font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+b,
+strong {
+    font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+    font-family: monospace; /* 1 */
+    font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+    font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+sub,
+sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+}
+
+sub {
+    bottom: -0.25em;
+}
+
+sup {
+    top: -0.5em;
+}


### PR DESCRIPTION
### Proposed Changes

HTML tags like `<b>` or `<strong>` that inherently imply css style (`font-weight: bold` in this case) would not work anymore. This is due to the fact that Mantine version 6 would import [normalize.css](https://necolas.github.io/normalize.css/) and they stopped doing that in version 7. 

In this PR, I cherry picked some of the normalize.css that make sense for us and added them in the existing `reset.scss` file of the plasma-style package.

You can test it out in the demo, by editing the HTML somewhere to add a `<b>` tag around text. It should make it bold, while before on the branch `next` it would not. On `master` branch it does work.


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
