### PR TITLE
fix(mantine, table): client side pagination rowCount

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -157,7 +157,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
             minSize: defaultColumnSizing.minSize,
             maxSize: defaultColumnSizing.maxSize,
         },
-        rowCount: store.state.totalEntries,
+        rowCount: options?.getFilteredRowModel ? undefined : store.state.totalEntries,
         ...options,
     });
 


### PR DESCRIPTION
### Proposed Changes

Fixed count not updating when using client-side pagination and the rows are filtered.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
