### PR TITLE
fix(mantine): make sure CodeEditor maxHeight prop works

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -227,13 +227,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     );
 
     return (
-        <Stack
-            justify="flex-start"
-            gap={0}
-            h={{height: Math.max(parentHeight, minHeight), maxHeight}}
-            ref={ref}
-            {...others}
-        >
+        <Stack justify="flex-start" gap={0} h={Math.max(parentHeight, minHeight)} mah={maxHeight} ref={ref} {...others}>
             {_header}
             {_buttons}
             {_editor}

--- a/packages/website/src/building-blocs/Demo.module.css
+++ b/packages/website/src/building-blocs/Demo.module.css
@@ -12,7 +12,7 @@
     right: 0;
     z-index: 2;
     padding: var(--mantine-spacing-xs);
-    background-color: '#1E1E1E';
+    background-color: #1e1e1e;
     & button:hover,
     & a:hover {
         background-color: var(--mantine-color-gray-8);


### PR DESCRIPTION
### Proposed Changes

Making sure the CodeEditor `maxHeight` prop works as designed.

Before
![image](https://github.com/coveo/plasma/assets/35579930/6492950d-7514-4253-a913-992a7cbb5092)

After
![image](https://github.com/coveo/plasma/assets/35579930/06cedcab-908a-4e18-b1de-9865c12e76d2)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
