### PR TITLE
fix(mantine): perf fix related to double click action

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -2,15 +2,18 @@ import {Box, Center, Factory, Loader, useProps, useStyles} from '@mantine/core';
 import {useClickOutside, useMergedRef} from '@mantine/hooks';
 import {
     ColumnDef,
-    defaultColumnSizing,
-    getCoreRowModel,
     Row,
     RowSelectionState,
+    defaultColumnSizing,
+    getCoreRowModel,
     useReactTable,
 } from '@tanstack/react-table';
 import isEqual from 'fast-deep-equal';
 import {Children, ForwardedRef, ReactElement, useRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../utils';
+import classes from './Table.module.css';
+import {TableLayout, TableProps} from './Table.types';
+import {TableProvider} from './TableContext';
 import {TableLayouts} from './layouts/TableLayouts';
 import {TableActionItem, TableActionItemStylesNames, TableHeaderActionsStylesNames} from './table-actions';
 import {TableActionsListStylesNames} from './table-actions/TableActionsList';
@@ -33,9 +36,6 @@ import {TableNoData} from './table-no-data/TableNoData';
 import {TablePagination} from './table-pagination/TablePagination';
 import {TablePerPage} from './table-per-page/TablePerPage';
 import {TablePredicate, TablePredicateStylesNames} from './table-predicate/TablePredicate';
-import classes from './Table.module.css';
-import {TableLayout, TableProps} from './Table.types';
-import {TableProvider} from './TableContext';
 import {TableState} from './use-table';
 
 type TableStylesNames =
@@ -241,7 +241,6 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                                     <Layout.Header
                                         getRowExpandedContent={getRowExpandedContent}
                                         getRowAttributes={getRowAttributes}
-                                        getRowActions={getRowActions}
                                         loading={loading}
                                         {...layoutProps}
                                     />
@@ -251,7 +250,6 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                                         <Layout.Body
                                             getRowExpandedContent={getRowExpandedContent}
                                             getRowAttributes={getRowAttributes}
-                                            getRowActions={getRowActions}
                                             loading={loading}
                                             {...layoutProps}
                                         />

--- a/packages/mantine/src/components/table/Table.types.ts
+++ b/packages/mantine/src/components/table/Table.types.ts
@@ -8,8 +8,9 @@ import {TableStore} from './use-table';
 
 export type TableLayoutProps<TData = unknown> = Pick<
     TableProps<TData>,
-    'getRowExpandedContent' | 'getRowAttributes' | 'getRowActions' | 'loading'
->;
+    'getRowExpandedContent' | 'getRowAttributes' | 'loading'
+> &
+    TableProps<TData>['layoutProps'];
 
 export interface TableLayout {
     (props: {children: ReactNode}): ReactElement;
@@ -64,7 +65,7 @@ export interface TableProps<TData> extends BoxProps, StylesApiProps<PlasmaTableF
      * @param datum the row for which the children should be generated.
      * @default []
      */
-    getRowActions?: (data: TData[]) => Array<TableAction<TData>>;
+    getRowActions?: (data: TData[]) => TableAction[];
     /**
      * Columns to display in the table.
      *
@@ -80,7 +81,16 @@ export interface TableProps<TData> extends BoxProps, StylesApiProps<PlasmaTableF
     /**
      * Props passed down to the active layout Header and Body components
      */
-    layoutProps?: Record<string, any>;
+    layoutProps?: {
+        /**
+         * Called by the table layout when a row is double clicked.
+         * @param selectedRow The data of the row that was double clicked
+         * @param index The index of the row that was double clicked
+         * @param row The row object that was double clicked
+         * @returns
+         */
+        onRowDoubleClick?: (selectedRow: TData, index: number, row: Row<TData>) => void;
+    } & Record<string, any>;
     /**
      * Whether the table is loading or not
      *
@@ -124,7 +134,7 @@ export interface TableProps<TData> extends BoxProps, StylesApiProps<PlasmaTableF
     >;
 }
 
-export interface TableAction<TData = unknown> {
+export interface TableAction {
     /**
      * Group to which the action belongs
      * $$primary is reserved for primary actions
@@ -136,8 +146,4 @@ export interface TableAction<TData = unknown> {
      * Component to render, should be either `Table.PrimaryAction` or `Table.SecondaryAction`
      */
     component: ReactNode;
-    /**
-     * Callback triggered on a double click on the row
-     */
-    onRowDoubleClick?: (datum: TData, index: number, row: Row<TData>) => void;
 }

--- a/packages/mantine/src/components/table/TableContext.tsx
+++ b/packages/mantine/src/components/table/TableContext.tsx
@@ -9,7 +9,7 @@ export interface TableContextValue<TData = unknown> {
     getStyles: GetStylesApi<PlasmaTableFactory>;
     store: TableStore<TData>;
     layouts: TableLayout[];
-    getRowActions: (datum: TData[]) => Array<TableAction<TData>>;
+    getRowActions: (datum: TData[]) => TableAction[];
     table: Table<TData>;
     containerRef: MutableRefObject<HTMLDivElement>;
 }

--- a/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
@@ -224,13 +224,7 @@ describe('RowLayout', () => {
                     getRowId={({id}) => id}
                     data={data}
                     columns={columns}
-                    getRowActions={() => [
-                        {
-                            group: 'any',
-                            component: null,
-                            onRowDoubleClick: doubleClickSpy,
-                        },
-                    ]}
+                    layoutProps={{onRowDoubleClick: doubleClickSpy}}
                 />
             );
         };

--- a/packages/mantine/src/components/table/layouts/row-layout/RowLayoutBody.tsx
+++ b/packages/mantine/src/components/table/layouts/row-layout/RowLayoutBody.tsx
@@ -30,7 +30,7 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
     const ctx = useRowLayout();
     const {
         getRowExpandedContent,
-        getRowActions,
+        onRowDoubleClick,
         loading,
         classNames,
         className,
@@ -47,8 +47,6 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
 
     const rows = table.getRowModel()?.rows.map((row) => {
         const rowChildren = getRowExpandedContent?.(row.original, row.index, row) ?? null;
-        const rowActions = getRowActions?.([row.original]) ?? null;
-        const doubleClickAction = rowActions?.find((action) => Boolean(action.onRowDoubleClick))?.onRowDoubleClick;
         const isSelected = !!row.getIsSelected();
         const shouldKeepSelection = store.rowSelectionForced && isSelected;
         const onClick = (event: MouseEvent<HTMLTableRowElement>) => {
@@ -64,7 +62,9 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
             <Fragment key={row.id}>
                 <tr
                     onClick={onClick}
-                    onDoubleClick={() => doubleClickAction?.(row.original, row.index, row)}
+                    onDoubleClick={() => {
+                        onRowDoubleClick?.(row.original, row.index, row);
+                    }}
                     data-selectable={store.rowSelectionEnabled}
                     data-selected={isSelected}
                     data-multi-selection={store.multiRowSelectionEnabled}

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -42,6 +42,7 @@ const Demo = () => {
             data={data}
             columns={columns}
             getRowId={({id}) => id.toString()}
+            layoutProps={{onRowDoubleClick: (row) => alert(`Row double clicked: ${row.firstName}`)}}
             getRowActions={(selected: Person[]) => [
                 {
                     group: 'Actions',

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -69,7 +69,7 @@ const Demo = () => {
             getRowId={({id}) => id}
             columns={columns}
             options={options}
-            getRowActions={(selected: IExampleRowData[]): Array<TableAction<IExampleRowData>> =>
+            getRowActions={(selected: IExampleRowData[]): TableAction[] =>
                 selected.length === 1
                     ? [
                           {


### PR DESCRIPTION
### Proposed Changes

Made some changes to the table row actions so that getRowActions does not get called once for every row on every render.

- `onRowDoubleClick` handler should now be passed down as prop within the `layoutProps`, instead of through the TableAction
- `TableAction` type no longer needs to be generic

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
