### PR TITLE
fix(style): add reset stuff into a CSS layer

### DIFF
--- a/packages/style/scss/common/common.scss
+++ b/packages/style/scss/common/common.scss
@@ -1,31 +1,33 @@
 @import 'font';
 
-html {
-    box-sizing: border-box;
-}
+@layer reset {
+    html {
+        box-sizing: border-box;
+    }
 
-*,
-*::before,
-*::after {
-    box-sizing: inherit;
-}
+    *,
+    *::before,
+    *::after {
+        box-sizing: inherit;
+    }
 
-body {
-    display: flex;
-    flex-flow: column nowrap;
-    align-content: flex-start;
+    body {
+        display: flex;
+        flex-flow: column nowrap;
+        align-content: flex-start;
 
-    // Base font size for the entire app
-    font-size: 13px;
-    font-family: var(--main-font);
-    -webkit-font-smoothing: antialiased;
-}
+        // Base font size for the entire app
+        font-size: 13px;
+        font-family: var(--main-font);
+        -webkit-font-smoothing: antialiased;
+    }
 
-.markdown-documentation {
-    font-size: var(--default-font-size);
+    .markdown-documentation {
+        font-size: var(--default-font-size);
 
-    p,
-    li {
-        line-height: 1.5em;
+        p,
+        li {
+            line-height: 1.5em;
+        }
     }
 }

--- a/packages/style/scss/lib/reset.scss
+++ b/packages/style/scss/lib/reset.scss
@@ -2,217 +2,218 @@
    v2.0 | 20110126
    License: none (public domain)
 */
+@layer reset {
+    html,
+    body,
+    div,
+    button,
+    span,
+    applet,
+    object,
+    iframe,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    blockquote,
+    pre,
+    a,
+    abbr,
+    acronym,
+    address,
+    big,
+    cite,
+    code,
+    del,
+    dfn,
+    em,
+    img,
+    ins,
+    kbd,
+    q,
+    s,
+    samp,
+    small,
+    strike,
+    strong,
+    sub,
+    sup,
+    tt,
+    var,
+    b,
+    u,
+    i,
+    center,
+    dl,
+    dt,
+    dd,
+    ol,
+    ul,
+    li,
+    fieldset,
+    form,
+    label,
+    legend,
+    table,
+    caption,
+    tbody,
+    tfoot,
+    thead,
+    tr,
+    th,
+    td,
+    article,
+    aside,
+    canvas,
+    details,
+    embed,
+    figure,
+    figcaption,
+    footer,
+    header,
+    hgroup,
+    menu,
+    nav,
+    output,
+    ruby,
+    section,
+    summary,
+    time,
+    mark,
+    audio,
+    video {
+        margin: 0;
+        padding: 0;
+        font: inherit;
+        font-size: 100%;
+        vertical-align: baseline;
+        border: 0;
+    }
 
-html,
-body,
-div,
-button,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-    margin: 0;
-    padding: 0;
-    font: inherit;
-    font-size: 100%;
-    vertical-align: baseline;
-    border: 0;
-}
+    // Prevent safari scroll bounce
+    html {
+        height: 100%;
+        overflow: hidden;
+    }
 
-// Prevent safari scroll bounce
-html {
-    height: 100%;
-    overflow: hidden;
-}
+    body {
+        height: 100%;
+        overflow: auto;
+    }
 
-body {
-    height: 100%;
-    overflow: auto;
-}
+    // HTML5 display-role reset for older browsers
+    article,
+    aside,
+    details,
+    figcaption,
+    figure,
+    footer,
+    header,
+    hgroup,
+    menu,
+    nav,
+    section {
+        display: block;
+    }
 
-// HTML5 display-role reset for older browsers
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-    display: block;
-}
+    body {
+        line-height: 1.5;
+    }
 
-body {
-    line-height: 1.5;
-}
+    ol,
+    ul {
+        list-style: none;
+    }
 
-ol,
-ul {
-    list-style: none;
-}
+    blockquote,
+    q {
+        quotes: none;
+    }
 
-blockquote,
-q {
-    quotes: none;
-}
+    blockquote::before,
+    blockquote::after,
+    q::before,
+    q::after {
+        content: '';
+        content: none;
+    }
 
-blockquote::before,
-blockquote::after,
-q::before,
-q::after {
-    content: '';
-    content: none;
-}
+    table {
+        border-collapse: inherit;
+        border-spacing: 0;
+    }
 
-table {
-    border-collapse: inherit;
-    border-spacing: 0;
-}
+    button::-moz-focus-inner,
+    input::-moz-focus-inner {
+        padding: 0;
+        border: 0;
+    }
 
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-    padding: 0;
-    border: 0;
-}
+    button {
+        align-items: unset;
+        text-align: unset;
+        background-color: transparent;
+        border: none;
+        border-radius: 0;
+    }
 
-button {
-    align-items: unset;
-    text-align: unset;
-    background-color: transparent;
-    border: none;
-    border-radius: 0;
-}
-
-/**
+    /**
  * 1. Correct the inheritance and scaling of font size in all browsers.
  * 2. Correct the odd `em` font sizing in all browsers.
  */
-pre {
-    font-family: monospace; /* 1 */
-    font-size: 1em; /* 2 */
-}
+    pre {
+        font-family: monospace; /* 1 */
+        font-size: 1em; /* 2 */
+    }
 
-/**
+    /**
  * Add the correct font weight in Chrome, Edge, and Safari.
  */
-b,
-strong {
-    font-weight: bolder;
-}
+    b,
+    strong {
+        font-weight: bolder;
+    }
 
-/**
+    /**
  * 1. Correct the inheritance and scaling of font size in all browsers.
  * 2. Correct the odd `em` font sizing in all browsers.
  */
 
-code,
-kbd,
-samp {
-    font-family: monospace; /* 1 */
-    font-size: 1em; /* 2 */
-}
+    code,
+    kbd,
+    samp {
+        font-family: monospace; /* 1 */
+        font-size: 1em; /* 2 */
+    }
 
-/**
+    /**
  * Add the correct font size in all browsers.
  */
 
-small {
-    font-size: 80%;
-}
+    small {
+        font-size: 80%;
+    }
 
-/**
+    /**
  * Prevent `sub` and `sup` elements from affecting the line height in
  * all browsers.
  */
-sub,
-sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
-}
+    sub,
+    sup {
+        font-size: 75%;
+        line-height: 0;
+        position: relative;
+        vertical-align: baseline;
+    }
 
-sub {
-    bottom: -0.25em;
-}
+    sub {
+        bottom: -0.25em;
+    }
 
-sup {
-    top: -0.5em;
+    sup {
+        top: -0.5em;
+    }
 }


### PR DESCRIPTION
### Proposed Changes

Move reset styles into a [CSS layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) called `reset`.

Doing this ensures that reset styles coming from this package cannot override anything from other libraries even if the loading order of stylesheets in the DOM would otherwise have caused it to.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
