### PR TITLE
chore: setup CI/CD for v53 legacy branch

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -14,6 +14,11 @@ runs:
                         tag: 'next',
                         branch: 'next',
                     });
+                  } else if (context.ref === 'refs/heads/v53') {
+                    await publishNewVersion({github, context, exec}, {
+                        tag: 'v53',
+                        branch: 'v53',
+                    });
                   } else {
                     await publishNewVersion({github, context, exec});
                   }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
     cd:
         name: Continuous Delivery
-        if: github.ref_name == 'master' || github.ref_name == 'next'
+        if: github.ref_name == 'master' || github.ref_name == 'next' || github.ref_name == 'v53'
         runs-on: ubuntu-latest
         environment: production
         permissions:
@@ -42,8 +42,6 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
             - name: Deploy
               uses: ./.github/actions/deploy
-              # Demo for next branch is deployed by the CI workflow
-              if: github.ref != 'refs/heads/next'
               with:
                   AWS_ROLE: ${{ secrets.AWS_ROLE }}
                   AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: 'CodeQL'
 
 on:
     push:
-        branches: ['master', next]
+        branches: ['master', 'next', 'v53']
     pull_request:
         # The branches below must be a subset of the branches above
-        branches: ['master']
+        branches: ['master', 'next', 'v53']
     schedule:
         - cron: '17 2 * * 1'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,17 +1,17 @@
 name: 'Dependency Review'
 
 on:
-  pull_request:
-    branches: [ "master", next ]
+    pull_request:
+        branches: ['master', 'next', 'v53']
 
 permissions:
-  contents: read
-  pull-requests: write
+    contents: read
+    pull-requests: write
 
 jobs:
-  dependency-Review:
-    name: Review
-    uses: coveo/public-actions/.github/workflows/dependency-review.yml@main
-    with:
-      public: true
-      distributed: true
+    dependency-Review:
+        name: Review
+        uses: coveo/public-actions/.github/workflows/dependency-review.yml@main
+        with:
+            public: true
+            distributed: true


### PR DESCRIPTION
### Proposed Changes

- Modify the CD workflow to allow building the v53 branch.
- Added logic to prevent bumping a major on the branch
- Added special tag when publishing on NPM
- Branch protections were already added

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
