### PR TITLE
fix(mantine,table): table header alignment issues

### DIFF
--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -35,8 +35,7 @@
 .headerRoot {
     border-bottom: 1px solid var(--mantine-color-gray-3);
     background-color: var(--mantine-color-gray-1);
-    padding-left: var(--mantine-spacing-xl);
-    padding-right: var(--mantine-spacing-lg);
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-xl);
     position: relative;
 }
 

--- a/packages/mantine/src/components/table/table-column/TableCollapsibleColumn.tsx
+++ b/packages/mantine/src/components/table/table-column/TableCollapsibleColumn.tsx
@@ -11,7 +11,7 @@ const sharedProps: ColumnDef<unknown> = {
     id: 'collapsible',
     enableSorting: false,
     header: '',
-    size: 62,
+    size: 84, // 16px padding left + 28px ActionIcon + 40px padding right
 };
 
 /**

--- a/packages/mantine/src/components/table/table-header/TableHeader.tsx
+++ b/packages/mantine/src/components/table/table-header/TableHeader.tsx
@@ -43,13 +43,7 @@ export const TableHeader = factory<TableHeaderFactory>((props, ref) => {
     const gridStyles = ctx.getStyles('headerGrid', stylesApiProps);
 
     return (
-        <Box
-            py="sm"
-            px="lg"
-            ref={ref}
-            {...ctx.getStyles('headerRoot', {className, style, ...stylesApiProps})}
-            {...others}
-        >
+        <Box ref={ref} {...ctx.getStyles('headerRoot', {className, style, ...stylesApiProps})} {...others}>
             <Grid
                 justify="flex-start"
                 align="center"


### PR DESCRIPTION
### Proposed Changes

Fixing some alignment issues with the table header and collapsible column.

| Before | After |
| --- | --- |
| <img width="529" alt="image" src="https://github.com/coveo/plasma/assets/35579930/529315cc-d1eb-426c-97fa-aeafb161b60e"> | <img width="531" alt="image" src="https://github.com/coveo/plasma/assets/35579930/61b11da5-027c-4d8f-9283-4443286d75e2"> |


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
