### PR TITLE
fix(mantine): adjust Alert visual look

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -336,6 +336,10 @@ const components: Component[] = [
         name: 'InlineConfirm',
         packageName: '@coveord/plasma-mantine',
     },
+    {
+        name: 'Alert',
+        packageName: '@coveord/plasma-mantine',
+    },
 ];
 
 export default components;

--- a/packages/mantine/src/styles/Alert.module.css
+++ b/packages/mantine/src/styles/Alert.module.css
@@ -1,3 +1,30 @@
+.root {
+    padding: var(--mantine-spacing-sm);
+}
+
+.wrapper {
+    gap: var(--mantine-spacing-sm);
+}
+
 .title {
-    font-weight: var(--font-weight-medium);
+    font-weight: 500;
+}
+
+.icon {
+    width: 16px;
+    height: 16px;
+    margin-right: 0;
+}
+
+.message {
+    @mixin light {
+        color: var(--mantine-color-gray-7);
+        &:where([data-variant='filled']) {
+            color: var(--alert-color);
+        }
+    }
+
+    &:where([data-variant='white']) {
+        color: var(--mantine-color-black);
+    }
 }

--- a/packages/mantine/src/styles/Alert.module.css
+++ b/packages/mantine/src/styles/Alert.module.css
@@ -1,5 +1,8 @@
 .root {
     padding: var(--mantine-spacing-sm);
+    &:not(&[data-variant]) {
+        border-color: color-mix(in srgb, var(--alert-color), var(--alert-bg) 85%);
+    }
 }
 
 .wrapper {

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -4,6 +4,7 @@ import {
     CheckSize16Px,
     CrossSize16Px,
     FilterSize16Px,
+    InfoSize16Px,
     InfoSize24Px,
 } from '@coveord/plasma-react-icons';
 import {color} from '@coveord/plasma-tokens';
@@ -116,10 +117,10 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         }),
         Alert: Alert.extend({
             defaultProps: {
-                icon: <InfoSize24Px height={24} />,
+                icon: <InfoSize16Px height={16} />,
                 color: 'navy',
             },
-            classNames: {title: AlertClasses.title},
+            classNames: AlertClasses,
         }),
         Anchor: Anchor.extend({
             defaultProps: {

--- a/packages/website/src/Navigation.tsx
+++ b/packages/website/src/Navigation.tsx
@@ -122,6 +122,9 @@ const MantineNavigation = () => (
                 <InternalNavLink to="/form/CopyToClipboard" label="Copy to Clipboard" />
                 <InternalNavLink to="/form/InlineConfirm" label="Inline confirm" />
             </NavLink>
+            <NavLink label="Feedback" leftSection={<AnnouncementSize16Px height={16} />} defaultOpened>
+                <InternalNavLink to="/feedback/Alert" label="Alert" />
+            </NavLink>
             <NavLink label="Mantine" leftSection={<Image src={MantineLogo} height={16} />} defaultOpened>
                 {Object.keys(mantinePages).map((filePath) => {
                     const parts = filePath.split('/');

--- a/packages/website/src/building-blocs/PageHeader.tsx
+++ b/packages/website/src/building-blocs/PageHeader.tsx
@@ -8,7 +8,7 @@ export interface PageHeaderProps {
     title: string;
     thumbnail?: TileProps['thumbnail'];
     description?: ReactNode;
-    section: 'Foundations' | 'Layout' | 'Form' | 'Navigation' | 'Feedback' | 'Advanced' | 'Mantine' | 'Feedbacl';
+    section: 'Foundations' | 'Layout' | 'Form' | 'Navigation' | 'Feedback' | 'Advanced' | 'Mantine';
     /**
      * Path to a relevant source file in the repo
      *

--- a/packages/website/src/building-blocs/PageHeader.tsx
+++ b/packages/website/src/building-blocs/PageHeader.tsx
@@ -8,7 +8,7 @@ export interface PageHeaderProps {
     title: string;
     thumbnail?: TileProps['thumbnail'];
     description?: ReactNode;
-    section: 'Foundations' | 'Layout' | 'Form' | 'Navigation' | 'Feedback' | 'Advanced' | 'Mantine';
+    section: 'Foundations' | 'Layout' | 'Form' | 'Navigation' | 'Feedback' | 'Advanced' | 'Mantine' | 'Feedbacl';
     /**
      * Path to a relevant source file in the repo
      *

--- a/packages/website/src/examples/feedback/alert/Alert.demo.tsx
+++ b/packages/website/src/examples/feedback/alert/Alert.demo.tsx
@@ -1,0 +1,9 @@
+import {Alert} from '@coveord/plasma-mantine';
+
+const Demo = () => (
+    <Alert title="Information" withCloseButton>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+    </Alert>
+);
+export default Demo;

--- a/packages/website/src/examples/feedback/alert/AlertCritical.demo.tsx
+++ b/packages/website/src/examples/feedback/alert/AlertCritical.demo.tsx
@@ -1,0 +1,10 @@
+import {Alert} from '@coveord/plasma-mantine';
+import {CriticalSize16Px} from '@coveord/plasma-react-icons';
+
+const Demo = () => (
+    <Alert title="Attention!" withCloseButton color="critical" icon={<CriticalSize16Px height={16} />}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+    </Alert>
+);
+export default Demo;

--- a/packages/website/src/examples/feedback/alert/AlertSuccess.demo.tsx
+++ b/packages/website/src/examples/feedback/alert/AlertSuccess.demo.tsx
@@ -1,0 +1,10 @@
+import {Alert} from '@coveord/plasma-mantine';
+import {CheckmarkSize16Px} from '@coveord/plasma-react-icons';
+
+const Demo = () => (
+    <Alert title="Congrats!" withCloseButton color="success" icon={<CheckmarkSize16Px height={16} />}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+    </Alert>
+);
+export default Demo;

--- a/packages/website/src/examples/feedback/alert/AlertTip.demo.tsx
+++ b/packages/website/src/examples/feedback/alert/AlertTip.demo.tsx
@@ -1,0 +1,10 @@
+import {Alert} from '@coveord/plasma-mantine';
+import {TipSize16Px} from '@coveord/plasma-react-icons';
+
+const Demo = () => (
+    <Alert title="Tip" withCloseButton color="gray" icon={<TipSize16Px height={16} />}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+    </Alert>
+);
+export default Demo;

--- a/packages/website/src/examples/feedback/alert/AlertWarning.demo.tsx
+++ b/packages/website/src/examples/feedback/alert/AlertWarning.demo.tsx
@@ -1,0 +1,10 @@
+import {Alert} from '@coveord/plasma-mantine';
+import {WarningSize16Px} from '@coveord/plasma-react-icons';
+
+const Demo = () => (
+    <Alert title="Warning!" withCloseButton color="warning" icon={<WarningSize16Px height={16} />}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+    </Alert>
+);
+export default Demo;

--- a/packages/website/src/pages/feedback/Alert.tsx
+++ b/packages/website/src/pages/feedback/Alert.tsx
@@ -1,0 +1,29 @@
+import {AlertMetadata} from '@coveord/plasma-components-props-analyzer';
+import AlertDemo from '@examples/feedback/alert/Alert.demo?demo';
+import AlertTipDemo from '@examples/feedback/alert/AlertTip.demo?demo';
+import AlertSuccessDemo from '@examples/feedback/alert/AlertSuccess.demo?demo';
+import AlertWarningDemo from '@examples/feedback/alert/AlertWarning.demo?demo';
+import AlertCriticalDemo from '@examples/feedback/alert/AlertCritical.demo?demo';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
+
+const AlertPage = () => (
+    <PageLayout
+        id="Alert"
+        title="Alert"
+        section="Feedback"
+        thumbnail="placeholder"
+        description="Attract user attention with important static message."
+        demo={<AlertDemo center />}
+        examples={{
+            tip: <AlertTipDemo center title="Tip" />,
+            success: <AlertSuccessDemo center title="Success" />,
+            warning: <AlertWarningDemo center title="Warning" />,
+            critical: <AlertCriticalDemo center title="Critical" />,
+        }}
+        sourcePath="/packages/mantine/src/components/button/Button.tsx"
+        propsMetadata={AlertMetadata}
+    />
+);
+
+export default AlertPage;

--- a/packages/website/src/pages/feedback/Alert.tsx
+++ b/packages/website/src/pages/feedback/Alert.tsx
@@ -21,7 +21,7 @@ const AlertPage = () => (
             warning: <AlertWarningDemo center title="Warning" />,
             critical: <AlertCriticalDemo center title="Critical" />,
         }}
-        sourcePath="/packages/mantine/src/components/button/Button.tsx"
+        sourcePath="/packages/mantine/src/styles/Alert.module.css"
         propsMetadata={AlertMetadata}
     />
 );


### PR DESCRIPTION
### Proposed Changes

Made some adjustments in the theme for the Alert component

- Icon should be 16px (was 20px)
- Space between icon and text should be 16px (was 24px)
- Padding around the alert should be 16px (was 24px)
- Content text should have color gray-7 (was gray-9)

| Before | After | Figma |
| --- | --- | --- |
| ![image](https://github.com/coveo/plasma/assets/35579930/f9d81ee6-2fbb-4e29-8393-55f1172bff94) | ![image](https://github.com/coveo/plasma/assets/35579930/81c52949-3a43-4ce7-9703-309e67eac39d) | ![image](https://github.com/coveo/plasma/assets/35579930/20628dff-59ce-418e-9ce6-b5ea039f65a1) |

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
