### PR TITLE
fix(mantine): add data-loading attribute on table component

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -229,7 +229,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                         noData
                     ) : (
                         <>
-                            <Box component="table" {...getStyles('table')} pb="sm">
+                            <Box component="table" {...getStyles('table')} pb="sm" mod={{loading}}>
                                 <thead {...getStyles('header')}>
                                     {!!header ? (
                                         <tr>

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -62,6 +62,17 @@ describe('Table', () => {
     });
 
     describe('when it is loading', () => {
+        it('indicates the table element as loading', () => {
+            const Fixture = ({loading}: {loading: boolean}) => {
+                const store = useTable<RowData>({initialState: {globalFilter: 'something'}});
+                return <Table store={store} loading={loading} data={[]} columns={columns} />;
+            };
+            const {rerender} = render(<Fixture loading />);
+            expect(screen.getByRole('table')).toHaveAttribute('data-loading', 'true');
+            rerender(<Fixture loading={false} />);
+            expect(screen.getByRole('table')).not.toHaveAttribute('data-loading');
+        });
+
         it('shows a loading animation over the no data children (filtered)', () => {
             const Fixture = () => {
                 const store = useTable<RowData>({initialState: {globalFilter: 'something'}});

--- a/packages/mantine/src/components/table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/Table.spec.tsx
@@ -64,7 +64,7 @@ describe('Table', () => {
     describe('when it is loading', () => {
         it('indicates the table element as loading', () => {
             const Fixture = ({loading}: {loading: boolean}) => {
-                const store = useTable<RowData>({initialState: {globalFilter: 'something'}});
+                const store = useTable<RowData>();
                 return <Table store={store} loading={loading} data={[]} columns={columns} />;
             };
             const {rerender} = render(<Fixture loading />);


### PR DESCRIPTION
### Proposed Changes

Adding the `data-loading={true}` attribute on the `<table>` element so that it is easier to wait for loading skeleton to be removed during tests, for example when changing page.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
