### PR TITLE
fix(mantine, table): avoid clearing rows when no rows are selected

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -216,7 +216,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     const containerRef = useRef<HTMLDivElement>();
     useClickOutside(
         () => {
-            if (!store.multiRowSelectionEnabled) {
+            if (!store.multiRowSelectionEnabled && store.getSelectedRows().length > 0) {
                 store.clearRowSelection();
             }
         },


### PR DESCRIPTION
### Proposed Changes

While debugging an issue with the click outside handler I saw that the table re-rendered each time I clicked outside even if no rows where selected. In this PR I avoid calling the clear method if no rows are selected

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
