### PR TITLE
feat(mantine): add variant modal-footer to StickyFooter

### DIFF
--- a/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
@@ -9,3 +9,11 @@
 .border {
     border-top: 1px solid var(--mantine-color-gray-3);
 }
+
+.modalFooter {
+    padding-bottom: 0;
+    margin-top: var(--mb-padding);
+    margin-bottom: calc(var(--mantine-spacing-md) - var(--mb-padding));
+    margin-left: calc(-1 * var(--mb-padding));
+    margin-right: calc(-1 * var(--mb-padding));
+}

--- a/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
@@ -4,16 +4,17 @@
     z-index: 10;
     background-color: white;
     padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
+
+    &[data-variant='modal-footer'] {
+        border-top: 1px solid var(--mantine-color-gray-3);
+        padding-bottom: 0;
+        margin-top: var(--mb-padding);
+        margin-bottom: calc(var(--mantine-spacing-md) - var(--mb-padding));
+        margin-left: calc(-1 * var(--mb-padding));
+        margin-right: calc(-1 * var(--mb-padding));
+    }
 }
 
 .border {
     border-top: 1px solid var(--mantine-color-gray-3);
-}
-
-.modalFooter {
-    padding-bottom: 0;
-    margin-top: var(--mb-padding);
-    margin-bottom: calc(var(--mantine-spacing-md) - var(--mb-padding));
-    margin-left: calc(-1 * var(--mb-padding));
-    margin-right: calc(-1 * var(--mb-padding));
 }

--- a/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
@@ -4,7 +4,7 @@ import {ReactNode} from 'react';
 import classes from './StickyFooter.module.css';
 
 export interface StickyFooterProps
-    extends Omit<GroupProps, 'classNames' | 'styles' | 'vars'>,
+    extends Omit<GroupProps, 'classNames' | 'styles' | 'vars' | 'variant'>,
         StylesApiProps<StickyFooterFactory> {
     /**
      * Whether a border is render on top of the footer
@@ -14,6 +14,12 @@ export interface StickyFooterProps
      * Footer's children, usually buttons
      */
     children?: ReactNode;
+    /**
+     * Set this to `true` when rendering the `StickyFooter` inside `Modal`.
+     *
+     * When true, removes the modal's default padding so that the footer properly hugs the bottom of the modal.
+     */
+    removeModalPadding?: boolean;
 }
 
 export type StickyFooterStylesNames = 'root';
@@ -30,8 +36,20 @@ const defaultProps: Partial<StickyFooterProps> = {
 };
 
 export const StickyFooter = factory<StickyFooterFactory>((props, ref) => {
-    const {borderTop, justify, gap, children, className, classNames, style, styles, unstyled, vars, ...others} =
-        useProps('StickyFooter', defaultProps, props);
+    const {
+        borderTop,
+        removeModalPadding,
+        justify,
+        gap,
+        children,
+        className,
+        classNames,
+        style,
+        styles,
+        unstyled,
+        vars,
+        ...others
+    } = useProps('StickyFooter', defaultProps, props);
     const getStyles = useStyles<StickyFooterFactory>({
         name: 'StickyFooter',
         classes,
@@ -49,7 +67,10 @@ export const StickyFooter = factory<StickyFooterFactory>((props, ref) => {
         <Group
             justify={justify}
             gap={gap}
-            className={clsx(css.className, {[classes.border]: !!borderTop})}
+            className={clsx(css.className, {
+                [classes.border]: !!borderTop,
+                [classes.modalFooter]: !!removeModalPadding,
+            })}
             style={css.style}
             ref={ref}
             {...others}

--- a/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.tsx
@@ -15,11 +15,12 @@ export interface StickyFooterProps
      */
     children?: ReactNode;
     /**
-     * Set this to `true` when rendering the `StickyFooter` inside `Modal`.
+     * Use variant 'modal-footer' when rendering the `StickyFooter` inside `Modal`.
      *
-     * When true, removes the modal's default padding so that the footer properly hugs the bottom of the modal.
+     * The 'modal-footer' removes the modal's default padding so that the footer properly hugs the bottom of the modal.
+     * It also adds a border on top of the footer.
      */
-    removeModalPadding?: boolean;
+    variant?: 'default' | 'modal-footer';
 }
 
 export type StickyFooterStylesNames = 'root';
@@ -36,20 +37,8 @@ const defaultProps: Partial<StickyFooterProps> = {
 };
 
 export const StickyFooter = factory<StickyFooterFactory>((props, ref) => {
-    const {
-        borderTop,
-        removeModalPadding,
-        justify,
-        gap,
-        children,
-        className,
-        classNames,
-        style,
-        styles,
-        unstyled,
-        vars,
-        ...others
-    } = useProps('StickyFooter', defaultProps, props);
+    const {borderTop, justify, gap, children, className, classNames, style, styles, unstyled, vars, ...others} =
+        useProps('StickyFooter', defaultProps, props);
     const getStyles = useStyles<StickyFooterFactory>({
         name: 'StickyFooter',
         classes,
@@ -67,10 +56,7 @@ export const StickyFooter = factory<StickyFooterFactory>((props, ref) => {
         <Group
             justify={justify}
             gap={gap}
-            className={clsx(css.className, {
-                [classes.border]: !!borderTop,
-                [classes.modalFooter]: !!removeModalPadding,
-            })}
+            className={clsx(css.className, {[classes.border]: !!borderTop})}
             style={css.style}
             ref={ref}
             {...others}

--- a/packages/website/src/examples/layout/Modal/Modal.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/Modal.demo.tsx
@@ -10,7 +10,7 @@ const Demo = () => {
                 size="md"
                 opened={opened}
                 title={
-                    <Header variant="primary" description="Modal description">
+                    <Header variant="secondary" description="Modal description">
                         Modal Title
                         <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
                     </Header>
@@ -21,7 +21,7 @@ const Demo = () => {
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim. Phasellus
                 lacinia sem nunc, vel dapibus odio suscipit id. Aenean lobortis sollicitudin suscipit. Cras vitae ipsum
                 sit amet nibh efficitur imperdiet. Praesent scelerisque erat est. Cras dictum sodales tellus sed pretium
-                <StickyFooter p={0} pt="lg">
+                <StickyFooter borderTop removeModalPadding>
                     <Button variant="outline" onClick={() => setOpened(false)}>
                         Cancel
                     </Button>

--- a/packages/website/src/examples/layout/Modal/Modal.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/Modal.demo.tsx
@@ -21,7 +21,7 @@ const Demo = () => {
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim. Phasellus
                 lacinia sem nunc, vel dapibus odio suscipit id. Aenean lobortis sollicitudin suscipit. Cras vitae ipsum
                 sit amet nibh efficitur imperdiet. Praesent scelerisque erat est. Cras dictum sodales tellus sed pretium
-                <StickyFooter borderTop removeModalPadding>
+                <StickyFooter variant="modal-footer">
                     <Button variant="outline" onClick={() => setOpened(false)}>
                         Cancel
                     </Button>


### PR DESCRIPTION
### Proposed Changes

Currently, without going full blown modal compound components, there is no good way of having a border above the modal footer that stretches to the edges of the modal. This is because the footer is inside the modal body and that body has padding by default.

The solution I suggest is to add a new prop on the `StickyFooter` component called `removeModalPadding`. When true, this prop removes the modal's default padding so that the footer properly hugs the bottom of the modal. Making it easy for people to achieve the desired look without introducing any breaking change.

See first Modal example in the demo website

```
<StickyFooter borderTop removeModalPadding>
    <Button variant="outline" onClick={() => setOpened(false)}>
        Cancel
    </Button>
    <Button onClick={() => setOpened(false)}>Accept</Button>
</StickyFooter>
```

<img width="952" alt="image" src="https://github.com/coveo/plasma/assets/35579930/b304f2fe-c3a1-4106-a18f-ecde9137a780">


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
