### PR TITLE
feat(website): clarify table examples

### DIFF
--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -37,6 +37,7 @@
     background-color: var(--mantine-color-gray-1);
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-xl);
     position: relative;
+    min-height: 69px;
 }
 
 .headerGridInner {

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -9,7 +9,7 @@ import {
     useReactTable,
 } from '@tanstack/react-table';
 import isEqual from 'fast-deep-equal';
-import {Children, ForwardedRef, ReactElement, cloneElement, useRef} from 'react';
+import {Children, ForwardedRef, ReactElement, useRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../utils';
 import classes from './Table.module.css';
 import {TableLayout, TableProps} from './Table.types';
@@ -148,6 +148,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
             minSize: defaultColumnSizing.minSize,
             maxSize: defaultColumnSizing.maxSize,
         },
+        rowCount: store.state.totalEntries,
         ...options,
     });
 
@@ -215,7 +216,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
         <Box ref={mergedRef} {...others} {...getStyles('root')}>
             <TableProvider<T> value={{getStyles, store, table, layouts, containerRef}}>
                 <Layout>
-                    {!hasRows && !store.isFiltered && !loading ? (
+                    {store.isVacant && !store.isFiltered ? (
                         noData
                     ) : (
                         <>
@@ -246,18 +247,16 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                                     ) : (
                                         <tr>
                                             <td colSpan={table.getAllColumns().length}>
-                                                <TableLoading visible={loading}>{noData}</TableLoading>
+                                                <TableLoading visible={loading || !store.isFiltered}>
+                                                    {noData}
+                                                </TableLoading>
                                             </td>
                                         </tr>
                                     )}
                                 </tbody>
                             </Box>
                             {footer}
-                            {lastUpdated
-                                ? cloneElement(lastUpdated, {
-                                      dependencies: [data, ...(lastUpdated.props.dependencies ?? [])],
-                                  })
-                                : null}
+                            {lastUpdated}
                         </>
                     )}
                 </Layout>

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -18,10 +18,10 @@ const EmptyState = (props: {isFiltered: boolean}) =>
     props.isFiltered ? <span data-testid="filtered-empty-state" /> : <span data-testid="empty-state" />;
 
 describe('Table', () => {
-    describe('when it has no data', () => {
+    describe('when it is vacant', () => {
         it('hides the footer and header if the table is not filtered', () => {
             const Fixture = () => {
-                const store = useTable<RowData>();
+                const store = useTable<RowData>({initialState: {totalEntries: 0}});
                 return (
                     <Table data={[]} store={store} columns={columns}>
                         <Table.Header data-testid="table-header">header</Table.Header>

--- a/packages/mantine/src/components/table/table-pagination/TablePagination.tsx
+++ b/packages/mantine/src/components/table/table-pagination/TablePagination.tsx
@@ -14,10 +14,7 @@ export const TablePagination: FunctionComponent<TablePaginationProps> = ({onPage
         containerRef.current.scrollIntoView({behavior: 'smooth'});
     };
 
-    const total =
-        store.state.totalEntries == null
-            ? table.getPageCount()
-            : Math.ceil(store.state.totalEntries / store.state.pagination.pageSize);
+    const total = table.getPageCount();
 
     useDidUpdate(() => {
         if (store.state.pagination.pageIndex + 1 > total && total > 0) {

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -1,156 +1,84 @@
-import {BlankSlate, Box, Button, ColumnDef, createColumnHelper, Table, Title, useTable} from '@coveord/plasma-mantine';
-import {EditSize16Px} from '@coveord/plasma-react-icons';
-import {FunctionComponent, useEffect, useState} from 'react';
+import {Button, ColumnDef, createColumnHelper, Table, useTable} from '@coveord/plasma-mantine';
+import {faker} from '@faker-js/faker';
+import {useMemo} from 'react';
 
-interface IExampleRowData {
-    userId: number;
-    id: number;
-    title: string;
-    body: string;
-}
-
-const columnHelper = createColumnHelper<IExampleRowData>();
+const columnHelper = createColumnHelper<Person>();
 
 /**
  * Define your columns outside the component rendering the table
  * (or memoize them) to avoid unnecessary render loops
  */
-const columns: Array<ColumnDef<IExampleRowData>> = [
-    columnHelper.accessor('userId', {
-        header: 'User ID',
-        cell: (info) => info.row.original.userId,
+const columns: Array<ColumnDef<Person>> = [
+    columnHelper.accessor('firstName', {
+        header: 'First name',
+        enableSorting: false,
     }),
-    columnHelper.accessor('id', {
-        header: 'Post ID',
-        cell: (info) => info.row.original.id,
+    columnHelper.accessor('lastName', {
+        header: 'Last name',
+        enableSorting: false,
     }),
-    columnHelper.accessor('title', {
-        header: 'Title',
-        cell: (info) => info.row.original.title,
+    columnHelper.accessor('age', {
+        header: 'Age',
+        enableSorting: false,
     }),
-    Table.CollapsibleColumn as ColumnDef<IExampleRowData>,
-    // or if you prefer an accordion behaviour
-    // Table.AccordionColumn as ColumnDef<IExampleRowData>,
 ];
 
 const Demo = () => {
     // How you manage your data and loading state is up to you
     // Just make sure data is a stable reference and isn't recreated on every render
-    const [data, setData] = useState<IExampleRowData[]>(null);
-    const [loading, setLoading] = useState(true);
+    // Here for the sake of example we're building 10 rows of mock data
+    const data = useMemo(() => makeData(10), []);
 
     // `useTable` hook provides a table store.
     // The store contains the current state of the table and methods to update it.
-    const table = useTable<IExampleRowData>({
-        initialState: {predicates: {user: ''}},
+    const table = useTable<Person>({
+        initialState: {totalEntries: data.length},
     });
 
-    const fetchData = async () => {
-        setLoading(true);
-        // you can use the store state to build your query
-        const searchParams = new URLSearchParams({
-            _sort: table.state.sorting?.[0]?.id ?? 'userId',
-            _order: table.state.sorting?.[0]?.desc ? 'desc' : 'asc',
-            _page: (table.state.pagination.pageIndex + 1).toString(),
-            _limit: table.state.pagination.pageSize.toString(),
-            userId: table.state.predicates.user,
-            title_like: table.state.globalFilter,
-        });
-        if (table.state.predicates.user === '') {
-            searchParams.delete('userId');
-        }
-        if (!table.state.globalFilter) {
-            searchParams.delete('title_like');
-        }
-        try {
-            const response = await fetch(`https://jsonplaceholder.typicode.com/posts?${searchParams.toString()}`);
-            const body = await response.json();
-            setData(body);
-            // The table needs to know the total number of entries to calculate the number of pages
-            table.setTotalEntries(Number(response.headers.get('x-total-count')));
-        } catch (e) {
-            console.error(e);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    // refetch data when the table state you care about changes
-    useEffect(() => {
-        fetchData();
-    }, [table.state.predicates, table.state.sorting, table.state.pagination, table.state.globalFilter]);
-
     return (
-        <Table<IExampleRowData>
-            store={table}
-            data={data}
-            getRowId={({id}) => id.toString()}
-            columns={columns}
-            loading={loading}
-            getExpandChildren={(datum) => <Box py="xs">{datum.body}</Box>}
-        >
+        <Table<Person> store={table} data={data} columns={columns} getRowId={({id}) => id.toString()}>
             <Table.Header>
-                <Table.Actions>{(datum: IExampleRowData) => <TableActions datum={datum} />}</Table.Actions>
-                <UserPredicate />
-                <Table.Filter placeholder="Search posts by title" />
+                <Table.Actions>
+                    {(selectedRow: Person) => (
+                        <>
+                            <Button
+                                variant="subtle"
+                                onClick={() => alert(`Action 1 triggered for row: ${selectedRow.id}`)}
+                            >
+                                Action 1
+                            </Button>
+                            <Button
+                                variant="subtle"
+                                onClick={() => alert(`Action 2 triggered for row: ${selectedRow.id}`)}
+                            >
+                                Action 2
+                            </Button>
+                        </>
+                    )}
+                </Table.Actions>
             </Table.Header>
-            <Table.NoData>
-                <EmptyState isFiltered={table.isFiltered} clearFilters={table.clearFilters} />
-            </Table.NoData>
-            <Table.Footer>
-                <Table.PerPage />
-                <Table.Pagination />
-            </Table.Footer>
         </Table>
     );
 };
 export default Demo;
 
-const EmptyState: FunctionComponent<{isFiltered: boolean; clearFilters: () => void}> = ({isFiltered, clearFilters}) =>
-    isFiltered ? (
-        <BlankSlate>
-            <Title order={4}>No data found for those filters</Title>
-            <Button onClick={clearFilters}>Clear filters</Button>
-        </BlankSlate>
-    ) : (
-        <BlankSlate>
-            <Title order={4}>No Data</Title>
-        </BlankSlate>
-    );
-
-const TableActions: FunctionComponent<{datum: IExampleRowData}> = ({datum}) => {
-    const actionCondition = datum.id % 2 === 0 ? true : false;
-    const pressedAction = () => alert('Edit action is triggered!');
-    return (
-        <>
-            {actionCondition ? (
-                <Button variant="subtle" onClick={pressedAction} leftSection={<EditSize16Px height={16} />}>
-                    Edit
-                </Button>
-            ) : null}
-        </>
-    );
+export type Person = {
+    id: string;
+    firstName: string;
+    lastName: string;
+    age: number;
+    bio: string;
+    pic: string;
 };
 
-const UserPredicate: FunctionComponent = () => (
-    <Table.Predicate
-        id="user"
-        label="User"
-        data={[
-            {
-                value: '',
-                label: 'All',
-            },
-            {value: '1', label: '1'},
-            {value: '2', label: '2'},
-            {value: '3', label: '3'},
-            {value: '4', label: '4'},
-            {value: '5', label: '5'},
-            {value: '6', label: '6'},
-            {value: '7', label: '7'},
-            {value: '8', label: '8'},
-            {value: '9', label: '9'},
-            {value: '10', label: '10'},
-        ]}
-    />
-);
+const makeData = (len: number): Person[] =>
+    Array(len)
+        .fill(0)
+        .map(() => ({
+            id: faker.string.uuid(),
+            pic: faker.image.avatar(),
+            firstName: faker.person.firstName(),
+            lastName: faker.person.lastName(),
+            age: faker.number.int(40),
+            bio: faker.lorem.sentences({min: 1, max: 5}),
+        }));

--- a/packages/website/src/examples/layout/Table/TableClientSide.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableClientSide.demo.tsx
@@ -1,4 +1,6 @@
 import {
+    BlankSlate,
+    Button,
     ColumnDef,
     createColumnHelper,
     FilterFn,
@@ -7,6 +9,7 @@ import {
     getSortedRowModel,
     Table,
     TableProps,
+    Title,
     useTable,
 } from '@coveord/plasma-mantine';
 import {faker} from '@faker-js/faker';
@@ -50,15 +53,21 @@ const columns: Array<ColumnDef<Person>> = [
 ];
 
 const options: TableProps<Person>['options'] = {
-    globalFilterFn: fuzzyFilter,
+    // Specify the row models you need in the table options
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    globalFilterFn: fuzzyFilter, // defines how the filter should operate
 };
 
 const Demo = () => {
     const data = useMemo(() => makeData(45), []);
-    const table = useTable<Person>({initialState: {pagination: {pageSize: 5}}});
+    const table = useTable<Person>({
+        initialState: {
+            pagination: {pageSize: 5},
+            totalEntries: data.length,
+        },
+    });
     return (
         <Table<Person> store={table} data={data} columns={columns} options={options} getRowId={({id}) => id}>
             <Table.Header>
@@ -68,6 +77,12 @@ const Demo = () => {
                 <Table.PerPage values={[5, 10, 25]} />
                 <Table.Pagination />
             </Table.Footer>
+            <Table.NoData>
+                <BlankSlate>
+                    <Title order={4}>Nothing found for "{table.state.globalFilter}"</Title>
+                    <Button onClick={table.clearFilters}>Clear filter</Button>
+                </BlankSlate>
+            </Table.NoData>
         </Table>
     );
 };

--- a/packages/website/src/examples/layout/Table/TableCollapsible.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableCollapsible.demo.tsx
@@ -1,0 +1,65 @@
+import {Avatar, ColumnDef, createColumnHelper, Group, Table, useTable} from '@coveord/plasma-mantine';
+import {faker} from '@faker-js/faker';
+import {useMemo} from 'react';
+
+const columnHelper = createColumnHelper<Person>();
+
+const columns: Array<ColumnDef<Person>> = [
+    columnHelper.accessor('firstName', {
+        header: 'First name',
+    }),
+    columnHelper.accessor('lastName', {
+        header: 'Last name',
+    }),
+    columnHelper.accessor('age', {
+        header: 'Age',
+    }),
+    // Add the pre-built collapsible column at the end
+    Table.CollapsibleColumn as ColumnDef<Person>,
+    // or if you prefer an accordion behaviour
+    // Table.AccordionColumn as ColumnDef<Person>,
+];
+
+const Demo = () => {
+    const data = useMemo(() => makeData(10), []);
+
+    const table = useTable<Person>({initialState: {totalEntries: data.length}});
+
+    return (
+        <Table<Person>
+            store={table}
+            data={data}
+            getRowId={({id}) => id.toString()}
+            columns={columns}
+            // Define the collapsible content with getExpandChildren
+            getExpandChildren={(datum) => (
+                <Group py="xs" px="md" wrap="nowrap">
+                    <Avatar src={datum.pic} />
+                    {datum.bio}
+                </Group>
+            )}
+        />
+    );
+};
+export default Demo;
+
+export type Person = {
+    id: string;
+    firstName: string;
+    lastName: string;
+    age: number;
+    bio: string;
+    pic: string;
+};
+
+const makeData = (len: number): Person[] =>
+    Array(len)
+        .fill(0)
+        .map(() => ({
+            id: faker.string.uuid(),
+            pic: faker.image.avatar(),
+            firstName: faker.person.firstName(),
+            lastName: faker.person.lastName(),
+            age: faker.number.int(40),
+            bio: faker.lorem.sentences({min: 1, max: 5}),
+        }));

--- a/packages/website/src/examples/layout/Table/TableColumnsSelector.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableColumnsSelector.demo.tsx
@@ -1,4 +1,4 @@
-import {Box, ColumnDef, createColumnHelper, Table, Text, useTable} from '@coveord/plasma-mantine';
+import {ColumnDef, createColumnHelper, Table, Text, useTable} from '@coveord/plasma-mantine';
 import {faker} from '@faker-js/faker';
 import {useMemo} from 'react';
 
@@ -50,7 +50,6 @@ const columns: Array<ColumnDef<IEmployeeData>> = [
         header: 'Hire Date',
         cell: (info) => info.row.original.hireDate?.toDateString(),
     }),
-    Table.CollapsibleColumn as ColumnDef<IEmployeeData>,
 ];
 
 const Demo = () => {
@@ -62,13 +61,7 @@ const Demo = () => {
     });
 
     return (
-        <Table
-            store={table}
-            data={data}
-            getRowId={({employeeId}) => employeeId?.toString()}
-            columns={columns}
-            getExpandChildren={(datum) => <Box py="xs">{datum.body}</Box>}
-        >
+        <Table store={table} data={data} getRowId={({employeeId}) => employeeId?.toString()} columns={columns}>
             <Table.Header>
                 <Table.ColumnsSelector
                     label="Edit columns"

--- a/packages/website/src/examples/layout/Table/TableDateRangePicker.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableDateRangePicker.demo.tsx
@@ -1,0 +1,93 @@
+import {
+    ColumnDef,
+    createColumnHelper,
+    DateRangePickerPreset,
+    DateRangePickerValue,
+    Table,
+    useTable,
+} from '@coveord/plasma-mantine';
+import {faker} from '@faker-js/faker';
+import dayjs from 'dayjs';
+import LocalizedFormat from 'dayjs/plugin/localizedFormat';
+import {useMemo} from 'react';
+
+dayjs.extend(LocalizedFormat);
+
+const columnHelper = createColumnHelper<Person>();
+
+/**
+ * Define your columns outside the component rendering the table
+ * (or memoize them) to avoid unnecessary render loops
+ */
+const columns: Array<ColumnDef<Person>> = [
+    columnHelper.accessor('firstName', {
+        header: 'First name',
+        enableSorting: false,
+    }),
+    columnHelper.accessor('lastName', {
+        header: 'Last name',
+        enableSorting: false,
+    }),
+    columnHelper.accessor('lastActivity', {
+        header: 'Activity',
+        enableSorting: false,
+        cell: ({getValue}) => dayjs(getValue()).format('LLL'),
+    }),
+];
+
+const today: Date = dayjs().endOf('day').toDate();
+const previousDay: Date = dayjs().subtract(1, 'day').startOf('day').toDate();
+const previousWeek: Date = dayjs().subtract(1, 'week').startOf('day').toDate();
+const datePickerPresets: Record<string, DateRangePickerPreset> = {
+    lastDay: {label: 'Last 24 hours', range: [previousDay, today]},
+    lastWeek: {label: 'Last week', range: [previousWeek, today]},
+};
+
+const Demo = () => {
+    const data = useMemo(() => makeData(10), []);
+    const table = useTable<Person>({
+        initialState: {totalEntries: data.length, dateRange: [previousWeek, today]},
+    });
+
+    // we're filtering the data ourselves here for the example,
+    // but normally you would just send the date range to the backend
+    const filteredData = useMemo(
+        () => data.filter((person) => lastActivityDateFilter(person, table.state.dateRange)),
+        [table.state.dateRange, data],
+    );
+
+    return (
+        <Table<Person> store={table} data={filteredData} columns={columns} getRowId={({id}) => id.toString()}>
+            <Table.Header>
+                <Table.DateRangePicker
+                    rangeCalendarProps={{maxDate: dayjs().endOf('day').toDate()}}
+                    presets={datePickerPresets}
+                />
+            </Table.Header>
+        </Table>
+    );
+};
+export default Demo;
+
+export type Person = {
+    id: string;
+    firstName: string;
+    lastName: string;
+    lastActivity: Date;
+};
+
+const makeData = (len: number): Person[] =>
+    Array(len)
+        .fill(0)
+        .map(() => ({
+            id: faker.string.uuid(),
+            firstName: faker.person.firstName(),
+            lastName: faker.person.lastName(),
+            lastActivity: faker.date.recent({days: 7}),
+        }));
+
+const lastActivityDateFilter = (row: Person, dateRange: DateRangePickerValue) => {
+    const lastActivity = row['lastActivity'];
+
+    return dayjs(lastActivity).isAfter(dateRange[0]) && dayjs(lastActivity).isBefore(dateRange[1]);
+};

--- a/packages/website/src/examples/layout/Table/TableEmptyState.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableEmptyState.demo.tsx
@@ -1,4 +1,4 @@
-import {BlankSlate, Button, ColumnDef, createColumnHelper, Table, Title, useTable} from '@coveord/plasma-mantine';
+import {BlankSlate, ColumnDef, createColumnHelper, Table, Title, useTable} from '@coveord/plasma-mantine';
 import {NoContentSize32Px} from '@coveord/plasma-react-icons';
 import {FunctionComponent} from 'react';
 
@@ -8,41 +8,30 @@ export type Person = {
     age: number;
 };
 
-const EmptyState: FunctionComponent<{isFiltered: boolean; clearFilters: () => void; filter: string}> = ({
-    clearFilters,
-    isFiltered,
-    filter,
-}) =>
-    isFiltered ? (
-        <BlankSlate>
-            <Title order={4}>No data found for filter "{filter}"</Title>
-            <Button onClick={clearFilters}>Clear filter</Button>
-        </BlankSlate>
-    ) : (
-        <BlankSlate withBorder={false}>
-            <NoContentSize32Px height={64} />
-            <Title order={4}>Hello Empty State</Title>
-        </BlankSlate>
-    );
+const EmptyState: FunctionComponent = () => (
+    <BlankSlate withBorder={false}>
+        <NoContentSize32Px height={64} />
+        <Title order={4}>Empty State</Title>
+        This table is vacant, in other words it has no data even when no filter is applied.
+    </BlankSlate>
+);
 
 const Demo = () => {
-    const table = useTable<Person>({initialState: {globalFilter: 'foo', pagination: {pageSize: 5}}});
+    /**
+     * In order to determine properly when to display the empty state, the table needs to know the `totalEntries`.
+     * Be sure to set it either in the `initialState` or by using `store.setTotalEntries()`
+     */
+    const data: Person[] = [];
+    const table = useTable<Person>({
+        initialState: {
+            totalEntries: data.length,
+        },
+    });
     return (
         <Table store={table} data={[]} columns={columns}>
-            <Table.Header>
-                <Table.Filter placeholder="Search" />
-            </Table.Header>
             <Table.NoData>
-                <EmptyState
-                    filter={table.state.globalFilter}
-                    isFiltered={table.isFiltered}
-                    clearFilters={table.clearFilters}
-                />
+                <EmptyState />
             </Table.NoData>
-            <Table.Footer>
-                <Table.PerPage values={[5, 10, 25]} />
-                <Table.Pagination />
-            </Table.Footer>
         </Table>
     );
 };

--- a/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
@@ -3,24 +3,18 @@ import {
     Button,
     ColumnDef,
     createColumnHelper,
-    FilterFn,
-    getFilteredRowModel,
-    getPaginationRowModel,
-    getSortedRowModel,
     Paper,
     renderTableCell,
     SimpleGrid,
     Table,
     TableLayout,
     TableLayoutProps,
-    TableProps,
     Title,
     useTable,
     useTableContext,
 } from '@coveord/plasma-mantine';
 import {CardSize16Px} from '@coveord/plasma-react-icons';
 import {faker} from '@faker-js/faker';
-import {rankItem} from '@tanstack/match-sorter-utils';
 import {useMemo} from 'react';
 
 const TableCards = <TData,>(props: TableLayoutProps<TData>) => {
@@ -78,14 +72,13 @@ CardLayout.Body = TableCards;
 CardLayout.Icon = CardSize16Px;
 
 const Demo = () => {
-    const data = useMemo(() => makeData(45), []);
+    const data = useMemo(() => makeData(10), []);
     const table = useTable<Person>({initialState: {pagination: {pageSize: 10}}});
     return (
         <Table<Person>
             store={table}
             data={data}
             columns={columns}
-            options={options}
             getRowId={({id}) => id}
             layouts={[Table.Layouts.Rows, CardLayout]}
             doubleClickAction={(person) => alert(`Double clicked ${person.firstName}`)}
@@ -99,10 +92,6 @@ const Demo = () => {
                     )}
                 </Table.Actions>
             </Table.Header>
-            <Table.Footer>
-                <Table.PerPage values={[5, 10, 25]} />
-                <Table.Pagination />
-            </Table.Footer>
         </Table>
     );
 };
@@ -138,12 +127,3 @@ const makeData = (len: number): Person[] =>
             lastName: faker.person.lastName(),
             age: faker.number.int(40),
         }));
-
-const fuzzyFilter: FilterFn<Person> = (row, columnId, value) => rankItem(row.getValue(columnId), value).passed;
-
-const options: TableProps<Person>['options'] = {
-    globalFilterFn: fuzzyFilter,
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-};

--- a/packages/website/src/examples/layout/Table/TablePredicate.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TablePredicate.demo.tsx
@@ -1,0 +1,125 @@
+import {ColumnDef, createColumnHelper, Table, useTable} from '@coveord/plasma-mantine';
+import {faker} from '@faker-js/faker';
+import {useMemo} from 'react';
+
+const columnHelper = createColumnHelper<Person>();
+
+/**
+ * Define your columns outside the component rendering the table
+ * (or memoize them) to avoid unnecessary render loops
+ */
+const columns: Array<ColumnDef<Person>> = [
+    columnHelper.accessor('firstName', {
+        header: 'First name',
+        enableSorting: false,
+    }),
+    columnHelper.accessor('lastName', {
+        header: 'Last name',
+        enableSorting: false,
+    }),
+    columnHelper.accessor('status', {
+        header: 'Status',
+        enableSorting: false,
+    }),
+    columnHelper.accessor('age', {
+        header: 'Age',
+        enableSorting: false,
+    }),
+];
+
+const Demo = () => {
+    const data = useMemo(() => makeData(10), []);
+    const table = useTable<Person>({
+        initialState: {totalEntries: data.length, predicates: {status: '', age: ''}},
+    });
+
+    // we're filtering the data ourselves here for the example,
+    // but normally you would just send the predicate value to the backend
+    const filteredData = useMemo(
+        () =>
+            data
+                .filter((person) => ageFilter(person, table.state.predicates))
+                .filter((person) => statusFilter(person, table.state.predicates)),
+        [table.state.predicates, data],
+    );
+
+    return (
+        <Table<Person> store={table} data={filteredData} columns={columns} getRowId={({id}) => id.toString()}>
+            <Table.Header>
+                <Table.Predicate
+                    id="age"
+                    label="Age group"
+                    data={[
+                        {
+                            value: '',
+                            label: 'Any',
+                        },
+                        {value: 'below20', label: 'Below 20'},
+                        {value: 'between20to60', label: '20 to 60'},
+                        {value: 'above60', label: 'Above 60'},
+                    ]}
+                />
+                <Table.Predicate
+                    id="status"
+                    label="Status"
+                    data={[
+                        {
+                            value: '',
+                            label: 'All',
+                        },
+                        {value: 'relationship', label: 'In a relationship'},
+                        {value: 'complicated', label: 'Its complicated'},
+                        {value: 'single', label: 'Single'},
+                    ]}
+                />
+            </Table.Header>
+        </Table>
+    );
+};
+export default Demo;
+
+export type Person = {
+    id: string;
+    firstName: string;
+    lastName: string;
+    age: number;
+    bio: string;
+    pic: string;
+    status: 'relationship' | 'complicated' | 'single';
+};
+
+const makeData = (len: number): Person[] =>
+    Array(len)
+        .fill(0)
+        .map(() => ({
+            id: faker.string.uuid(),
+            pic: faker.image.avatar(),
+            firstName: faker.person.firstName(),
+            lastName: faker.person.lastName(),
+            age: faker.number.int({min: 1, max: 99}),
+            bio: faker.lorem.sentences({min: 1, max: 5}),
+            status: faker.helpers.shuffle<Person['status']>(['relationship', 'complicated', 'single'])[0],
+        }));
+
+const ageFilter = (row: Person, predicates: Record<string, string>) => {
+    const age = row['age'];
+    const filterValue = predicates['age'];
+
+    switch (filterValue) {
+        case 'below20':
+            return age < 20;
+        case 'above60':
+            return age > 60;
+        case 'between20to60':
+            return age >= 20 && age <= 60;
+        default:
+            return true;
+    }
+};
+
+const statusFilter = (row: Person, predicates: Record<string, string>) => {
+    const status = row['status'];
+    const filterValue = predicates['status'];
+
+    return !filterValue || status === filterValue;
+};

--- a/packages/website/src/pages/layout/Table.tsx
+++ b/packages/website/src/pages/layout/Table.tsx
@@ -1,12 +1,15 @@
 import {TableMetadata} from '@coveord/plasma-components-props-analyzer';
 import TableDemo from '@examples/layout/Table/Table.demo?demo';
-import TableReactQuery from '@examples/layout/Table/TableReactQuery.demo?demo';
 import TableClientSideDemo from '@examples/layout/Table/TableClientSide.demo?demo';
+import TableCollapsibleDemo from '@examples/layout/Table/TableCollapsible.demo?demo';
+import TableColumnsSelectorDemo from '@examples/layout/Table/TableColumnsSelector.demo?demo';
+import TableDateRangePickerDemo from '@examples/layout/Table/TableDateRangePicker.demo?demo';
 import TableDisableRowSelection from '@examples/layout/Table/TableDisabledRowSelection.demo?demo';
 import TableEmptyStateDemo from '@examples/layout/Table/TableEmptyState.demo?demo';
-import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
-import TableColumnsSelectorDemo from '@examples/layout/Table/TableColumnsSelector.demo?demo';
 import TableLayoutsDemo from '@examples/layout/Table/TableLayouts.demo?demo';
+import TableMultiSelectionDemo from '@examples/layout/Table/TableMultiSelection.demo?demo';
+import TablePredicateDemo from '@examples/layout/Table/TablePredicate.demo?demo';
+import TableReactQuery from '@examples/layout/Table/TableReactQuery.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -18,18 +21,25 @@ const DemoPage = () => (
         description="A table displays large quantities of items or data in a list format. Filtering features, date picker, collapsible rows and actions may be added."
         id="Table"
         propsMetadata={TableMetadata}
-        demo={<TableDemo noPadding layout="vertical" />}
+        demo={<TableDemo noPadding layout="vertical" title="Basic table with actions on rows" />}
         examples={{
             reactQuery: (
-                <TableReactQuery noPadding layout="vertical" title="Table integrated with @tanstack/react-query" />
+                <TableReactQuery
+                    noPadding
+                    layout="vertical"
+                    title="Server-side table integrated with @tanstack/react-query"
+                />
             ),
             clientSide: (
                 <TableClientSideDemo
                     noPadding
                     layout="vertical"
-                    title="Table with client side pagination, sorting, and filtering"
+                    title="Client-side table with pagination, sorting, and filtering"
                 />
             ),
+            collapsible: <TableCollapsibleDemo noPadding layout="vertical" title="Table with collapsible content" />,
+            predicate: <TablePredicateDemo noPadding layout="vertical" title="Table with predicate filters" />,
+            datePicker: <TableDateRangePickerDemo noPadding layout="vertical" title="Table with date range picker" />,
             emptyState: <TableEmptyStateDemo noPadding layout="vertical" title="Table with empty states" />,
             multiSelect: (
                 <TableMultiSelectionDemo noPadding layout="vertical" title="Table with bulk selection of rows" />


### PR DESCRIPTION
### Proposed Changes

In this PR I made one addition to the use-table hook and several improvements to the table examples on the website.

The main fix is I added `isVacant` flag on the store object. This boolean indicates whether the table has rows when unfiltered. This is useful mainly in the case of server side tables to determine whether the table should show the empty state.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
