### PR TITLE
fix(mantine): close date range picker on click outside

### DIFF
--- a/packages/mantine/src/components/table/table-actions/TableActionsList.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableActionsList.tsx
@@ -101,14 +101,14 @@ export const TableActionsList = (props: TableActionsListProps) => {
             </InlineConfirm>
         );
     }
-
     const prompts = childrenArray.filter((child) => child.type === InlineConfirm.Prompt);
-    const menuItems = childrenArray
-        .filter((child) => child.type !== InlineConfirm.Prompt)
-        .map((child) => {
-            const {primary, ...childProps} = child.props;
-            return primary ? <Menu.Item {...childProps} /> : child;
-        });
+    const menuItems = Children.map(childrenArray, (child) => {
+        if (child.type === InlineConfirm.Prompt) {
+            return null;
+        }
+        const {primary, ...childProps} = child.props;
+        return primary ? <Menu.Item {...childProps} /> : child;
+    });
     return (
         <InlineConfirm>
             {prompts}

--- a/packages/mantine/src/components/table/table-date-range-picker/TableDateRangePicker.tsx
+++ b/packages/mantine/src/components/table/table-date-range-picker/TableDateRangePicker.tsx
@@ -74,7 +74,7 @@ export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props,
             {...getStyles('dateRangeRoot', {className, style, ...stylesApiProps})}
             {...others}
         >
-            <Popover withinPortal opened={opened}>
+            <Popover withinPortal opened={opened} onChange={setOpened}>
                 <Popover.Target>
                     <InputBase
                         component="button"


### PR DESCRIPTION
### Proposed Changes

Two small fixes for the Table component:
- Remove TableActionsList unique keys warning
- Close date range picker popover when clicking outside of it

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
