### PR TITLE
feat(mantine): pass down row object to getRow* props

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -156,7 +156,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
         manualPagination: options?.getPaginationRowModel === undefined,
         enableMultiRowSelection: !!store.multiRowSelectionEnabled,
         getRowId,
-        getRowCanExpand: (row: Row<T>) => !!getExpandChildren?.(row.original) ?? false,
+        getRowCanExpand: (row: Row<T>) => !!getExpandChildren?.(row.original, row.index, row) ?? false,
         enableRowSelection: !loading,
         defaultColumn: {
             size: undefined,

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -1,6 +1,6 @@
 import {Icon} from '@coveord/plasma-react-icons';
 import {BoxProps, StylesApiProps} from '@mantine/core';
-import {ColumnDef, CoreOptions, TableOptions} from '@tanstack/table-core';
+import {ColumnDef, CoreOptions, Row, TableOptions} from '@tanstack/table-core';
 import {ReactElement, ReactNode} from 'react';
 
 import {type PlasmaTableFactory} from './Table';
@@ -11,18 +11,18 @@ export interface TableLayoutProps<TData = unknown> {
     /**
      * Action passed when user double-clicks on a row
      */
-    doubleClickAction?: (datum: TData) => void;
+    doubleClickAction?: (datum: TData, index: number, row: Row<TData>) => void;
     /**
      * Function that generates the expandable content of a row
      * Return null for rows that don't need to be expandable
      *
      * @param datum the row for which the children should be generated.
      */
-    getExpandChildren?: (datum: TData) => ReactNode;
+    getExpandChildren?: (datum: TData, index: number, row: Row<TData>) => ReactNode;
     /**
      * Function that can be used to add additional attributes on rows
      */
-    getRowAttributes?: (datum: TData) => Record<string, unknown>;
+    getRowAttributes?: (datum: TData, index: number, row: Row<TData>) => Record<string, unknown>;
 }
 
 export interface TableLayout {
@@ -62,7 +62,7 @@ export interface TableProps<TData> extends BoxProps, StylesApiProps<PlasmaTableF
     /**
      * Allows to define html attributes that will be passed down to each row.
      */
-    getRowAttributes?: (row: TData) => Record<string, unknown>;
+    getRowAttributes?: (datum: TData, index: number, row: Row<TData>) => Record<string, unknown>;
     /**
      * Columns to display in the table.
      *
@@ -85,7 +85,7 @@ export interface TableProps<TData> extends BoxProps, StylesApiProps<PlasmaTableF
      *
      * @param datum the row for which the children should be generated.
      */
-    getExpandChildren?: (datum: TData) => ReactNode;
+    getExpandChildren?: (datum: TData, index: number, row: Row<TData>) => ReactNode;
     /**
      * Whether the table is loading or not
      *

--- a/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
@@ -229,7 +229,11 @@ describe('RowLayout', () => {
         render(<Fixture />);
         await user.dblClick(screen.getByRole('cell', {name: 'Mario'}));
         expect(doubleClickSpy).toHaveBeenCalledTimes(1);
-        expect(doubleClickSpy).toHaveBeenCalledWith({id: '🆔-1', firstName: 'Mario'});
+        expect(doubleClickSpy).toHaveBeenCalledWith(
+            {id: '🆔-1', firstName: 'Mario'},
+            0,
+            expect.objectContaining({id: '🆔-1'}),
+        );
     });
 
     it('toggles row selection when clicking on a selected row', async () => {

--- a/packages/mantine/src/components/table/layouts/row-layout/RowLayoutBody.tsx
+++ b/packages/mantine/src/components/table/layouts/row-layout/RowLayoutBody.tsx
@@ -46,7 +46,7 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
     };
 
     const rows = table.getRowModel()?.rows.map((row) => {
-        const rowChildren = getExpandChildren?.(row.original) ?? null;
+        const rowChildren = getExpandChildren?.(row.original, row.index, row) ?? null;
         const isSelected = !!row.getIsSelected();
         const shouldKeepSelection = store.rowSelectionForced && isSelected;
         const onClick = (event: MouseEvent<HTMLTableRowElement>) => {
@@ -62,14 +62,14 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
             <Fragment key={row.id}>
                 <tr
                     onClick={onClick}
-                    onDoubleClick={() => doubleClickAction?.(row.original)}
+                    onDoubleClick={() => doubleClickAction?.(row.original, row.index, row)}
                     data-selectable={store.rowSelectionEnabled}
                     data-selected={isSelected}
                     data-multi-selection={store.multiRowSelectionEnabled}
                     aria-selected={isSelected}
                     data-testid={row.id}
                     {...ctx.getStyles('row', {classNames, className, styles, style})}
-                    {...(getRowAttributes?.(row.original) ?? {})}
+                    {...(getRowAttributes?.(row.original, row.index, row) ?? {})}
                     {...others}
                 >
                     {row.getVisibleCells().map((cell) => {

--- a/packages/mantine/src/components/table/table-header/Th.tsx
+++ b/packages/mantine/src/components/table/table-header/Th.tsx
@@ -70,7 +70,9 @@ export const Th = <T,>(props: ThProps<T> & {ref?: ForwardedRef<HTMLTableCellElem
                 }}
                 {...others}
             >
-                {flexRender(header.column.columnDef.header, header.getContext())}
+                <Group wrap="nowrap" gap="xs">
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                </Group>
             </th>
         );
     }

--- a/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
@@ -35,7 +35,7 @@ const TableCards = <TData,>(props: TableLayoutProps<TData>) => {
                     if (event.detail <= 1) {
                         row.toggleSelected(true);
                     } else {
-                        props.doubleClickAction(row.original);
+                        props.doubleClickAction(row.original, row.index, row);
                     }
                 }}
             >


### PR DESCRIPTION
### Proposed Changes

Adjusting Table's `getRowAttributes` and `getExpandChildren` props so that they all match the same arguments signature. I chose the signature of the existing `getRowId` prop, which is the following:

```ts
getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string;
```

Doing so has a few benefits:
- It gives more flexibility to the Table implementer. For instance since you have access to the row object (3rd param) you can gain access to tanstack table's row API. So you can do stuff like 
```tsx
<Table
    getExpandChildren={(rowData, index, row) => row.getIsExpanded() 
        ? <ExpensiveContentOnlyFetchedWhenExpanded id={rowData.id} /> 
        : <Loader />
    }
/>
```
- It brings consistency to the table props `get*`

### Potential Breaking Changes

It can break custom layout implementations because the layout props now expect 3 arguments to be passed down the affected props.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
