### PR TITLE
fix(mantine, inline-confirm): allow prompt to be wrapped

### DIFF
--- a/packages/mantine/src/components/inline-confirm/InlineConfirm.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirm.tsx
@@ -5,6 +5,16 @@ import {InlineConfirmPrompt} from './InlineConfirmPrompt';
 
 import {InlineConfirmTarget} from './InlineConfirmTarget';
 
+/**
+ * Direct children of InlineConfirm that wraps an InlineConfirm.Prompt need this prop
+ */
+export interface InlineConfirmComponentsProps {
+    /**
+     * Unique id to map the prompt to the target
+     */
+    inlineConfirmId: string;
+}
+
 export interface InlineConfirmProps extends StylesApiProps<InlineConfirmFactory> {
     /**
      * The content of the component. Should contain at least one `InlineConfirm.Target` and one `InlineConfirm.Prompt` with matching ids
@@ -29,10 +39,9 @@ export const InlineConfirm = ((_props) => {
 
     const convertedChildren = Children.toArray(children) as ReactElement[];
     const prompt = convertedChildren.find(
-        (child) => child.type === InlineConfirmPrompt && child.props.id === confirmingId,
+        (child) => child.type !== InlineConfirmTarget && child.props?.inlineConfirmId === confirmingId,
     );
     const clearConfirm = () => setConfirmingId(null);
-
     return (
         <InlineConfirmProvider value={{confirmingId, setConfirmingId, clearConfirm}}>
             {prompt ?? children}

--- a/packages/mantine/src/components/inline-confirm/InlineConfirmPrompt.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirmPrompt.tsx
@@ -1,14 +1,11 @@
 import {Factory, factory, Group, GroupProps, isElement, useProps} from '@mantine/core';
 import {cloneElement, ReactElement, ReactNode, useEffect} from 'react';
+import {Button} from '../button/Button';
+import {InlineConfirmComponentsProps} from './InlineConfirm';
 
 import {useInlineConfirm} from './InlineConfirmContext';
-import {Button} from '../button/Button';
 
-interface InlineConfirmPromptProps extends Omit<GroupProps, 'children'> {
-    /**
-     * Unique id to map the prompt to the target
-     */
-    id: string;
+interface InlineConfirmPromptProps extends Omit<GroupProps, 'children'>, InlineConfirmComponentsProps {
     /**
      * Label element
      *
@@ -52,7 +49,7 @@ const defaultProps: Partial<InlineConfirmPromptProps> = {
 };
 
 export const InlineConfirmPrompt = factory<InlineConfirmPromptFactory>((props, ref) => {
-    const {id, label, confirm, cancel, onConfirm, onCancel, ...others} = useProps(
+    const {inlineConfirmId, label, confirm, cancel, onConfirm, onCancel, ...others} = useProps(
         'InlineConfirmPrompt',
         defaultProps,
         props,
@@ -80,12 +77,12 @@ export const InlineConfirmPrompt = factory<InlineConfirmPromptFactory>((props, r
     });
 
     useEffect(() => {
-        if (confirmingId !== id) {
+        if (confirmingId !== inlineConfirmId) {
             clearConfirm();
         }
     }, []);
 
-    if (confirmingId === id) {
+    if (confirmingId === inlineConfirmId) {
         return (
             <Group ref={ref} {...others}>
                 {label}

--- a/packages/mantine/src/components/inline-confirm/InlineConfirmTarget.tsx
+++ b/packages/mantine/src/components/inline-confirm/InlineConfirmTarget.tsx
@@ -1,22 +1,27 @@
 import {createPolymorphicComponent} from '@mantine/core';
 import {forwardRef, MouseEventHandler} from 'react';
 import {Button, ButtonProps} from '../button';
+import {InlineConfirmComponentsProps} from './InlineConfirm';
 import {useInlineConfirm} from './InlineConfirmContext';
 
-export interface InlineConfirmTargetProps extends ButtonProps {
-    id: string;
+export interface InlineConfirmTargetProps extends ButtonProps, InlineConfirmComponentsProps {
     onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 export const InlineConfirmTarget = createPolymorphicComponent<typeof Button, InlineConfirmTargetProps>(
     forwardRef(
         (
-            {onClick, id, component: Component = Button, ...others}: InlineConfirmTargetProps & {component?: any},
+            {
+                onClick,
+                inlineConfirmId,
+                component: Component = Button,
+                ...others
+            }: InlineConfirmTargetProps & {component?: any},
             ref,
         ) => {
             const {setConfirmingId} = useInlineConfirm();
             const handleOnClick: MouseEventHandler<HTMLButtonElement> = (e) => {
-                setConfirmingId(id);
+                setConfirmingId(inlineConfirmId);
                 onClick?.(e);
             };
 

--- a/packages/mantine/src/components/inline-confirm/__tests__/InlineConfirm.spec.tsx
+++ b/packages/mantine/src/components/inline-confirm/__tests__/InlineConfirm.spec.tsx
@@ -1,7 +1,7 @@
 import {Button, Menu} from '@mantine/core';
 import {render, screen, userEvent} from '@test-utils';
 
-import {InlineConfirm} from '../InlineConfirm';
+import {InlineConfirm, InlineConfirmComponentsProps} from '../InlineConfirm';
 
 describe('InlineConfirm', () => {
     it('renders its children', () => {
@@ -15,7 +15,7 @@ describe('InlineConfirm', () => {
         const onClickSpy = vi.fn();
         render(
             <InlineConfirm>
-                <InlineConfirm.Target id="delete" onClick={onClickSpy}>
+                <InlineConfirm.Target inlineConfirmId="delete" onClick={onClickSpy}>
                     Delete
                 </InlineConfirm.Target>
             </InlineConfirm>,
@@ -36,7 +36,7 @@ describe('InlineConfirm', () => {
                         <button>open menu</button>
                     </Menu.Target>
                     <Menu.Dropdown>
-                        <InlineConfirm.Target component={Menu.Item} id="delete" onClick={onClickSpy}>
+                        <InlineConfirm.Target component={Menu.Item} inlineConfirmId="delete" onClick={onClickSpy}>
                             Delete
                         </InlineConfirm.Target>
                     </Menu.Dropdown>
@@ -54,8 +54,28 @@ describe('InlineConfirm', () => {
         const user = userEvent.setup({delay: null});
         render(
             <InlineConfirm>
-                <InlineConfirm.Target id="my-button-id">Remove</InlineConfirm.Target>
-                <InlineConfirm.Prompt id="my-button-id" />
+                <InlineConfirm.Target inlineConfirmId="my-button-id">Remove</InlineConfirm.Target>
+                <InlineConfirm.Prompt inlineConfirmId="my-button-id" />
+            </InlineConfirm>,
+        );
+        expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Remove'})).toBeVisible();
+
+        await user.click(screen.getByRole('button', {name: 'Remove'}));
+
+        expect(screen.getByText('Are you sure?')).toBeVisible();
+        expect(screen.queryByRole('button', {name: 'Remove'})).not.toBeInTheDocument();
+    });
+
+    it('replace the children with a prompt when clicking on a button which requires confirmation even if the prompt is nested', async () => {
+        const user = userEvent.setup();
+        const Fixture = ({inlineConfirmId}: InlineConfirmComponentsProps) => (
+            <InlineConfirm.Prompt inlineConfirmId={inlineConfirmId} />
+        );
+        render(
+            <InlineConfirm>
+                <InlineConfirm.Target inlineConfirmId="my-button-id">Remove</InlineConfirm.Target>
+                <Fixture inlineConfirmId="my-button-id" />
             </InlineConfirm>,
         );
         expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
@@ -72,9 +92,9 @@ describe('InlineConfirm', () => {
         const confirmSpy = vi.fn();
         render(
             <InlineConfirm>
-                <InlineConfirm.Target id="my-button-id">Remove</InlineConfirm.Target>
+                <InlineConfirm.Target inlineConfirmId="my-button-id">Remove</InlineConfirm.Target>
                 <InlineConfirm.Prompt
-                    id="my-button-id"
+                    inlineConfirmId="my-button-id"
                     label="Remove?"
                     confirm={<Button onClick={confirmSpy}>I confirm</Button>}
                     cancel={<Button>I changed my mind</Button>}
@@ -101,17 +121,17 @@ describe('InlineConfirm', () => {
         const user = userEvent.setup({delay: null});
         render(
             <InlineConfirm>
-                <InlineConfirm.Target id="remove">Remove</InlineConfirm.Target>
+                <InlineConfirm.Target inlineConfirmId="remove">Remove</InlineConfirm.Target>
                 <InlineConfirm.Prompt
-                    id="remove"
+                    inlineConfirmId="remove"
                     label="Delete X?"
                     confirm={<Button>I confirm</Button>}
                     cancel={<Button>Cancel</Button>}
                 />
 
-                <InlineConfirm.Target id="print">Print</InlineConfirm.Target>
+                <InlineConfirm.Target inlineConfirmId="print">Print</InlineConfirm.Target>
                 <InlineConfirm.Prompt
-                    id="print"
+                    inlineConfirmId="print"
                     label="Print?"
                     confirm={<Button>Yes</Button>}
                     cancel={<Button>No, save the trees</Button>}
@@ -135,7 +155,12 @@ describe('InlineConfirm', () => {
         const onClickSpy = vi.fn();
         render(
             <InlineConfirm>
-                <InlineConfirm.Target id="delete" onClick={onClickSpy} disabled disabledTooltip="You shall not pass">
+                <InlineConfirm.Target
+                    inlineConfirmId="delete"
+                    onClick={onClickSpy}
+                    disabled
+                    disabledTooltip="You shall not pass"
+                >
                     Delete
                 </InlineConfirm.Target>
             </InlineConfirm>,

--- a/packages/website/src/examples/form/inline-confirm/InlineConfirm.demo.tsx
+++ b/packages/website/src/examples/form/inline-confirm/InlineConfirm.demo.tsx
@@ -4,10 +4,10 @@ const Demo = () => (
     <InlineConfirm>
         <Group gap="sm">
             <Button disabled>I will hide</Button>
-            <InlineConfirm.Target id="delete">Delete</InlineConfirm.Target>
+            <InlineConfirm.Target inlineConfirmId="delete">Delete</InlineConfirm.Target>
         </Group>
         <InlineConfirm.Prompt
-            id="delete"
+            inlineConfirmId="delete"
             onConfirm={() => showNotification({message: 'Confirm clicked', autoClose: true})}
             onCancel={() => showNotification({message: 'Cancel clicked', autoClose: true})}
         />

--- a/packages/website/src/examples/form/inline-confirm/InlineConfirmMenu.demo.tsx
+++ b/packages/website/src/examples/form/inline-confirm/InlineConfirmMenu.demo.tsx
@@ -7,13 +7,13 @@ const Demo = () => (
                 <Button>Menu</Button>
             </Menu.Target>
             <Menu.Dropdown>
-                <InlineConfirm.Target component={Menu.Item} id="delete">
+                <InlineConfirm.Target component={Menu.Item} inlineConfirmId="delete">
                     Delete
                 </InlineConfirm.Target>
 
                 <InlineConfirm.Target
                     component={Menu.Item}
-                    id="delete2"
+                    inlineConfirmId="delete2"
                     disabled
                     disabledTooltip="Will not trigger since its disabled"
                 >
@@ -22,11 +22,11 @@ const Demo = () => (
             </Menu.Dropdown>
         </Menu>
         <InlineConfirm.Prompt
-            id="delete"
+            inlineConfirmId="delete"
             onConfirm={() => showNotification({message: 'Confirm clicked', autoClose: true})}
             onCancel={() => showNotification({message: 'Cancel clicked', autoClose: true})}
         />
-        <InlineConfirm.Prompt id="delete2" />
+        <InlineConfirm.Prompt inlineConfirmId="delete2" />
     </InlineConfirm>
 );
 export default Demo;

--- a/packages/website/src/examples/form/inline-confirm/InlineConfirmStyle.demo.tsx
+++ b/packages/website/src/examples/form/inline-confirm/InlineConfirmStyle.demo.tsx
@@ -3,12 +3,12 @@ import {DeleteSize24Px, CrossSize24Px} from '@coveord/plasma-react-icons';
 
 const Demo = () => (
     <InlineConfirm>
-        <InlineConfirm.Target id="delete" variant="subtle" color="critical">
+        <InlineConfirm.Target inlineConfirmId="delete" variant="subtle" color="critical">
             <DeleteSize24Px />
         </InlineConfirm.Target>
 
         <InlineConfirm.Prompt
-            id="delete"
+            inlineConfirmId="delete"
             label={
                 <Text c="critical" fw={500}>
                     Delete?

--- a/packages/website/src/examples/layout/Table/TableConfirmAction.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableConfirmAction.demo.tsx
@@ -1,4 +1,5 @@
 import {ColumnDef, createColumnHelper, InlineConfirm, showNotification, Table, useTable} from '@coveord/plasma-mantine';
+import {InlineConfirmComponentsProps} from '@coveord/plasma-mantine';
 import {DeleteSize16Px} from '@coveord/plasma-react-icons';
 import {faker} from '@faker-js/faker';
 import {useMemo} from 'react';
@@ -44,11 +45,11 @@ const Demo = () => {
             getRowId={({id}) => id.toString()}
             getRowActions={(selected: Person[]) => [
                 {
-                    group: 'other',
+                    group: '$$primary',
                     component: (
                         <InlineConfirm.Target
                             component={Table.ActionItem}
-                            id="delete"
+                            inlineConfirmId="delete"
                             leftSection={<DeleteSize16Px height={16} />}
                         >
                             Delete
@@ -57,14 +58,7 @@ const Demo = () => {
                 },
                 {
                     group: '$$confirmPrompt',
-                    component: (
-                        <InlineConfirm.Prompt
-                            id="delete"
-                            label={`Are you sure you want to delete ${selected[0].firstName} ${selected[0].lastName}?`}
-                            onConfirm={() => showNotification({message: 'Confirm clicked', autoClose: true})}
-                            onCancel={() => showNotification({message: 'Cancel clicked', autoClose: true})}
-                        />
-                    ),
+                    component: <MyAction inlineConfirmId="delete" person={selected[0]} />,
                 },
             ]}
         >
@@ -94,3 +88,12 @@ const makeData = (len: number): Person[] =>
             age: faker.number.int(40),
             bio: faker.lorem.sentences({min: 1, max: 5}),
         }));
+
+const MyAction = ({person, inlineConfirmId}: {person: Person} & InlineConfirmComponentsProps) => (
+    <InlineConfirm.Prompt
+        inlineConfirmId={inlineConfirmId}
+        label={`Are you sure you want to delete ${person.firstName} ${person.lastName}?`}
+        onConfirm={() => showNotification({message: 'Confirm clicked', autoClose: true})}
+        onCancel={() => showNotification({message: 'Cancel clicked', autoClose: true})}
+    />
+);


### PR DESCRIPTION
### Proposed Changes

Allow wrapping of InlineConfirm.Prompt. To do so we need to add the `inlineConfirmId` (from `InlineConfirmComponentsProps`) on the immediate child of `InlineConfirm`

### Potential Breaking Changes

Changed prop `id` to `inlineConfirmId ` on InlineConfirm components

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
