### PR TITLE
fix(mantine): make sure rowSelection row data stays fresh

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -9,7 +9,7 @@ import {
     useReactTable,
 } from '@tanstack/react-table';
 import isEqual from 'fast-deep-equal';
-import {Children, ForwardedRef, ReactElement, useRef} from 'react';
+import {Children, ForwardedRef, ReactElement, useEffect, useRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../utils';
 import classes from './Table.module.css';
 import {TableLayout, TableProps} from './Table.types';
@@ -196,6 +196,22 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
             });
         },
     }));
+
+    useEffect(() => {
+        // Update the selected rows data when the data prop changes
+        if (store.getSelectedRows().length > 0) {
+            store.setRowSelection((old) => {
+                const rowsById = table.getRowModel().rowsById;
+                const newSelection = {...old};
+                Object.keys(old).forEach((rowId) => {
+                    if (rowsById[rowId]) {
+                        newSelection[rowId] = rowsById[rowId].original;
+                    }
+                });
+                return isEqual(newSelection, old) ? old : newSelection;
+            });
+        }
+    }, [data]);
 
     const containerRef = useRef<HTMLDivElement>();
     useClickOutside(

--- a/packages/mantine/src/components/table/table-actions/TableHeaderActions.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableHeaderActions.tsx
@@ -1,8 +1,7 @@
 import {Factory, factory, Grid, GridColProps, Group, useProps} from '@mantine/core';
-import {ReactElement} from 'react';
+import {ReactElement, useMemo} from 'react';
 
 import {TableComponentsOrder} from '../Table';
-import {TableAction} from '../Table.types';
 import {useTableContext} from '../TableContext';
 import {TableActionsList} from './TableActionsList';
 
@@ -27,12 +26,15 @@ export const TableHeaderActions = factory<TableHeaderActionsFactory>(
             defaultProps,
             props,
         );
-        const selectedRows = store.getSelectedRows();
-        if (selectedRows.length === 0) {
-            return null;
-        }
 
-        const actions: TableAction[] = getRowActions(selectedRows);
+        const actions = useMemo(() => {
+            const selectedRows = store.getSelectedRows();
+            if (selectedRows.length === 0) {
+                return [];
+            }
+            return getRowActions(selectedRows);
+        }, [store.state.rowSelection]);
+
         if (actions.length === 0) {
             return null;
         }


### PR DESCRIPTION
### Proposed Changes

`table.state.rowSelection` is an object whose key is the row id and the value is the row data. Before this change, the row data in this object would remain the same even if the `data` prop changed. In this PR, I am adding an effect which keeps this `rowSelection` object in sync with the latest data.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
