### PR TITLE
fix(tableActions): changed interface so it extends button

### DIFF
--- a/packages/mantine/src/components/table/table-actions/TableActionItem.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableActionItem.tsx
@@ -1,12 +1,17 @@
-import {BoxProps, CompoundStylesApiProps, Menu, PolymorphicFactory, polymorphicFactory, useProps} from '@mantine/core';
+import {CompoundStylesApiProps, Menu, PolymorphicFactory, polymorphicFactory, useProps} from '@mantine/core';
 import {ReactNode} from 'react';
-import {Button} from '../../button';
+import {Button, ButtonProps} from '../../button';
 import {useTableContext} from '../TableContext';
 import {useTableActionContext} from './TableActionContext';
 
 export type TableActionItemStylesNames = 'actionItemRoot';
 
-export interface TableActionItemProps extends BoxProps, CompoundStylesApiProps<TableActionItemFactory> {
+export interface TableActionItemProps
+    extends Omit<
+            ButtonProps,
+            'classNames' | 'styles' | 'vars' | 'variant' | 'leftSection' | 'rightSection' | 'disabled'
+        >,
+        CompoundStylesApiProps<TableActionItemFactory> {
     /**
      * Action label
      */


### PR DESCRIPTION
### Proposed Changes

I've extended ButtonProps for the TableActionItemsProps so that we can have access to `disabled, leftSection, rightSection, disabledTooltip, etc`. 

I've omitted some props to redefine them with its own description and also to make leftSection mandatory (which is optional in the Button implementation)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
