### PR TITLE
fix(plasma-react, multiselect): fix margin for selected options

### DIFF
--- a/packages/style/scss/components/multiselect-input.scss
+++ b/packages/style/scss/components/multiselect-input.scss
@@ -28,6 +28,7 @@
 .selected-options-container {
     display: inline-flex;
     flex-flow: row wrap;
+    margin-bottom: $spacing;
 
     .selected-option,
     .sortable-selected-option {
@@ -53,14 +54,8 @@
 }
 
 .multiselect-empty {
-    margin-bottom: $spacing;
     color: var(--deprecated-medium-grey);
     line-height: $button-small-height + 2 * $button-border-width;
-}
-
-.selected-option:last-child,
-.sortable-selected-option:last-child {
-    margin-bottom: $spacing;
 }
 
 .remove-all-selected-options {

--- a/packages/website/src/examples/legacy/form/MultiSelect/main.demo.tsx
+++ b/packages/website/src/examples/legacy/form/MultiSelect/main.demo.tsx
@@ -3,6 +3,7 @@ import {MultiSelectConnected} from '@coveord/plasma-react';
 const Demo = () => (
     <MultiSelectConnected
         id="mutli-select-1"
+        multiSelectStyle={{width: '100%', maxWidth: '400px'}}
         items={[
             {value: 'one', displayValue: 'Option 1'},
             {value: 'two', displayValue: 'Option 2'},


### PR DESCRIPTION
### Proposed Changes

[SEARCHAPI-10134](https://coveord.atlassian.net/browse/SEARCHAPI-10134)

Adjust how the margin is handled for the selected options in the legacy plasma-react `MultiSelect` component.

**Before**

margin was set on the last selected option and on the empty placeholder directly. This looked a bit weird when you had options side by side.

![Screenshot 2024-04-29 at 11 25 26 AM](https://github.com/coveo/plasma/assets/133259861/b510a957-bc06-42ab-bccb-b6be051f2702)

**After**

I put the margin directly on the parent container and tested the various use-cases.

![Screenshot 2024-04-29 at 11 25 45 AM](https://github.com/coveo/plasma/assets/133259861/2c3e8601-4c21-4c0f-8996-8072ea934fdb)
![Screenshot 2024-04-29 at 11 25 52 AM](https://github.com/coveo/plasma/assets/133259861/9c681342-3dfe-47bf-8a10-667e55b206ae)
![Screenshot 2024-04-29 at 11 26 03 AM](https://github.com/coveo/plasma/assets/133259861/e0798163-7ea2-42b6-846b-9ea7e2a06a24)
![Screenshot 2024-04-29 at 11 26 09 AM](https://github.com/coveo/plasma/assets/133259861/2b205666-e142-43f0-9c62-cf3e24a876a8)

### How to test

Use can play with the demo [here](https://plasma.coveo.com/feature/SEARCHAPI-10134-multiselect-selected-margin/legacy/form/MultiSelect). 🧪 

### Potential Breaking Changes

None.


[SEARCHAPI-10134]: https://coveord.atlassian.net/browse/SEARCHAPI-10134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ