### PR TITLE
chore: fix typing of TableActionsItem

### DIFF
--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -2,5 +2,4 @@ export {flexRender as renderTableCell} from '@tanstack/react-table';
 export * from './Table';
 export {type TableLayout, type TableProps, type TableLayoutProps} from './Table.types';
 export {useTable, type TableState, type TableStore, type UseTableOptions} from './use-table';
-export type {TableActionsItems, TableActionsItemElements} from './table-actions';
 export {useTableContext} from './TableContext';

--- a/packages/mantine/src/components/table/table-actions/TableActions.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableActions.tsx
@@ -2,20 +2,10 @@ import {Factory, useProps} from '@mantine/core';
 import {ForwardedRef, ReactElement, ReactNode} from 'react';
 
 import {CustomComponentThemeExtend, identity} from '../../../utils';
-import {InlineConfirm} from '../../inline-confirm';
-import {Table} from '../Table';
 import {useTableContext} from '../TableContext';
 import {TableActionsList} from './TableActionsList';
 
 export type TableActionsStylesNames = 'actionsTarget' | 'actionsDropdown' | 'actionsTooltip';
-
-export type TableActionsItemElements =
-    | typeof Table.ActionItem
-    | typeof Table.ActionLabel
-    | typeof Table.ActionDivider
-    | typeof InlineConfirm.Target
-    | typeof InlineConfirm.Prompt;
-export type TableActionsItems = TableActionsItemElements | Iterable<TableActionsItemElements> | null;
 
 export interface TableActionsProps<T> {
     /**
@@ -35,7 +25,7 @@ export interface TableActionsProps<T> {
      *     )}
      * </Table.Actions>
      */
-    children: ((datum: T) => TableActionsItems) | ((data: T[]) => TableActionsItems);
+    children: ((datum: T) => ReactNode) | ((data: T[]) => ReactNode);
     /**
      * Label for the more menu
      * @default 'More' when variant is 'split', 'Actions' when variant is 'combined'

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -7,7 +7,6 @@ import {
     getFilteredRowModel,
     getPaginationRowModel,
     Table,
-    TableActionsItems,
     Title,
     useDidUpdate,
     useTable,
@@ -15,7 +14,7 @@ import {
 import {DeleteSize16Px, EditSize16Px} from '@coveord/plasma-react-icons';
 import {faker} from '@faker-js/faker';
 import {rankItem} from '@tanstack/match-sorter-utils';
-import {FunctionComponent, useMemo} from 'react';
+import {FunctionComponent, ReactNode, useMemo} from 'react';
 
 interface IExampleRowData {
     userId: number;
@@ -92,7 +91,7 @@ const EmptyState: FunctionComponent<{isFiltered: boolean; clearFilters: () => vo
         </BlankSlate>
     );
 
-const rowActions = (selected: IExampleRowData | IExampleRowData[]): TableActionsItems => {
+const rowActions = (selected: IExampleRowData | IExampleRowData[]): ReactNode => {
     const selectedAsArr = selected instanceof Array ? selected : [selected];
     if (selectedAsArr.length === 1) {
         return (


### PR DESCRIPTION
### Proposed Changes

The typing was too restrictive and prevented us from properly using Table.Actions

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
