### PR TITLE
fix(website): remove custom style with props and module css

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -230,7 +230,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         <Stack
             justify="flex-start"
             gap={0}
-            style={{height: Math.max(parentHeight, minHeight), maxHeight}}
+            h={{height: Math.max(parentHeight, minHeight), maxHeight}}
             ref={ref}
             {...others}
         >

--- a/packages/mantine/src/components/table/table-column/TableSelectableColumn.tsx
+++ b/packages/mantine/src/components/table/table-column/TableSelectableColumn.tsx
@@ -15,7 +15,7 @@ export const TableSelectableColumn: ColumnDef<unknown> = {
                     checked={table.getIsAllPageRowsSelected()}
                     indeterminate={table.getIsSomePageRowsSelected()}
                     onChange={table.getToggleAllPageRowsSelectedHandler()}
-                    style={{display: 'flex'}}
+                    flex={1}
                     aria-label={label}
                 />
             </Tooltip>
@@ -26,7 +26,7 @@ export const TableSelectableColumn: ColumnDef<unknown> = {
             checked={row.getIsSelected()}
             indeterminate={row.getIsSomeSelected()}
             onChange={row.getToggleSelectedHandler()}
-            style={{display: 'flex'}}
+            flex={1}
             aria-label="Select row"
         />
     ),

--- a/packages/website/src/TopBar.tsx
+++ b/packages/website/src/TopBar.tsx
@@ -5,16 +5,7 @@ import StandaloneSearchBar from './search/StandaloneSearchBar';
 import classes from './styles/TopBar.module.css';
 
 const TopBar = () => (
-    <Group
-        justify="space-between"
-        px="lg"
-        py="xs"
-        bg={
-            'linear-gradient(217deg, var(--mantine-color-purple-6) 0%, var(--mantine-color-navy-7) 74.62%, var(--mantine-color-navy-7) 100%)'
-        }
-        h="100%"
-        wrap="nowrap"
-    >
+    <Group justify="space-between" px="lg" py="xs" h="100%" wrap="nowrap" className={classes.topBar}>
         <div>
             <Image src={plasmaLogo} className="header-logo" height={80} fit="contain" alt="Plasma Design System" />
         </div>

--- a/packages/website/src/TopBar.tsx
+++ b/packages/website/src/TopBar.tsx
@@ -2,16 +2,17 @@ import {Group, Image} from '@coveord/plasma-mantine';
 import githubLogo from './assets/github-mark.svg';
 import plasmaLogo from './assets/plasma-logo.svg';
 import StandaloneSearchBar from './search/StandaloneSearchBar';
+import classes from './styles/TopBar.module.css';
 
 const TopBar = () => (
     <Group
         justify="space-between"
         px="lg"
         py="xs"
-        style={(theme) => ({
-            background: `linear-gradient(217deg, ${theme.colors.purple[6]} 0%, ${theme.colors.navy[7]} 74.62%, ${theme.colors.navy[7]} 100%)`,
-            height: '100%',
-        })}
+        bg={
+            'linear-gradient(217deg, var(--mantine-color-purple-6) 0%, var(--mantine-color-navy-7) 74.62%, var(--mantine-color-navy-7) 100%)'
+        }
+        h="100%"
         wrap="nowrap"
     >
         <div>
@@ -19,7 +20,7 @@ const TopBar = () => (
         </div>
         <StandaloneSearchBar />
         <a href="https://github.com/coveo/plasma#readme" aria-label="README" target="_blank">
-            <Image src={githubLogo} width={32} height={32} style={{filter: 'invert(1)'}} />
+            <Image src={githubLogo} width={32} height={32} className={classes.githubImage} />
         </a>
     </Group>
 );

--- a/packages/website/src/UnexpectedError.tsx
+++ b/packages/website/src/UnexpectedError.tsx
@@ -1,5 +1,6 @@
 import {Center, Code, Container, Stack, Text, Title} from '@coveord/plasma-mantine';
 import {useRouteError} from 'react-router-dom';
+import classes from './styles/UnexpectedError.module.css';
 
 export const UnexpectedError = () => {
     const error = useRouteError() as Error;
@@ -12,7 +13,7 @@ export const UnexpectedError = () => {
                     <Text size="sm">
                         <div>💥 An error occurred while rendering the page 👇</div>
                     </Text>
-                    <Code block style={{overflowWrap: 'break-word', whiteSpace: 'pre-wrap'}}>
+                    <Code block className={classes.code}>
                         {error.stack}
                     </Code>
                     <Text size="sm">

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -13,7 +13,7 @@ import {
 import {CheckSize16Px, CopySize16Px, PlaySize16Px} from '@coveord/plasma-react-icons';
 import {CodeHighlight} from '@mantine/code-highlight';
 import '@mantine/code-highlight/styles.css';
-import {ReactNode, Component} from 'react';
+import {Component, ReactNode} from 'react';
 import CodeHighlightClassesThemeClasses from '../styles/CodeHighlight.theme.module.css';
 import DemoClasses from './Demo.module.css';
 import getCodeSandboxLink from './getCodeSandboxLink';
@@ -48,24 +48,16 @@ const Demo = ({children, snippet, center = false, grow = false, title, layout, n
                 <ErrorBoundary>
                     <Box<'div' | typeof Center> component={center ? Center : 'div'} className={DemoClasses.preview}>
                         {maxHeight ? (
-                            <Flex direction={'column'} mah={maxHeight} style={{flex: 1}}>
-                                <div
-                                    className={DemoClasses.flexPreviewWrapper}
-                                    style={{padding: noPadding ? 0 : 'var(--mantine-spacing-md)'}}
-                                >
+                            <Flex direction={'column'} mah={maxHeight} flex={1}>
+                                <Box className={DemoClasses.flexPreviewWrapper} p={noPadding ? 0 : 'md'}>
                                     {children}
-                                </div>
+                                </Box>
                             </Flex>
                         ) : (
                             <ScrollArea.Autosize mah={MAX_HEIGHT}>
-                                <div
-                                    style={{
-                                        padding: noPadding ? 0 : 'var(--mantine-spacing-md)',
-                                        height: grow ? MAX_HEIGHT : '100%',
-                                    }}
-                                >
+                                <Box p={noPadding ? 0 : 'md'} h={grow ? MAX_HEIGHT : '100%'}>
                                     {children}
-                                </div>
+                                </Box>
                             </ScrollArea.Autosize>
                         )}
                     </Box>

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -27,6 +27,7 @@ interface DemoProps extends DemoComponentProps {
 }
 
 const Demo = ({children, snippet, center = false, grow = false, title, layout, noPadding, maxHeight}: DemoProps) => {
+    console.log(snippet);
     const clipboard = useClipboard();
     const createSandbox = async () => {
         try {

--- a/packages/website/src/building-blocs/Demo.tsx
+++ b/packages/website/src/building-blocs/Demo.tsx
@@ -27,7 +27,6 @@ interface DemoProps extends DemoComponentProps {
 }
 
 const Demo = ({children, snippet, center = false, grow = false, title, layout, noPadding, maxHeight}: DemoProps) => {
-    console.log(snippet);
     const clipboard = useClipboard();
     const createSandbox = async () => {
         try {

--- a/packages/website/src/building-blocs/PageHeader.tsx
+++ b/packages/website/src/building-blocs/PageHeader.tsx
@@ -39,7 +39,7 @@ export const PageHeader: FunctionComponent<PageHeaderProps> = ({
                         View source
                     </GithubButton>
                 )}
-                <Box style={{maxWidth: 264}}>
+                <Box maw={264}>
                     <Tile thumbnail={thumbnail} />
                 </Box>
             </Stack>

--- a/packages/website/src/building-blocs/ResultList.tsx
+++ b/packages/website/src/building-blocs/ResultList.tsx
@@ -1,12 +1,13 @@
 import {
     AtomicQuerySummary,
     AtomicSearchInterface,
-    Result,
-    loadClickAnalyticsActions,
     ResultList as HeadlessResultList,
+    Result,
     SearchEngine,
+    loadClickAnalyticsActions,
 } from '@coveo/atomic-react';
 import {Section} from '@coveord/plasma-react';
+import {Box} from '@mantine/core';
 import {FunctionComponent, useEffect, useState} from 'react';
 import {Tile, TileProps} from '../building-blocs/Tile';
 import {NoSearchResultTemplate} from '../search/NoSearchResult';
@@ -26,11 +27,11 @@ export const ResultList: FunctionComponent<ResultListProps> = ({controller, engi
     return (
         <>
             {!state.hasResults && !state.isLoading ? (
-                <div style={{width: '100%'}}>
+                <Box w="100%">
                     <AtomicSearchInterface engine={engine}>
                         <NoSearchResultTemplate engine={engine} query={query} />
                     </AtomicSearchInterface>
-                </div>
+                </Box>
             ) : (
                 <Section className="home flex-auto overflow-auto">
                     <Section className="section">

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreview.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreview.demo.tsx
@@ -33,7 +33,7 @@ const Demo = ({pageSize = 5, numberOfItems = 40}: DemoProps) => {
 
     return (
         <BrowserPreview>
-            <Stack style={{flexGrow: 1}}>
+            <Stack flex={1}>
                 <Stack gap="xl" pb="sm">
                     {data[page - 1].map((product) => (
                         <Stack gap={0}>
@@ -55,8 +55,8 @@ const Demo = ({pageSize = 5, numberOfItems = 40}: DemoProps) => {
                         </Stack>
                     ))}
                 </Stack>
-                <Flex align="flex-end" justify="center" style={{flexGrow: 1}}>
-                    <Pagination value={page} total={numberOfPages} onChange={setPage} style={{align: 'center'}} />
+                <Flex align="flex-end" justify="center" flex={1}>
+                    <Pagination value={page} total={numberOfPages} onChange={setPage} />
                 </Flex>
             </Stack>
         </BrowserPreview>

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewOverflow.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewOverflow.demo.tsx
@@ -6,9 +6,7 @@ const Demo = () => {
     return (
         <BrowserPreview>
             <Stack gap="xs">
-                <Title order={3} style={{align: 'center'}}>
-                    Hello World !
-                </Title>
+                <Title order={3}>Hello World !</Title>
                 <Text>{content}</Text>
             </Stack>
         </BrowserPreview>

--- a/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewWithTitleAndDescription.demo.tsx
+++ b/packages/website/src/examples/layout/BrowserPreview/BrowserPreviewWithTitleAndDescription.demo.tsx
@@ -7,9 +7,7 @@ const Demo = () => {
     return (
         <BrowserPreview title={title} headerTooltip="This is a custom tooltip message.">
             <Stack gap="xs">
-                <Title order={3} style={{align: 'center'}}>
-                    Hello World !
-                </Title>
+                <Title order={3}>Hello World !</Title>
                 <Text>{content}</Text>
             </Stack>
         </BrowserPreview>

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
@@ -2,6 +2,14 @@ import {Button, Header, Modal, StickyFooter, Tabs} from '@coveord/plasma-mantine
 import {useState} from 'react';
 import classes from './ModalWithTabs.module.css';
 
+/**
+import classes from ./ModalWithTabs.module.css
+ 
+.headerWithTabs {
+     border-bottom: none;
+};
+ */
+
 const Demo = () => {
     const [opened, setOpened] = useState(false);
     return (

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
@@ -1,5 +1,6 @@
 import {Button, Header, Modal, StickyFooter, Tabs} from '@coveord/plasma-mantine';
 import {useState} from 'react';
+import classes from './ModalWithTabs.module.css';
 
 const Demo = () => {
     const [opened, setOpened] = useState(false);
@@ -8,7 +9,7 @@ const Demo = () => {
             <Modal.Root opened={opened} onClose={() => setOpened(false)}>
                 <Modal.Overlay />
                 <Modal.Content>
-                    <Modal.Header style={{borderBottom: 'none'}}>
+                    <Modal.Header className={classes.headerWithTabs}>
                         <Modal.Title>
                             <Header variant="secondary" description="Modal description">
                                 Modal Title

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.module.css
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.module.css
@@ -1,0 +1,3 @@
+.headerWithTabs {
+    border-bottom: none;
+}

--- a/packages/website/src/styles/TopBar.module.css
+++ b/packages/website/src/styles/TopBar.module.css
@@ -1,0 +1,3 @@
+.githubImage {
+    filter: invert(1);
+}

--- a/packages/website/src/styles/TopBar.module.css
+++ b/packages/website/src/styles/TopBar.module.css
@@ -1,3 +1,11 @@
+.topBar {
+    background: linear-gradient(
+        217deg,
+        var(--mantine-color-purple-6) 0%,
+        var(--mantine-color-navy-7) 74.62%,
+        var(--mantine-color-navy-7) 100%
+    );
+}
 .githubImage {
     filter: invert(1);
 }

--- a/packages/website/src/styles/UnexpectedError.module.css
+++ b/packages/website/src/styles/UnexpectedError.module.css
@@ -1,0 +1,4 @@
+.code {
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/ADUI-9964

### Proposed Changes

Since our last big migration from mantine 6 -> 7, we also instaure good practices to standardize code throughout our products and also reduce the maintenance of our code.

One of these good practices is to stop using **custom style** from `style` and `styles` props and use module.css instead. From there, I noticed that our own plasma website has not been updated to follow this good practice.

This PR aims to fix that so devs who are consulting our plasma website have examples that reflect how we want to write style in components.

FYI. I have done only /website (and few easy changeable ones from our mantine package), but I have not done the changes from the example we pull from the mantine repo. These examples are the result of a fetch from the mantine's github repository and it would be hell to add extra work/code to fix all these

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
