### PR TITLE
fix(mantine): stop passing onRowDoubleClick handler to tr node

### DIFF
--- a/packages/mantine/src/components/table/layouts/row-layout/RowLayoutHeader.tsx
+++ b/packages/mantine/src/components/table/layouts/row-layout/RowLayoutHeader.tsx
@@ -29,11 +29,12 @@ export const RowLayoutHeader = <T,>(props: RowLayoutHeaderProps<T> & {ref?: Forw
         getRowExpandedContent: _getRowExpandedContent,
         getRowActions: _getRowActions,
         loading: _loading,
+        getRowAttributes: _getRowAttributes,
+        onRowDoubleClick: _onRowDoubleClick,
         className,
         style,
         classNames,
         styles,
-        getRowAttributes: _getRowAttributes,
         ...others
     } = useProps('RowLayoutHeader', defaultProps as RowLayoutHeaderProps<T>, props);
     const {table, store} = useTableContext<T>();


### PR DESCRIPTION
### Proposed Changes

little oopsie on my end

![image](https://github.com/coveo/plasma/assets/35579930/b3da9b2e-bde4-4623-990a-1e9965d49500)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
