### PR TITLE
refactor(mantine, table): decouple table actions from table header

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -9,7 +9,7 @@ import {
     useReactTable,
 } from '@tanstack/react-table';
 import isEqual from 'fast-deep-equal';
-import {Children, cloneElement, ForwardedRef, ReactElement, useRef} from 'react';
+import {Children, ForwardedRef, ReactElement, useRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../utils';
 import {TableLayouts} from './layouts/TableLayouts';
 import {
@@ -17,7 +17,6 @@ import {
     TableActionItemStylesNames,
     TableActions,
     TableActionsStylesNames,
-    TableHeaderActions,
     TableHeaderActionsStylesNames,
 } from './table-actions';
 import {TableActionsColumn} from './table-column/TableActionsColumn';
@@ -139,19 +138,6 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     const noData = convertedChildren.find((child) => child.type === TableNoData);
     const actions = convertedChildren.find((child) => child.type === TableActions);
 
-    // clone the header and add the actions to it
-    const headerWithActions = !!header
-        ? cloneElement(header, {
-              ...header.props,
-              children: (
-                  <>
-                      {header.props.children}
-                      <TableHeaderActions>{actions}</TableHeaderActions>
-                  </>
-              ),
-          })
-        : null;
-
     const table = useReactTable({
         data,
         state: {
@@ -253,7 +239,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                                     {!!header ? (
                                         <tr>
                                             <th style={{padding: 0}} colSpan={table.getAllColumns().length}>
-                                                {headerWithActions}
+                                                {header}
                                             </th>
                                         </tr>
                                     ) : null}

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -1,21 +1,26 @@
-import {Box, Center, Factory, Loader, useProps, useStyles} from '@mantine/core';
+import {Box, Center, Factory, Loader, Menu, useProps, useStyles} from '@mantine/core';
 import {useClickOutside, useMergedRef} from '@mantine/hooks';
 import {
     ColumnDef,
-    Row,
-    RowSelectionState,
     defaultColumnSizing,
     getCoreRowModel,
+    Row,
+    RowSelectionState,
     useReactTable,
 } from '@tanstack/react-table';
 import isEqual from 'fast-deep-equal';
-import {Children, ForwardedRef, ReactElement, useRef} from 'react';
+import {Children, cloneElement, ForwardedRef, ReactElement, useRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../utils';
-import classes from './Table.module.css';
-import {TableLayout, TableProps} from './Table.types';
-import {TableProvider} from './TableContext';
 import {TableLayouts} from './layouts/TableLayouts';
-import {TableActions, TableActionsStylesNames} from './table-actions/TableActions';
+import {
+    TableActionItem,
+    TableActionItemStylesNames,
+    TableActions,
+    TableActionsStylesNames,
+    TableHeaderActions,
+    TableHeaderActionsStylesNames,
+} from './table-actions';
+import {TableActionsColumn} from './table-column/TableActionsColumn';
 import {
     TableAccordionColumn,
     TableCollapsibleColumn,
@@ -34,6 +39,9 @@ import {TableNoData} from './table-no-data/TableNoData';
 import {TablePagination} from './table-pagination/TablePagination';
 import {TablePerPage} from './table-per-page/TablePerPage';
 import {TablePredicate, TablePredicateStylesNames} from './table-predicate/TablePredicate';
+import classes from './Table.module.css';
+import {TableLayout, TableProps} from './Table.types';
+import {TableProvider} from './TableContext';
 import {TableState} from './use-table';
 
 type TableStylesNames =
@@ -41,6 +49,8 @@ type TableStylesNames =
     | 'table'
     | 'header'
     | 'body'
+    | TableHeaderActionsStylesNames
+    | TableActionItemStylesNames
     | TableActionsStylesNames
     | TableCollapsibleColumnStylesNames
     | TableDateRangePickerStylesNames
@@ -58,6 +68,10 @@ export type PlasmaTableFactory = Factory<{
     staticComponents: {
         AccordionColumn: typeof TableAccordionColumn;
         Actions: typeof TableActions;
+        ActionsColumn: typeof TableActionsColumn;
+        ActionItem: typeof TableActionItem;
+        ActionLabel: typeof Menu.Label;
+        ActionDivider: typeof Menu.Divider;
         CollapsibleColumn: typeof TableCollapsibleColumn;
         ColumnsSelector: typeof TableColumnsSelector;
         DateRangePicker: typeof TableDateRangePicker;
@@ -123,6 +137,23 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     const footer = convertedChildren.find((child) => child.type === TableFooter);
     const lastUpdated = convertedChildren.find((child) => child.type === TableLastUpdated);
     const noData = convertedChildren.find((child) => child.type === TableNoData);
+    const actions = convertedChildren.find((child) => child.type === TableActions);
+
+    const actionsForHeader = !!actions ? cloneElement(actions, {...actions.props, variant: 'split'}) : null;
+    // clone the header and add the actions to it
+    const headerWithActions = !!header
+        ? cloneElement(header, {
+              ...header.props,
+              children: !!actions ? (
+                  <>
+                      {header.props.children}
+                      <TableHeaderActions>{actionsForHeader}</TableHeaderActions>
+                  </>
+              ) : (
+                  header.props.children
+              ),
+          })
+        : null;
 
     const table = useReactTable({
         data,
@@ -214,7 +245,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
 
     return (
         <Box ref={mergedRef} {...others} {...getStyles('root')}>
-            <TableProvider<T> value={{getStyles, store, table, layouts, containerRef}}>
+            <TableProvider<T> value={{getStyles, actions, store, table, layouts, containerRef}}>
                 <Layout>
                     {store.isVacant && !store.isFiltered ? (
                         noData
@@ -225,7 +256,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                                     {!!header ? (
                                         <tr>
                                             <th style={{padding: 0}} colSpan={table.getAllColumns().length}>
-                                                {header}
+                                                {headerWithActions}
                                             </th>
                                         </tr>
                                     ) : null}
@@ -277,6 +308,10 @@ export const TableComponentsOrder = {
 
 Table.AccordionColumn = TableAccordionColumn;
 Table.Actions = TableActions;
+Table.ActionsColumn = TableActionsColumn;
+Table.ActionItem = TableActionItem;
+Table.ActionLabel = Menu.Label;
+Table.ActionDivider = Menu.Divider;
 Table.CollapsibleColumn = TableCollapsibleColumn;
 Table.ColumnsSelector = TableColumnsSelector;
 Table.DateRangePicker = TableDateRangePicker;

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -139,18 +139,15 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     const noData = convertedChildren.find((child) => child.type === TableNoData);
     const actions = convertedChildren.find((child) => child.type === TableActions);
 
-    const actionsForHeader = !!actions ? cloneElement(actions, {...actions.props, variant: 'split'}) : null;
     // clone the header and add the actions to it
     const headerWithActions = !!header
         ? cloneElement(header, {
               ...header.props,
-              children: !!actions ? (
+              children: (
                   <>
                       {header.props.children}
-                      <TableHeaderActions>{actionsForHeader}</TableHeaderActions>
+                      <TableHeaderActions>{actions}</TableHeaderActions>
                   </>
-              ) : (
-                  header.props.children
               ),
           })
         : null;

--- a/packages/mantine/src/components/table/TableContext.tsx
+++ b/packages/mantine/src/components/table/TableContext.tsx
@@ -9,6 +9,7 @@ export interface TableContextValue<TData = unknown> {
     getStyles: GetStylesApi<PlasmaTableFactory>;
     store: TableStore<TData>;
     layouts: TableLayout[];
+    actions: ReactElement;
     table: Table<TData>;
     containerRef: MutableRefObject<HTMLDivElement>;
 }

--- a/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
@@ -1,7 +1,6 @@
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
 import {render, screen, userEvent, within} from '@test-utils';
 
-import {Button} from '../../button';
 import {Table} from '../Table';
 import {useTable} from '../use-table';
 
@@ -18,7 +17,7 @@ describe('Table.Actions', () => {
             return (
                 <Table<RowData> store={store} data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns}>
                     <Table.Actions>
-                        {(datum: RowData) => [<Table.ActionItem primary>Eat {datum.name}</Table.ActionItem>]}
+                        {(datum: RowData) => <Table.ActionItem primary>Eat {datum.name}</Table.ActionItem>}
                     </Table.Actions>
                     <Table.Header />
                 </Table>
@@ -52,15 +51,37 @@ describe('Table.Actions', () => {
                     columns={columns}
                     loading={true}
                 >
-                    <Table.Header>
-                        <Table.Actions>{(datum: RowData) => <Button>Eat {datum.name}</Button>}</Table.Actions>
-                    </Table.Header>
+                    <Table.Actions>
+                        {(datum: RowData) => <Table.ActionItem>Eat {datum.name}</Table.ActionItem>}
+                    </Table.Actions>
+                    <Table.Header />
                 </Table>
             );
         };
         render(<Fixture />);
         await user.click(screen.getByRole('cell', {name: 'fruit'}));
         expect(screen.getByRole('row', {name: 'fruit', selected: false})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Eat fruit'})).not.toBeInTheDocument();
+        expect(screen.getByRole('row', {name: 'vegetable', selected: false})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Eat vegetable'})).not.toBeInTheDocument();
+    });
+
+    it('does not display the action in the header when the header showActions prop is false', async () => {
+        const user = userEvent.setup();
+        const Fixture = () => {
+            const store = useTable<RowData>();
+            return (
+                <Table<RowData> store={store} data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns}>
+                    <Table.Actions>
+                        {(datum: RowData) => <Table.ActionItem>Eat {datum.name}</Table.ActionItem>}
+                    </Table.Actions>
+                    <Table.Header showActions={false} />
+                </Table>
+            );
+        };
+        render(<Fixture />);
+        await user.click(screen.getByRole('cell', {name: 'fruit'}));
+        expect(screen.getByRole('row', {name: 'fruit'})).toBeInTheDocument();
         expect(screen.queryByRole('button', {name: 'Eat fruit'})).not.toBeInTheDocument();
         expect(screen.getByRole('row', {name: 'vegetable', selected: false})).toBeInTheDocument();
         expect(screen.queryByRole('button', {name: 'Eat vegetable'})).not.toBeInTheDocument();
@@ -79,9 +100,8 @@ describe('Table.Actions', () => {
                         data={[{name: 'fruit'}, {name: 'vegetable'}, {name: 'bread'}]}
                         columns={columns}
                     >
-                        <Table.Header>
-                            <Table.Actions>{renderSpy}</Table.Actions>
-                        </Table.Header>
+                        <Table.Actions>{renderSpy}</Table.Actions>
+                        <Table.Header />
                     </Table>
                 );
             };

--- a/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TableActions.spec.tsx
@@ -17,9 +17,10 @@ describe('Table.Actions', () => {
             const store = useTable<RowData>();
             return (
                 <Table<RowData> store={store} data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns}>
-                    <Table.Header>
-                        <Table.Actions>{(datum: RowData) => <Button>Eat {datum.name}</Button>}</Table.Actions>
-                    </Table.Header>
+                    <Table.Actions>
+                        {(datum: RowData) => [<Table.ActionItem primary>Eat {datum.name}</Table.ActionItem>]}
+                    </Table.Actions>
+                    <Table.Header />
                 </Table>
             );
         };

--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -2,4 +2,5 @@ export {flexRender as renderTableCell} from '@tanstack/react-table';
 export * from './Table';
 export {type TableLayout, type TableProps, type TableLayoutProps} from './Table.types';
 export {useTable, type TableState, type TableStore, type UseTableOptions} from './use-table';
+export type {TableActionsItems, TableActionsItemElements} from './table-actions';
 export {useTableContext} from './TableContext';

--- a/packages/mantine/src/components/table/table-actions/TableActionItem.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableActionItem.tsx
@@ -1,0 +1,87 @@
+import {BoxProps, CompoundStylesApiProps, Menu, PolymorphicFactory, polymorphicFactory, useProps} from '@mantine/core';
+import {ReactNode} from 'react';
+import {Button} from '../../button';
+import {useTableContext} from '../TableContext';
+
+export type TableActionItemStylesNames = 'actionItemRoot';
+
+export interface TableActionItemProps extends BoxProps, CompoundStylesApiProps<TableActionItemFactory> {
+    /**
+     * Action label
+     */
+    children: ReactNode;
+    /**
+     * Content to put on the left of the label. Usually used to render an icon
+     */
+    leftSection: ReactNode;
+    /**
+     * Whether action is primary. Primary items are visible outside the more menu
+     *
+     * @default false
+     */
+    primary?: boolean;
+
+    /**
+     * Section displayed on the right side of the label
+     */
+    rightSection?: ReactNode;
+
+    /**
+     * Disables action
+     */
+    disabled?: boolean;
+}
+
+type TableActionItemFactory = PolymorphicFactory<{
+    props: TableActionItemProps;
+    defaultRef: HTMLButtonElement;
+    defaultComponent: 'button';
+    stylesNames: TableActionItemStylesNames;
+    compound: true;
+}>;
+
+const defaultProps: Partial<TableActionItemProps> = {
+    primary: false,
+};
+
+export const TableActionItem = polymorphicFactory<TableActionItemFactory>(
+    (props: TableActionItemProps & {component?: any}, ref) => {
+        const {getStyles} = useTableContext();
+        const {
+            classNames,
+            className,
+            style,
+            styles,
+            vars: _vars,
+            children,
+            primary,
+            component,
+            ...others
+        } = useProps('PlasmaTableActionItem', defaultProps, props);
+
+        if (primary) {
+            return (
+                <Button
+                    component={component}
+                    ref={ref}
+                    variant="subtle"
+                    {...others}
+                    {...getStyles('actionItemRoot', {className, style, classNames, styles})}
+                >
+                    {children}
+                </Button>
+            );
+        }
+
+        return (
+            <Menu.Item
+                component={component}
+                ref={ref}
+                {...others}
+                {...getStyles('actionItemRoot', {className, style, classNames, styles})}
+            >
+                {children}
+            </Menu.Item>
+        );
+    },
+);

--- a/packages/mantine/src/components/table/table-actions/TableActions.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableActions.tsx
@@ -1,33 +1,40 @@
-import {Factory, Grid, GridColProps, Group, useProps} from '@mantine/core';
+import {Factory, useProps} from '@mantine/core';
 import {ForwardedRef, ReactElement, ReactNode} from 'react';
 
 import {CustomComponentThemeExtend, identity} from '../../../utils';
-import {TableComponentsOrder} from '../Table';
+import {Table} from '../Table';
 import {useTableContext} from '../TableContext';
+import {TableActionsList} from './TableActionsList';
 
-export type TableActionsStylesNames = 'actionsRoot' | 'actionsGroup';
+export type TableActionsStylesNames = 'actionsTarget' | 'actionsDropdown' | 'actionsTooltip';
 
-export interface TableActionsProps<T> extends Omit<GridColProps, 'children'> {
+export type TableActionsItemElements = typeof Table.ActionItem | typeof Table.ActionLabel | typeof Table.ActionDivider;
+export type TableActionsItems = TableActionsItemElements | Iterable<TableActionsItemElements> | null;
+
+export interface TableActionsProps<T> {
     /**
      * Function that return components for the selected row or selected rows when multi row selection is enabled
      *
      * @param datum the data of the selected row(s)
      * @example
      * <Table.Actions<MyType>>
-     *     {(datum: MyType) => (
-     *         <Button
+     *     {(datum: MyType) => [
+     *         <Table.ActionItem
      *             component={Link}
      *             to={`edit/${datum.id}`}
      *             leftIcon={<EditSize24Px />}
-     *             variant="subtle"
-     *             color="navy.8"
      *         >
      *             Edit
-     *         </Button>
-     *     )}
+     *         </Table.ActionItem>
+     *     ]}
      * </Table.Actions>
      */
-    children: ((datum: T) => ReactNode) | ((data: T[]) => ReactNode);
+    children: ((datum: T) => TableActionsItems) | ((data: T[]) => TableActionsItems);
+    /**
+     * Label for the more menu
+     * @default 'More' when variant is 'split', 'Actions' when variant is 'combined'
+     */
+    moreMenuLabel?: string;
 }
 
 type TableActionsFactory = Factory<{
@@ -40,27 +47,19 @@ type TableActionsFactory = Factory<{
 const defaultProps: Partial<TableActionsProps<unknown>> = {};
 
 export const TableActions = <T,>(props: TableActionsProps<T> & {ref?: ForwardedRef<HTMLDivElement>}): ReactElement => {
-    const {store, getStyles} = useTableContext<T>();
-    const {style, className, classNames, styles, children, ...others} = useProps(
-        'PlasmaTableActions',
-        defaultProps,
-        props,
-    );
+    const {store} = useTableContext<T>();
+    const {children, moreMenuLabel} = useProps('PlasmaTableActions', defaultProps, props);
     const selectedRows = store.getSelectedRows();
 
     if (selectedRows.length <= 0) {
         return null;
     }
 
-    return (
-        <Grid.Col span="content" order={TableComponentsOrder.Actions} {...getStyles('actionsRoot', {})} {...others}>
-            <Group gap="xs" {...getStyles('actionsGroup', {})}>
-                {store.multiRowSelectionEnabled
-                    ? (children as (data: T[]) => ReactNode)(selectedRows)
-                    : (children as (datum: T) => ReactNode)(selectedRows[0])}
-            </Group>
-        </Grid.Col>
-    );
+    const actions = store.multiRowSelectionEnabled
+        ? (children as (data: T[]) => ReactNode)(selectedRows)
+        : (children as (datum: T) => ReactNode)(selectedRows[0]);
+
+    return <TableActionsList actions={actions} variant="split" label={moreMenuLabel} />;
 };
 
 TableActions.extend = identity as CustomComponentThemeExtend<TableActionsFactory>;

--- a/packages/mantine/src/components/table/table-actions/TableActions.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableActions.tsx
@@ -18,7 +18,7 @@ export interface TableActionsProps<T> {
      * @param datum the data of the selected row(s)
      * @example
      * <Table.Actions<MyType>>
-     *     {(datum: MyType) => [
+     *     {(datum: MyType) => (
      *         <Table.ActionItem
      *             component={Link}
      *             to={`edit/${datum.id}`}
@@ -26,7 +26,7 @@ export interface TableActionsProps<T> {
      *         >
      *             Edit
      *         </Table.ActionItem>
-     *     ]}
+     *     )}
      * </Table.Actions>
      */
     children: ((datum: T) => TableActionsItems) | ((data: T[]) => TableActionsItems);

--- a/packages/mantine/src/components/table/table-actions/TableActionsList.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableActionsList.tsx
@@ -1,0 +1,119 @@
+import {MoreSize16Px} from '@coveord/plasma-react-icons';
+import {
+    ActionIcon,
+    Button,
+    CompoundStylesApiProps,
+    ExtendComponent,
+    Factory,
+    Menu,
+    MenuProps,
+    Tooltip,
+    useProps,
+} from '@mantine/core';
+import {Children, Fragment, MouseEventHandler, ReactElement, ReactNode, useState} from 'react';
+import {useTableContext} from '../TableContext';
+
+export type TableActionsListStylesNames = 'actionsTarget' | 'actionsDropdown' | 'actionsTooltip';
+
+export interface TableActionsListProps
+    extends Omit<MenuProps, 'classNames' | 'styles' | 'vars' | 'variant'>,
+        CompoundStylesApiProps<TableActionsListFactory> {
+    actions: ReactNode;
+    /**
+     * Label for the more menu
+     * @default 'More' when variant is 'split', 'Actions' when variant is 'combined'
+     */
+    label?: string;
+    icon?: ReactNode;
+}
+
+type TableActionsListFactory = Factory<{
+    props: TableActionsListProps;
+    ref: HTMLDivElement;
+    stylesNames: TableActionsListStylesNames;
+    compound: true;
+    variant: 'split' | 'combined';
+}>;
+
+const defaultProps: Partial<TableActionsListProps> = {
+    label: 'More',
+    icon: <MoreSize16Px height={16} />,
+};
+
+export const TableActionsList = (props: TableActionsListProps) => {
+    const {getStyles} = useTableContext();
+    const {
+        actions,
+        icon,
+        label,
+        classNames,
+        styles,
+        vars: _vars,
+        variant,
+        ...others
+    } = useProps('PlasmaTableActionsListColumn', defaultProps, props);
+    const [opened, setOpened] = useState(false);
+
+    const onClick: MouseEventHandler = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setOpened((prevState) => !prevState);
+    };
+    const onChange = (newOpened: boolean) => {
+        if (!newOpened) {
+            setOpened(false);
+        }
+    };
+
+    let childrenArray = Children.toArray(actions) as ReactElement[];
+    if (childrenArray.length === 1 && childrenArray[0].type === Fragment) {
+        childrenArray = Children.toArray(childrenArray[0].props.children) as ReactElement[];
+    }
+
+    if (variant === 'split') {
+        const primaryActions = childrenArray.filter((child) => child.props.primary);
+        const secondaryActions = childrenArray.filter((child) => !child.props.primary);
+
+        return (
+            <>
+                {primaryActions}
+                {secondaryActions.length > 0 ? (
+                    <Menu withinPortal={false} {...others}>
+                        <Menu.Target>
+                            <Button
+                                {...getStyles('actionsTarget', {styles, classNames})}
+                                variant="subtle"
+                                leftSection={icon}
+                            >
+                                {label}
+                            </Button>
+                        </Menu.Target>
+                        <Menu.Dropdown {...getStyles('actionsDropdown', {styles, classNames})}>
+                            {secondaryActions}
+                        </Menu.Dropdown>
+                    </Menu>
+                ) : null}
+            </>
+        );
+    }
+
+    const menuItems = childrenArray.map((child) => (child.props.primary ? <Menu.Item {...child.props} /> : child));
+    return (
+        <Menu opened={opened} onChange={onChange} {...others}>
+            <Menu.Target>
+                <Tooltip label={label} {...getStyles('actionsTooltip', {styles, classNames})}>
+                    <ActionIcon
+                        onClick={onClick}
+                        variant="subtle"
+                        {...getStyles('actionsTarget', {styles, classNames})}
+                    >
+                        {icon}
+                    </ActionIcon>
+                </Tooltip>
+            </Menu.Target>
+            <Menu.Dropdown {...getStyles('actionsDropdown', {styles, classNames})}>{menuItems}</Menu.Dropdown>
+        </Menu>
+    );
+};
+
+TableActionsList.extend = (input: ExtendComponent<TableActionsListFactory>) => input;

--- a/packages/mantine/src/components/table/table-actions/TableHeaderActions.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableHeaderActions.tsx
@@ -27,7 +27,7 @@ export const TableHeaderActions = factory<TableHeaderActionsFactory>(
         );
         const selectedRows = store.getSelectedRows();
 
-        if (selectedRows.length <= 0) {
+        if (selectedRows.length <= 0 || !props.children) {
             return null;
         }
 

--- a/packages/mantine/src/components/table/table-actions/TableHeaderActions.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableHeaderActions.tsx
@@ -1,0 +1,50 @@
+import {Factory, factory, Grid, GridColProps, Group, useProps} from '@mantine/core';
+import {ReactElement} from 'react';
+
+import {TableComponentsOrder} from '../Table';
+import {useTableContext} from '../TableContext';
+
+export type TableHeaderActionsStylesNames = 'headerActionsRoot' | 'headerActionsGroup';
+
+export interface TableHeaderActionsProps extends GridColProps {}
+
+type TableHeaderActionsFactory = Factory<{
+    props: TableHeaderActionsProps;
+    ref: HTMLDivElement;
+    stylesNames: TableHeaderActionsStylesNames;
+    compound: true;
+}>;
+
+const defaultProps: Partial<TableHeaderActionsProps> = {};
+
+export const TableHeaderActions = factory<TableHeaderActionsFactory>(
+    (props: TableHeaderActionsProps, ref): ReactElement => {
+        const {store, getStyles} = useTableContext();
+        const {style, className, classNames, styles, children, ...others} = useProps(
+            'PlasmaTableHeaderActions',
+            defaultProps,
+            props,
+        );
+        const selectedRows = store.getSelectedRows();
+
+        if (selectedRows.length <= 0) {
+            return null;
+        }
+
+        const stylesApiProps = {classNames, styles};
+
+        return (
+            <Grid.Col
+                span="content"
+                order={TableComponentsOrder.Actions}
+                ref={ref}
+                {...getStyles('headerActionsRoot', {className, style, ...stylesApiProps})}
+                {...others}
+            >
+                <Group gap="xs" {...getStyles('headerActionsGroup', stylesApiProps)}>
+                    {children}
+                </Group>
+            </Grid.Col>
+        );
+    },
+);

--- a/packages/mantine/src/components/table/table-actions/index.ts
+++ b/packages/mantine/src/components/table/table-actions/index.ts
@@ -1,0 +1,3 @@
+export * from './TableActionItem';
+export * from './TableActions';
+export * from './TableHeaderActions';

--- a/packages/mantine/src/components/table/table-column/TableActionsColumn.tsx
+++ b/packages/mantine/src/components/table/table-column/TableActionsColumn.tsx
@@ -1,0 +1,39 @@
+import {MoreSize16Px} from '@coveord/plasma-react-icons';
+import {useProps} from '@mantine/core';
+import {CellContext, ColumnDef} from '@tanstack/table-core';
+import {FunctionComponent} from 'react';
+import {TableActionsList, TableActionsListProps} from '../table-actions/TableActionsList';
+import {useTableContext} from '../TableContext';
+
+/**
+ * Generic column to use when your table needs actions on rows
+ */
+export const TableActionsColumn: ColumnDef<unknown> = {
+    id: 'actions',
+    enableSorting: false,
+    enableHiding: false,
+    meta: {
+        controlColumn: true,
+    },
+    header: '',
+    size: 84, // 16px padding left + 28px ActionIcon + 40px padding right
+    cell: (info) => <ActionsMenu info={info} />,
+};
+
+interface TableActionsColumnProps extends Omit<TableActionsListProps, 'actions'> {
+    info: CellContext<unknown, unknown>;
+}
+
+const defaultProps: Partial<TableActionsColumnProps> = {
+    label: 'Actions',
+    icon: <MoreSize16Px height={16} />,
+};
+
+const ActionsMenu: FunctionComponent<TableActionsColumnProps> = (props) => {
+    const {actions} = useTableContext();
+
+    const {info, ...others} = useProps('PlasmaTableActionsColumn', defaultProps, props);
+
+    const actionsElements = actions.props.children(info.row.original);
+    return <TableActionsList actions={actionsElements} variant="combined" {...others} />;
+};

--- a/packages/mantine/src/components/table/table-header/TableHeader.tsx
+++ b/packages/mantine/src/components/table/table-header/TableHeader.tsx
@@ -5,6 +5,7 @@ import {ReactNode} from 'react';
 import {Button} from '../../button';
 import {TableLayoutControl} from '../layouts/TableLayoutControl';
 import {TableComponentsOrder} from '../Table';
+import {TableHeaderActions} from '../table-actions';
 import {useTableContext} from '../TableContext';
 
 export type TableHeaderStylesNames = 'headerRoot' | 'headerGrid' | 'headerGridInner' | 'headerCol';
@@ -16,6 +17,12 @@ export interface TableHeaderProps
     children?: ReactNode;
     unselectAllLabel?: string;
     selectedCountLabel?: (count: number) => string;
+    /**
+     * Whether to show actions when rows are selected
+     *
+     * default true
+     */
+    showActions?: boolean;
 }
 
 export type TableHeaderFactory = Factory<{
@@ -28,12 +35,23 @@ export type TableHeaderFactory = Factory<{
 const defaultProps: Partial<TableHeaderProps> = {
     unselectAllLabel: 'Unselect all',
     selectedCountLabel: (count) => `${count} selected`,
+    showActions: true,
 };
 
 export const TableHeader = factory<TableHeaderFactory>((props, ref) => {
-    const {store, getStyles} = useTableContext();
-    const {unselectAllLabel, selectedCountLabel, children, classNames, className, styles, style, vars, ...others} =
-        useProps('PlasmaTableHeader', defaultProps, props);
+    const {store, actions, getStyles} = useTableContext();
+    const {
+        showActions,
+        unselectAllLabel,
+        selectedCountLabel,
+        children,
+        classNames,
+        className,
+        styles,
+        style,
+        vars: _vars,
+        ...others
+    } = useProps('PlasmaTableHeader', defaultProps, props);
     const selectedRows = store.getSelectedRows();
 
     const stylesApiProps = {classNames, styles};
@@ -67,6 +85,7 @@ export const TableHeader = factory<TableHeaderFactory>((props, ref) => {
                     </Grid.Col>
                 ) : null}
                 {children}
+                {showActions ? <TableHeaderActions>{actions}</TableHeaderActions> : null}
                 <TableLayoutControl />
             </Grid>
         </Box>

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -1,4 +1,5 @@
-import {Button, ColumnDef, createColumnHelper, Table, useTable} from '@coveord/plasma-mantine';
+import {ColumnDef, createColumnHelper, Table, useTable} from '@coveord/plasma-mantine';
+import {AbTestingSize16Px, EditSize16Px} from '@coveord/plasma-react-icons';
 import {faker} from '@faker-js/faker';
 import {useMemo} from 'react';
 
@@ -37,26 +38,26 @@ const Demo = () => {
 
     return (
         <Table<Person> store={table} data={data} columns={columns} getRowId={({id}) => id.toString()}>
-            <Table.Header>
-                <Table.Actions>
-                    {(selectedRow: Person) => (
-                        <>
-                            <Button
-                                variant="subtle"
-                                onClick={() => alert(`Action 1 triggered for row: ${selectedRow.id}`)}
-                            >
-                                Action 1
-                            </Button>
-                            <Button
-                                variant="subtle"
-                                onClick={() => alert(`Action 2 triggered for row: ${selectedRow.id}`)}
-                            >
-                                Action 2
-                            </Button>
-                        </>
-                    )}
-                </Table.Actions>
-            </Table.Header>
+            <Table.Actions>
+                {(selectedRow: Person) => (
+                    <>
+                        <Table.ActionItem
+                            primary
+                            onClick={() => alert(`Action 1 triggered for row: ${selectedRow.id}`)}
+                            leftSection={<EditSize16Px height={16} />}
+                        >
+                            Action 1
+                        </Table.ActionItem>
+                        <Table.ActionItem
+                            onClick={() => alert(`Action 2 triggered for row: ${selectedRow.id}`)}
+                            leftSection={<AbTestingSize16Px height={16} />}
+                        >
+                            Action 2
+                        </Table.ActionItem>
+                    </>
+                )}
+            </Table.Actions>
+            <Table.Header />
         </Table>
     );
 };

--- a/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
@@ -83,15 +83,15 @@ const Demo = () => {
             doubleClickAction={(person) => alert(`Double clicked ${person.firstName}`)}
         >
             <Table.Actions>
-                {(selected: Person) => [
+                {(selected: Person) => (
                     <Table.ActionItem
                         primary
                         onClick={() => alert(`Clicked ${selected.firstName}`)}
                         leftSection={<EditSize16Px height={16} />}
                     >
                         Action 1
-                    </Table.ActionItem>,
-                ]}
+                    </Table.ActionItem>
+                )}
             </Table.Actions>
             <Table.Header />
         </Table>

--- a/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
@@ -1,6 +1,5 @@
 import {
     Box,
-    Button,
     ColumnDef,
     createColumnHelper,
     Paper,
@@ -13,7 +12,7 @@ import {
     useTable,
     useTableContext,
 } from '@coveord/plasma-mantine';
-import {CardSize16Px} from '@coveord/plasma-react-icons';
+import {CardSize16Px, EditSize16Px} from '@coveord/plasma-react-icons';
 import {faker} from '@faker-js/faker';
 import {useMemo} from 'react';
 
@@ -83,15 +82,18 @@ const Demo = () => {
             layouts={[Table.Layouts.Rows, CardLayout]}
             doubleClickAction={(person) => alert(`Double clicked ${person.firstName}`)}
         >
-            <Table.Header>
-                <Table.Actions>
-                    {(selected) => (
-                        <Button variant="subtle" onClick={() => alert(`Clicked ${selected.firstName}`)}>
-                            Action 1
-                        </Button>
-                    )}
-                </Table.Actions>
-            </Table.Header>
+            <Table.Actions>
+                {(selected: Person) => [
+                    <Table.ActionItem
+                        primary
+                        onClick={() => alert(`Clicked ${selected.firstName}`)}
+                        leftSection={<EditSize16Px height={16} />}
+                    >
+                        Action 1
+                    </Table.ActionItem>,
+                ]}
+            </Table.Actions>
+            <Table.Header />
         </Table>
     );
 };

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -7,6 +7,7 @@ import {
     getFilteredRowModel,
     getPaginationRowModel,
     Table,
+    TableActionsItems,
     Title,
     useDidUpdate,
     useTable,
@@ -35,6 +36,7 @@ const columns: Array<ColumnDef<IExampleRowData>> = [
         cell: (info) => info.row.original.title,
         enableSorting: false,
     }),
+    Table.ActionsColumn as ColumnDef<IExampleRowData>,
 ];
 
 const Demo = () => {
@@ -62,10 +64,8 @@ const Demo = () => {
 
     return (
         <Table<IExampleRowData> store={table} data={data} getRowId={({id}) => id} columns={columns} options={options}>
+            <Table.Actions>{rowActions}</Table.Actions>
             <Table.Header>
-                <Table.Actions>
-                    {(selectedRows: IExampleRowData[]) => <TableActions data={selectedRows} />}
-                </Table.Actions>
                 <Table.Filter placeholder="Search posts by title" />
             </Table.Header>
             <Table.NoData>
@@ -92,27 +92,31 @@ const EmptyState: FunctionComponent<{isFiltered: boolean; clearFilters: () => vo
         </BlankSlate>
     );
 
-const TableActions: FunctionComponent<{data: IExampleRowData[]}> = ({data}) => {
-    if (data.length === 1) {
+const rowActions = (selected: IExampleRowData | IExampleRowData[]): TableActionsItems => {
+    const selectedAsArr = selected instanceof Array ? selected : [selected];
+    if (selectedAsArr.length === 1) {
         return (
-            <Button
-                variant="subtle"
-                onClick={() => alert(`Action triggered on a single row: ${data[0].id}`)}
+            <Table.ActionItem
+                primary
+                onClick={() => alert(`Action triggered on a single row: ${selectedAsArr[0].id}`)}
                 leftSection={<EditSize16Px height={16} />}
             >
                 Single row action
-            </Button>
+            </Table.ActionItem>
         );
     }
-    if (data.length > 1) {
+    if (selectedAsArr.length > 1) {
         return (
-            <Button
+            <Table.ActionItem
+                primary
                 variant="subtle"
-                onClick={() => alert(`Bulk action triggered on multiple rows: ${data.map(({id}) => id).join(', ')}`)}
+                onClick={() =>
+                    alert(`Bulk action triggered on multiple rows: ${selectedAsArr.map(({id}) => id).join(', ')}`)
+                }
                 leftSection={<DeleteSize16Px height={16} />}
             >
                 Bulk action
-            </Button>
+            </Table.ActionItem>
         );
     }
 


### PR DESCRIPTION
### Proposed Changes

Rework the Table.Actions
- Developer need to move it outside of the `<TableHeader>` , it will be automatically added inside the header if the prop `showActions` is true.
- Created a new `Table.ActionsColumn` that can be used the same way as the `Table.CollapsibleColumn`, `Table.AccordionColumn` or `Table.SelectableColumn`. I wasn't able to find any UX mockup so take it with a grain of salt, but it's a good base.
- children must now return Table.ActionItem
- Updated the examples and fixed the tests

### Potential Breaking Changes

See above!

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
