### PR TITLE
Fix Mantine react warnings

### DIFF
--- a/packages/mantine/src/components/inline-confirm/InlineConfirm.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirm.tsx
@@ -1,11 +1,10 @@
-import {factory, Factory, StylesApiProps, useProps} from '@mantine/core';
+import {Factory, StylesApiProps, useProps} from '@mantine/core';
+import {MantineComponent} from '@mantine/core/lib/core/factory/factory';
 import {Children, ReactElement, ReactNode, useState} from 'react';
 import {InlineConfirmProvider} from './InlineConfirmContext';
 import {InlineConfirmPrompt} from './InlineConfirmPrompt';
 
 import {InlineConfirmTarget} from './InlineConfirmTarget';
-
-export type InlineConfirmStyleNames = 'root';
 
 export interface InlineConfirmProps extends StylesApiProps<InlineConfirmFactory> {
     /**
@@ -17,7 +16,6 @@ export interface InlineConfirmProps extends StylesApiProps<InlineConfirmFactory>
 export type InlineConfirmFactory = Factory<{
     props: InlineConfirmProps;
     ref: never;
-    stylesNames: InlineConfirmStyleNames;
     staticComponents: {
         Prompt: typeof InlineConfirmPrompt;
         Target: typeof InlineConfirmTarget;
@@ -26,7 +24,7 @@ export type InlineConfirmFactory = Factory<{
 
 const defaultProps: Partial<InlineConfirmProps> = {};
 
-export const InlineConfirm = factory<InlineConfirmFactory>((_props) => {
+export const InlineConfirm = ((_props) => {
     const {children} = useProps('InlineConfirm', defaultProps, _props);
     const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
@@ -41,7 +39,7 @@ export const InlineConfirm = factory<InlineConfirmFactory>((_props) => {
             {prompt ?? children}
         </InlineConfirmProvider>
     );
-});
+}) as MantineComponent<InlineConfirmFactory>;
 
 InlineConfirm.Prompt = InlineConfirmPrompt;
 InlineConfirm.Target = InlineConfirmTarget;

--- a/packages/mantine/src/components/inline-confirm/__tests__/InlineConfirm.spec.tsx
+++ b/packages/mantine/src/components/inline-confirm/__tests__/InlineConfirm.spec.tsx
@@ -1,4 +1,4 @@
-import {Button, Menu, MenuItem} from '@mantine/core';
+import {Button, Menu} from '@mantine/core';
 import {render, screen, userEvent} from '@test-utils';
 
 import {InlineConfirm} from '../InlineConfirm';
@@ -36,7 +36,7 @@ describe('InlineConfirm', () => {
                         <button>open menu</button>
                     </Menu.Target>
                     <Menu.Dropdown>
-                        <InlineConfirm.Target component={MenuItem} id="delete" onClick={onClickSpy}>
+                        <InlineConfirm.Target component={Menu.Item} id="delete" onClick={onClickSpy}>
                             Delete
                         </InlineConfirm.Target>
                     </Menu.Dropdown>

--- a/packages/mantine/src/components/table/layouts/row-layout/RowLayoutHeader.tsx
+++ b/packages/mantine/src/components/table/layouts/row-layout/RowLayoutHeader.tsx
@@ -26,11 +26,8 @@ const defaultProps: Partial<RowLayoutHeaderProps<unknown>> = {};
 
 export const RowLayoutHeader = <T,>(props: RowLayoutHeaderProps<T> & {ref?: ForwardedRef<HTMLTableRowElement>}) => {
     const ctx = useRowLayout();
-    const {table, getExpandChildren, loading, className, style, classNames, styles, ...others} = useProps(
-        'RowLayoutHeader',
-        defaultProps as RowLayoutHeaderProps<T>,
-        props,
-    );
+    const {table, getExpandChildren, loading, doubleClickAction, className, style, classNames, styles, ...others} =
+        useProps('RowLayoutHeader', defaultProps as RowLayoutHeaderProps<T>, props);
     const {multiRowSelectionEnabled, disableRowSelection} = useTable();
 
     const headers = table.getHeaderGroups().map((headerGroup) => (

--- a/packages/website/src/examples/form/inline-confirm/InlineConfirmMenu.demo.tsx
+++ b/packages/website/src/examples/form/inline-confirm/InlineConfirmMenu.demo.tsx
@@ -1,5 +1,4 @@
-import {Button, InlineConfirm, showNotification} from '@coveord/plasma-mantine';
-import {Menu, MenuItem} from '@mantine/core';
+import {Button, InlineConfirm, Menu, showNotification} from '@coveord/plasma-mantine';
 
 const Demo = () => (
     <InlineConfirm>
@@ -8,8 +7,17 @@ const Demo = () => (
                 <Button>Menu</Button>
             </Menu.Target>
             <Menu.Dropdown>
-                <InlineConfirm.Target component={MenuItem} id="delete">
+                <InlineConfirm.Target component={Menu.Item} id="delete">
                     Delete
+                </InlineConfirm.Target>
+
+                <InlineConfirm.Target
+                    component={Menu.Item}
+                    id="delete2"
+                    disabled
+                    disabledTooltip="Will not trigger since its disabled"
+                >
+                    Delete 2
                 </InlineConfirm.Target>
             </Menu.Dropdown>
         </Menu>
@@ -18,6 +26,7 @@ const Demo = () => (
             onConfirm={() => showNotification({message: 'Confirm clicked', autoClose: true})}
             onCancel={() => showNotification({message: 'Cancel clicked', autoClose: true})}
         />
+        <InlineConfirm.Prompt id="delete2" />
     </InlineConfirm>
 );
 export default Demo;


### PR DESCRIPTION
### Proposed Changes

InlineConfirm: Stop using forwardRef on InlineConfirm via Mantine factory, react warns about it
Table: Do not spread doubleClickAction on RowLayoutHeader, react warns about it

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
