### PR TITLE
ci: fix demo not building properly

### DIFF
--- a/packages/website/build/start.js
+++ b/packages/website/build/start.js
@@ -1,7 +1,0 @@
-import {spawn} from 'node:child_process';
-
-const viteArgs = [];
-
-setTimeout(() => {
-    spawn('vite', viteArgs, {stdio: 'inherit', shell: true});
-}, 5000);

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -8,7 +8,7 @@
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
         "mantine:fetch": "ts-node --project ./bin/tsconfig.json ./bin/index.ts",
         "preview": "vite preview",
-        "start": "node ./build/start.js"
+        "start": "vite"
     },
     "dependencies": {
         "@coveo/atomic-react": "2.10.1",

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
         "build": {
             "dependsOn": ["^build"],
             "outputs": ["dist/**"],
-            "outputLogs": "new-only"
+            "outputLogs": "new-only",
+            "env": ["CI", "BRANCH_NAME", "GITHUB_HEAD_REF", "GITHUB_REF_NAME"]
         },
         "test": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
### Proposed Changes

The new major version of turbo repo enforces a whitelist for environment variables that needs to be defined in the turbo.json config. You can read more about it here https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables, but essentially this was preventing the `GITHUB_*` and `CI` variables defined by the GitHub runners from reaching Vite.

To test the change, you can simply open the demo link and see that it works like it used to.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
