### PR TITLE
fix(mantine): table actions group type

### DIFF
--- a/helpers/eslint-config-plasma/index.js
+++ b/helpers/eslint-config-plasma/index.js
@@ -21,7 +21,7 @@ module.exports = {
             },
         ],
         '@typescript-eslint/ban-types': [
-            'error',
+            'warn',
             {
                 types: {
                     Object: {

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -131,7 +131,7 @@ export interface TableAction<TData = unknown> {
      * $$confirmPrompt is reserved for InlineConfirm.Prompt, it will hide other actions when prompt is opened
      * other string will be considered secondary custom group
      */
-    group: '$$primary' | '$$confirmPrompt' | (string & unknown);
+    group: '$$primary' | '$$confirmPrompt' | (string & {});
     /**
      * Component to render, should be either `Table.PrimaryAction` or `Table.SecondaryAction`
      */


### PR DESCRIPTION
### Proposed Changes

Make sure autocomplete works in all IDE for the table actions group name

Before
![image](https://github.com/coveo/plasma/assets/35579930/c1c2d797-c787-4620-9200-b32d9d2fddf5)

After
![image](https://github.com/coveo/plasma/assets/35579930/339325f9-5572-4fe2-bf1c-f4d5890c7026)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
