### PR TITLE
fix(mantine, table): modify condition to determine page total

### DIFF
--- a/packages/mantine/src/components/table/__tests__/TablePagination.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TablePagination.spec.tsx
@@ -137,6 +137,28 @@ describe('Table.Pagination', () => {
         expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
     });
 
+    it('renders nothing if pages is null', () => {
+        render(
+            <Table data={[]} columns={columns} initialState={{globalFilter: 'filter'}}>
+                <Table.Footer data-testid="table-footer">
+                    <Table.Pagination totalPages={null} />
+                </Table.Footer>
+            </Table>,
+        );
+        expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing if pages is undefined', () => {
+        render(
+            <Table data={[]} columns={columns} initialState={{globalFilter: 'filter'}}>
+                <Table.Footer data-testid="table-footer">
+                    <Table.Pagination totalPages={undefined} />
+                </Table.Footer>
+            </Table>,
+        );
+        expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
+    });
+
     it('changes page when the current page is greater than the total number of pages', async () => {
         const user = userEvent.setup();
         const onChangePage = vi.fn();

--- a/packages/mantine/src/components/table/table-pagination/TablePagination.tsx
+++ b/packages/mantine/src/components/table/table-pagination/TablePagination.tsx
@@ -17,7 +17,7 @@ export const TablePagination: FunctionComponent<TablePaginationProps> = ({totalP
         containerRef.current.scrollIntoView({behavior: 'smooth'});
     };
 
-    const total = totalPages === null ? getPageCount() : totalPages;
+    const total = totalPages == null ? getPageCount() : totalPages;
 
     useDidUpdate(() => {
         if (state.pagination.pageIndex + 1 > total && total > 0) {


### PR DESCRIPTION
### Proposed Changes
Modified the code that determines the total amount of pages in `TablePagination` to also take into account the case where `totalPages` could be `undefined` and not just `null`.

See [comment](https://github.com/coveo-platform/admin-ui/pull/10735#discussion_r1578149562) for more details.

<!-- Explain what are your changes. -->

### Potential Breaking Changes
None

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
