### PR TITLE
refactor(mantine): remove admin-ui specific styles from the theme

### DIFF
--- a/packages/mantine/src/styles/ScrollArea.module.css
+++ b/packages/mantine/src/styles/ScrollArea.module.css
@@ -1,5 +1,5 @@
 .viewport {
-    /* https://github.com/radix-ui/primitives/issues/926*/
+    /* https://github.com/radix-ui/primitives/issues/926 */
     &[data-radix-scroll-area-viewport] {
         & > :first-of-type {
             display: block !important;

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -17,7 +17,6 @@ import {
     InputWrapper,
     List,
     Loader,
-    LoadingOverlay,
     MantineThemeOverride,
     MenuItem,
     Modal,
@@ -178,9 +177,6 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 role: 'presentation',
             },
         }),
-        LoadingOverlay: LoadingOverlay.extend({
-            defaultProps: {zIndex: 1400},
-        }),
         List: List.extend({
             classNames: {root: ListClasses.root},
         }),
@@ -221,7 +217,6 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             defaultProps: {
                 shadow: 'md',
                 withArrow: true,
-                zIndex: 1300,
             },
         }),
         Radio: Radio.extend({


### PR DESCRIPTION
### Proposed Changes

Some styles in the plasmantine theme were solving very specific problems that only the admin console app has. These styles have been moved inside the app's repository so it is safe to remove from the main theme.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
