### PR TITLE
feat(mantine, prompt): update look of prompt component

### DIFF
--- a/packages/mantine/src/components/prompt/Prompt.context.ts
+++ b/packages/mantine/src/components/prompt/Prompt.context.ts
@@ -1,0 +1,11 @@
+import {createSafeContext, GetStylesApi} from '@mantine/core';
+import {PromptFactory, PromptVariant} from './Prompt';
+
+interface PromptContext {
+    variant: PromptVariant;
+    getStyles: GetStylesApi<PromptFactory>;
+}
+
+export const [PromptContextProvider, usePromptContext] = createSafeContext<PromptContext>(
+    'Prompt component was not found in the tree',
+);

--- a/packages/mantine/src/components/prompt/Prompt.module.css
+++ b/packages/mantine/src/components/prompt/Prompt.module.css
@@ -1,45 +1,35 @@
 .root {
-    &[data-variant='success']&[data-size] {
-        .header {
-            background-color: var(--mantine-color-lime-6);
-        }
+    --prompt-icon-size: 88px;
+
+    .header {
+        border-bottom: none;
+        align-items: center;
     }
-    &[data-variant='warning']&[data-size] {
-        .header {
-            background-color: var(--mantine-color-yellow-5);
-        }
-    }
-    &[data-variant='critical']&[data-size] {
-        .header {
-            background-color: var(--mantine-color-red-6);
-        }
-    }
-    &[data-variant='info']&[data-size] {
-        .header {
-            background-color: var(--mantine-color-navy-5);
-        }
+
+    .body {
+        padding: 0 var(--mantine-spacing-lg) var(--mantine-spacing-lg)
+            calc(var(--prompt-icon-size) + (2 * var(--mantine-spacing-lg)));
     }
 }
 
-.title {
-    color: var(--mantine-color-white);
+.icon {
+    width: var(--prompt-icon-size);
+    height: var(--prompt-icon-size);
 }
 
 .header {
+    gap: var(--mantine-spacing-lg);
     width: 100%;
-    border-bottom: 1px solid var(--mantine-color-gray-3);
     font-size: var(--mantine-h3-font-size);
     line-height: var(--mantine-h3-line-height);
     overflow-wrap: anywhere;
-    padding-top: var(--mantine-spacing-md);
-    padding-bottom: var(--mantine-spacing-md);
+    padding: var(--mantine-spacing-lg) var(--mantine-spacing-md) var(--mantine-spacing-xs) var(--mantine-spacing-lg);
 }
 
-.whiteClose {
-    @mixin light {
-        color: var(--mantine-color-white);
-        @mixin hover {
-            background-color: transparent;
-        }
-    }
+.close {
+    align-self: flex-start;
+}
+
+.inner {
+    color: var(--mantine-color-gray-7);
 }

--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -12,7 +12,7 @@ import {
     useStyles,
 } from '@mantine/core';
 import {Children, ReactElement, ReactNode} from 'react';
-import classes from '../header/Header.module.css';
+import classes from './Prompt.module.css';
 import Critical from './icons/critical.svg';
 import Info from './icons/info.svg';
 import Success from './icons/success.svg';
@@ -98,10 +98,15 @@ export const Prompt = factory<PromptFactory>((_props, ref) => {
                 <Modal.Overlay {...getStyles('overlay', stylesApiProps)} />
                 <Modal.Content {...getStyles('content', stylesApiProps)}>
                     <Modal.Header {...getStyles('header', stylesApiProps)}>
-                        {icon ? (
+                        {icon || icon === null ? (
                             icon
                         ) : (
-                            <Image {...getStyles('icon', stylesApiProps)} src={PROMPT_VARIANT_ICONS_SRC[variant]} />
+                            <Image
+                                alt=""
+                                role="presentation"
+                                {...getStyles('icon', stylesApiProps)}
+                                src={PROMPT_VARIANT_ICONS_SRC[variant]}
+                            />
                         )}
                         <Modal.Title {...getStyles('title', stylesApiProps)}>{title}</Modal.Title>
                         <Modal.CloseButton {...getStyles('close', stylesApiProps)} />

--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -1,43 +1,121 @@
-import {Box, Modal, ModalProps} from '@mantine/core';
+import {
+    Box,
+    createVarsResolver,
+    factory,
+    Factory,
+    Image,
+    Modal,
+    ModalRootProps,
+    ModalStylesNames,
+    StylesApiProps,
+    useProps,
+    useStyles,
+} from '@mantine/core';
 import {Children, ReactElement, ReactNode} from 'react';
-import PromptClasses from './Prompt.module.css';
+import classes from '../header/Header.module.css';
+import Critical from './icons/critical.svg';
+import Info from './icons/info.svg';
+import Success from './icons/success.svg';
+import Warning from './icons/warning.svg';
+import {PromptContextProvider} from './Prompt.context';
+import {PromptCancelButton, PromptCancelButtonStylesNamesVariant} from './PromptCancelButton';
+import {PromptConfirmButton} from './PromptConfirmButton';
 import {PromptFooter} from './PromptFooter';
 
-export interface PromptProps extends ModalProps {
+export type PromptVariant = 'success' | 'warning' | 'critical' | 'info';
+export type PromptVars = {root: '--prompt-icon-size'};
+export type PromptStylesNames = ModalStylesNames | 'icon' | PromptCancelButtonStylesNamesVariant;
+
+export interface PromptProps
+    extends StylesApiProps<PromptFactory>,
+        Omit<ModalRootProps, 'classNames' | 'styles' | 'vars'> {
     /**
      * Controls prompt appearance
      *
      * @default "info"
      */
-    variant?: 'success' | 'warning' | 'critical' | 'info';
+    variant?: PromptVariant;
     children: ReactNode;
-}
-interface PromptType {
-    (props: PromptProps): ReactElement;
-    Footer: typeof PromptFooter;
+    title: ReactNode;
+    icon?: ReactNode;
 }
 
-export const Prompt: PromptType = ({children, ...otherProps}) => {
-    const {classNames: classesProps, ...otherPropsWithoutClasses} = otherProps;
+export type PromptFactory = Factory<{
+    props: PromptProps;
+    ref: HTMLDivElement;
+    vars: PromptVars;
+    variant: PromptVariant;
+    stylesNames: PromptStylesNames;
+    staticComponents: {
+        CancelButton: typeof PromptCancelButton;
+        ConfirmButton: typeof PromptConfirmButton;
+        Footer: typeof PromptFooter;
+    };
+}>;
+
+const PROMPT_VARIANT_ICONS_SRC: Record<PromptVariant, string> = {
+    success: Success,
+    warning: Warning,
+    critical: Critical,
+    info: Info,
+};
+
+const defaultProps: Partial<PromptProps> = {
+    variant: 'info',
+};
+
+const varsResolver = createVarsResolver<PromptFactory>((_theme, {icon}) => ({
+    root: {
+        '--prompt-icon-size': icon ? undefined : '88px',
+    },
+}));
+
+export const Prompt = factory<PromptFactory>((_props, ref) => {
+    const props = useProps('Prompt', defaultProps, _props);
+    const {variant, title, icon, children, className, classNames, style, styles, unstyled, vars, ...others} = props;
+    const getStyles = useStyles<PromptFactory>({
+        name: 'Prompt',
+        props,
+        classes,
+        className,
+        style,
+        classNames,
+        styles,
+        unstyled,
+        vars,
+        varsResolver,
+    });
+    const stylesApiProps = {classNames, styles};
+
     const convertedChildren = Children.toArray(children) as ReactElement[];
 
     const otherChildren = convertedChildren.filter((child) => child.type !== PromptFooter);
     const footer = convertedChildren.find((child) => child.type === PromptFooter);
 
-    const classNames = {
-        root: PromptClasses.root,
-        header: PromptClasses.header,
-        close: PromptClasses.whiteClose,
-        body: PromptClasses.body,
-        title: PromptClasses.title,
-    };
-
     return (
-        <Modal variant="prompt" classNames={{...classNames, ...classesProps}} size="sm" {...otherPropsWithoutClasses}>
-            <Box className={PromptClasses.innerBody}>{otherChildren}</Box>
-            {footer}
-        </Modal>
+        <PromptContextProvider value={{variant, getStyles}}>
+            <Modal.Root ref={ref} variant="prompt" size="sm" {...others} {...getStyles('root')}>
+                <Modal.Overlay {...getStyles('overlay', stylesApiProps)} />
+                <Modal.Content {...getStyles('content', stylesApiProps)}>
+                    <Modal.Header {...getStyles('header', stylesApiProps)}>
+                        {icon ? (
+                            icon
+                        ) : (
+                            <Image {...getStyles('icon', stylesApiProps)} src={PROMPT_VARIANT_ICONS_SRC[variant]} />
+                        )}
+                        <Modal.Title {...getStyles('title', stylesApiProps)}>{title}</Modal.Title>
+                        <Modal.CloseButton {...getStyles('close', stylesApiProps)} />
+                    </Modal.Header>
+                    <Modal.Body {...getStyles('body', stylesApiProps)}>
+                        <Box {...getStyles('inner', stylesApiProps)}>{otherChildren}</Box>
+                    </Modal.Body>
+                    {footer}
+                </Modal.Content>
+            </Modal.Root>
+        </PromptContextProvider>
     );
-};
+});
 
+Prompt.CancelButton = PromptCancelButton;
+Prompt.ConfirmButton = PromptConfirmButton;
 Prompt.Footer = PromptFooter;

--- a/packages/mantine/src/components/prompt/PromptCancelButton.tsx
+++ b/packages/mantine/src/components/prompt/PromptCancelButton.tsx
@@ -1,0 +1,33 @@
+import {Button, CompoundStylesApiProps, factory, Factory, useProps} from '@mantine/core';
+import {ButtonProps} from '../button/Button';
+import {usePromptContext} from './Prompt.context';
+
+export type PromptCancelButtonStylesNamesVariant = 'cancel';
+
+export interface PromptCancelButtonProps
+    extends CompoundStylesApiProps<PromptCancelButtonFactory>,
+        Omit<ButtonProps, 'primary' | 'classNames' | 'styles' | 'vars' | 'variant'> {}
+
+export type PromptCancelButtonFactory = Factory<{
+    props: PromptCancelButtonProps;
+    ref: HTMLButtonElement;
+    stylesNames: PromptCancelButtonStylesNamesVariant;
+    compound: true;
+}>;
+
+const defaultProps: Partial<PromptCancelButtonProps> = {};
+
+export const PromptCancelButton = factory<PromptCancelButtonFactory>((_props, ref) => {
+    const {getStyles} = usePromptContext();
+    const props = useProps('PromptCancelButton', defaultProps, _props);
+    const {className, classNames, style, styles, unstyled, vars, ...others} = props;
+
+    return (
+        <Button
+            ref={ref}
+            variant="outline"
+            {...others}
+            {...getStyles('cancel', {style, styles, className, classNames})}
+        />
+    );
+});

--- a/packages/mantine/src/components/prompt/PromptConfirmButton.tsx
+++ b/packages/mantine/src/components/prompt/PromptConfirmButton.tsx
@@ -1,0 +1,42 @@
+import {Button, CompoundStylesApiProps, factory, Factory, useProps} from '@mantine/core';
+import {ButtonProps} from '../button/Button';
+import {PromptVariant} from './Prompt';
+import {usePromptContext} from './Prompt.context';
+
+export type PromptConfirmButtonStylesNamesVariant = 'confirm';
+
+export interface PromptConfirmButtonProps
+    extends CompoundStylesApiProps<PromptConfirmButtonFactory>,
+        Omit<ButtonProps, 'primary' | 'classNames' | 'styles' | 'vars' | 'variant'> {}
+
+export type PromptConfirmButtonFactory = Factory<{
+    props: PromptConfirmButtonProps;
+    ref: HTMLButtonElement;
+    stylesNames: PromptConfirmButtonStylesNamesVariant;
+    compound: true;
+}>;
+
+const COLOR_BY_VARIANT: Record<PromptVariant, string> = {
+    success: 'action',
+    info: 'action',
+    warning: 'critical',
+    critical: 'critical',
+};
+
+const defaultProps: Partial<PromptConfirmButtonProps> = {};
+
+export const PromptConfirmButton = factory<PromptConfirmButtonFactory>((_props, ref) => {
+    const {variant, getStyles} = usePromptContext();
+    const props = useProps('PromptConfirmButton', defaultProps, _props);
+    const {className, classNames, style, styles, unstyled, vars, ...others} = props;
+
+    return (
+        <Button
+            ref={ref}
+            variant="filled"
+            color={COLOR_BY_VARIANT[variant]}
+            {...others}
+            {...getStyles('cancel', {style, styles, className, classNames})}
+        />
+    );
+});

--- a/packages/mantine/src/components/prompt/PromptFooter.tsx
+++ b/packages/mantine/src/components/prompt/PromptFooter.tsx
@@ -4,7 +4,7 @@ import {StickyFooter, StickyFooterProps} from '../sticky-footer';
 export interface PromptFooterProps extends StickyFooterProps {}
 
 export const PromptFooter: FunctionComponent<PropsWithChildren<PromptFooterProps>> = ({children, ...otherProps}) => (
-    <StickyFooter p={0} pt="lg" {...otherProps}>
+    <StickyFooter borderTop {...otherProps}>
         {children}
     </StickyFooter>
 );

--- a/packages/mantine/src/components/prompt/__tests__/Prompt.spec.tsx
+++ b/packages/mantine/src/components/prompt/__tests__/Prompt.spec.tsx
@@ -4,7 +4,7 @@ import {Prompt} from '../Prompt';
 describe('Prompt', () => {
     it('displays the title, body and close button', () => {
         render(
-            <Prompt variant="default" opened onClose={vi.fn()} title="title modal">
+            <Prompt opened onClose={vi.fn()} title="title modal">
                 content modal
                 <Prompt.Footer>footer content</Prompt.Footer>
             </Prompt>,
@@ -18,12 +18,30 @@ describe('Prompt', () => {
     it('calls onClose when clicking on the close button', () => {
         const onClose = vi.fn();
         render(
-            <Prompt variant="default" opened onClose={onClose} title="title modal">
+            <Prompt opened onClose={onClose} title="title modal">
                 content modal
             </Prompt>,
         );
 
         screen.getByRole('button').click();
         expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('display an icon', () => {
+        render(
+            <Prompt opened onClose={vi.fn()} title="title modal">
+                content modal
+            </Prompt>,
+        );
+        expect(screen.getByRole('presentation')).toBeVisible();
+    });
+
+    it('does not display the icon when the icon prop is null', () => {
+        render(
+            <Prompt opened onClose={vi.fn()} title="title modal" icon={null}>
+                content modal
+            </Prompt>,
+        );
+        expect(screen.queryByRole('presentation')).not.toBeInTheDocument();
     });
 });

--- a/packages/mantine/src/components/prompt/icons/critical.svg
+++ b/packages/mantine/src/components/prompt/icons/critical.svg
@@ -1,21 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 88 90">
-  <g filter="url(#a)">
-    <path fill="url(#b)" d="M54.217 15c1.155 0 2.257.489 3.032 1.346l12.694 14.031A4.089 4.089 0 0 1 71 33.121v18.856c0 .974-.348 1.916-.98 2.656L57.254 69.568A4.089 4.089 0 0 1 54.147 71H32.132a4.089 4.089 0 0 1-3.081-1.401L16.007 54.64A4.09 4.09 0 0 1 15 51.953V33.144c0-1.028.387-2.018 1.084-2.773l12.974-14.055A4.089 4.089 0 0 1 32.063 15h22.154Z"/>
-    <path stroke="url(#c)" stroke-linecap="round" d="M54.217 15.5a3.59 3.59 0 0 1 2.661 1.181l12.695 14.032c.597.66.927 1.518.927 2.408v18.856c0 .855-.305 1.681-.86 2.331L56.874 69.243a3.589 3.589 0 0 1-2.728 1.257H32.132a3.59 3.59 0 0 1-2.705-1.23L16.384 54.312a3.589 3.589 0 0 1-.884-2.358v-18.81c0-.902.34-1.771.952-2.434l12.974-14.055a3.589 3.589 0 0 1 2.637-1.155h22.154Z"/>
+  <g filter="url(#critical-icon-a)">
+    <path fill="url(#critical-icon-b)" d="M54.217 15c1.155 0 2.257.489 3.032 1.346l12.694 14.031A4.089 4.089 0 0 1 71 33.121v18.856c0 .974-.348 1.916-.98 2.656L57.254 69.568A4.089 4.089 0 0 1 54.147 71H32.132a4.089 4.089 0 0 1-3.081-1.401L16.007 54.64A4.09 4.09 0 0 1 15 51.953V33.144c0-1.028.387-2.018 1.084-2.773l12.974-14.055A4.089 4.089 0 0 1 32.063 15h22.154Z"/>
+    <path stroke="url(#critical-icon-c)" stroke-linecap="round" d="M54.217 15.5a3.59 3.59 0 0 1 2.661 1.181l12.695 14.032c.597.66.927 1.518.927 2.408v18.856c0 .855-.305 1.681-.86 2.331L56.874 69.243a3.589 3.589 0 0 1-2.728 1.257H32.132a3.59 3.59 0 0 1-2.705-1.23L16.384 54.312a3.589 3.589 0 0 1-.884-2.358v-18.81c0-.902.34-1.771.952-2.434l12.974-14.055a3.589 3.589 0 0 1 2.637-1.155h22.154Z"/>
   </g>
   <path stroke="#FFD7D3" stroke-linecap="round" d="M44 51.91v-28"/>
   <path stroke="#FFD7D3" stroke-linecap="round" stroke-linejoin="round" d="M44 60.088v2"/>
   <defs>
-    <linearGradient id="b" x1="23" x2="97" y1="-9" y2="116.5" gradientUnits="userSpaceOnUse">
+    <linearGradient id="critical-icon-b" x1="23" x2="97" y1="-9" y2="116.5" gradientUnits="userSpaceOnUse">
       <stop stop-color="#FB8E85"/>
       <stop offset=".314" stop-color="#E03729"/>
       <stop offset="1" stop-color="#A11409"/>
     </linearGradient>
-    <linearGradient id="c" x1="29.5" x2="43" y1="17" y2="71" gradientUnits="userSpaceOnUse">
+    <linearGradient id="critical-icon-c" x1="29.5" x2="43" y1="17" y2="71" gradientUnits="userSpaceOnUse">
       <stop stop-color="#A11409"/>
       <stop offset="1" stop-color="#CD2113"/>
     </linearGradient>
-    <filter id="a" width="83.754" height="83.754" x="1.123" y="6.079" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+    <filter id="critical-icon-a" width="83.754" height="83.754" x="1.123" y="6.079" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
       <feOffset dy="4.956"/>

--- a/packages/mantine/src/components/prompt/icons/critical.svg
+++ b/packages/mantine/src/components/prompt/icons/critical.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 88 90">
+  <g filter="url(#a)">
+    <path fill="url(#b)" d="M54.217 15c1.155 0 2.257.489 3.032 1.346l12.694 14.031A4.089 4.089 0 0 1 71 33.121v18.856c0 .974-.348 1.916-.98 2.656L57.254 69.568A4.089 4.089 0 0 1 54.147 71H32.132a4.089 4.089 0 0 1-3.081-1.401L16.007 54.64A4.09 4.09 0 0 1 15 51.953V33.144c0-1.028.387-2.018 1.084-2.773l12.974-14.055A4.089 4.089 0 0 1 32.063 15h22.154Z"/>
+    <path stroke="url(#c)" stroke-linecap="round" d="M54.217 15.5a3.59 3.59 0 0 1 2.661 1.181l12.695 14.032c.597.66.927 1.518.927 2.408v18.856c0 .855-.305 1.681-.86 2.331L56.874 69.243a3.589 3.589 0 0 1-2.728 1.257H32.132a3.59 3.59 0 0 1-2.705-1.23L16.384 54.312a3.589 3.589 0 0 1-.884-2.358v-18.81c0-.902.34-1.771.952-2.434l12.974-14.055a3.589 3.589 0 0 1 2.637-1.155h22.154Z"/>
+  </g>
+  <path stroke="#FFD7D3" stroke-linecap="round" d="M44 51.91v-28"/>
+  <path stroke="#FFD7D3" stroke-linecap="round" stroke-linejoin="round" d="M44 60.088v2"/>
+  <defs>
+    <linearGradient id="b" x1="23" x2="97" y1="-9" y2="116.5" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FB8E85"/>
+      <stop offset=".314" stop-color="#E03729"/>
+      <stop offset="1" stop-color="#A11409"/>
+    </linearGradient>
+    <linearGradient id="c" x1="29.5" x2="43" y1="17" y2="71" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#A11409"/>
+      <stop offset="1" stop-color="#CD2113"/>
+    </linearGradient>
+    <filter id="a" width="83.754" height="83.754" x="1.123" y="6.079" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dy="4.956"/>
+      <feGaussianBlur stdDeviation="6.939"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix values="0 0 0 0 0.879167 0 0 0 0 0.215764 0 0 0 0 0.161181 0 0 0 0.37 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_14620_3737"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_14620_3737" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/packages/mantine/src/components/prompt/icons/info.svg
+++ b/packages/mantine/src/components/prompt/icons/info.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 88 88">
+  <g filter="url(#a)">
+    <circle cx="44" cy="44" r="28" fill="url(#b)"/>
+    <circle cx="44" cy="44" r="27.5" stroke="url(#c)" stroke-linecap="round"/>
+  </g>
+  <path stroke="#F5F6FF" stroke-linecap="round" d="M44 57V35h-3m3 22h-4m4 0h4m-4-26v-1"/>
+  <defs>
+    <linearGradient id="b" x1="34.308" x2="55.308" y1="12.231" y2="78.462" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8787DB"/>
+      <stop offset="1" stop-color="#525296"/>
+    </linearGradient>
+    <linearGradient id="c" x1="56.385" x2="44" y1="79" y2="7" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#AEB0F1"/>
+      <stop offset="1" stop-color="#525296"/>
+    </linearGradient>
+    <filter id="a" width="70" height="70" x="9" y="13" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dy="4"/>
+      <feGaussianBlur stdDeviation="3.5"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix values="0 0 0 0 0.420278 0 0 0 0 0.420278 0 0 0 0 0.741667 0 0 0 0.38 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_14620_2221"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_14620_2221" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/packages/mantine/src/components/prompt/icons/info.svg
+++ b/packages/mantine/src/components/prompt/icons/info.svg
@@ -1,19 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 88 88">
-  <g filter="url(#a)">
-    <circle cx="44" cy="44" r="28" fill="url(#b)"/>
-    <circle cx="44" cy="44" r="27.5" stroke="url(#c)" stroke-linecap="round"/>
+  <g filter="url(#info-icon-a)">
+    <circle cx="44" cy="44" r="28" fill="url(#info-icon-b)"/>
+    <circle cx="44" cy="44" r="27.5" stroke="url(#info-icon-c)" stroke-linecap="round"/>
   </g>
   <path stroke="#F5F6FF" stroke-linecap="round" d="M44 57V35h-3m3 22h-4m4 0h4m-4-26v-1"/>
   <defs>
-    <linearGradient id="b" x1="34.308" x2="55.308" y1="12.231" y2="78.462" gradientUnits="userSpaceOnUse">
+    <linearGradient id="info-icon-b" x1="34.308" x2="55.308" y1="12.231" y2="78.462" gradientUnits="userSpaceOnUse">
       <stop stop-color="#8787DB"/>
       <stop offset="1" stop-color="#525296"/>
     </linearGradient>
-    <linearGradient id="c" x1="56.385" x2="44" y1="79" y2="7" gradientUnits="userSpaceOnUse">
+    <linearGradient id="info-icon-c" x1="56.385" x2="44" y1="79" y2="7" gradientUnits="userSpaceOnUse">
       <stop stop-color="#AEB0F1"/>
       <stop offset="1" stop-color="#525296"/>
     </linearGradient>
-    <filter id="a" width="70" height="70" x="9" y="13" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+    <filter id="info-icon-a" width="70" height="70" x="9" y="13" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
       <feOffset dy="4"/>

--- a/packages/mantine/src/components/prompt/icons/success.svg
+++ b/packages/mantine/src/components/prompt/icons/success.svg
@@ -1,19 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 88 88">
-  <g filter="url(#a)">
-    <circle cx="44" cy="44" r="28" fill="url(#b)"/>
-    <circle cx="44" cy="44" r="27.5" stroke="url(#c)" stroke-linecap="round"/>
+  <g filter="url(#success-icon-a)">
+    <circle cx="44" cy="44" r="28" fill="url(#success-icon-b)"/>
+    <circle cx="44" cy="44" r="27.5" stroke="url(#success-icon-c)" stroke-linecap="round"/>
   </g>
   <path stroke="#F2FFF9" stroke-linecap="round" stroke-linejoin="round" d="m30.571 47 7.858 7.858L59 34.286" opacity=".61"/>
   <defs>
-    <linearGradient id="b" x1="35.923" x2="74.692" y1="11.154" y2="115.615" gradientUnits="userSpaceOnUse">
+    <linearGradient id="success-icon-b" x1="35.923" x2="74.692" y1="11.154" y2="115.615" gradientUnits="userSpaceOnUse">
       <stop stop-color="#12A344"/>
       <stop offset="1" stop-color="#004A20"/>
     </linearGradient>
-    <linearGradient id="c" x1="16" x2="58" y1="-48" y2="93.5" gradientUnits="userSpaceOnUse">
+    <linearGradient id="success-icon-c" x1="16" x2="58" y1="-48" y2="93.5" gradientUnits="userSpaceOnUse">
       <stop stop-color="#004A20"/>
       <stop offset=".762" stop-color="#12A344"/>
     </linearGradient>
-    <filter id="a" width="78" height="78" x="5" y="9" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+    <filter id="success-icon-a" width="78" height="78" x="5" y="9" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
       <feOffset dy="4"/>

--- a/packages/mantine/src/components/prompt/icons/success.svg
+++ b/packages/mantine/src/components/prompt/icons/success.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 88 88">
+  <g filter="url(#a)">
+    <circle cx="44" cy="44" r="28" fill="url(#b)"/>
+    <circle cx="44" cy="44" r="27.5" stroke="url(#c)" stroke-linecap="round"/>
+  </g>
+  <path stroke="#F2FFF9" stroke-linecap="round" stroke-linejoin="round" d="m30.571 47 7.858 7.858L59 34.286" opacity=".61"/>
+  <defs>
+    <linearGradient id="b" x1="35.923" x2="74.692" y1="11.154" y2="115.615" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#12A344"/>
+      <stop offset="1" stop-color="#004A20"/>
+    </linearGradient>
+    <linearGradient id="c" x1="16" x2="58" y1="-48" y2="93.5" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#004A20"/>
+      <stop offset=".762" stop-color="#12A344"/>
+    </linearGradient>
+    <filter id="a" width="78" height="78" x="5" y="9" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dy="4"/>
+      <feGaussianBlur stdDeviation="5.5"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix values="0 0 0 0 0.0717188 0 0 0 0 0.6375 0 0 0 0 0.266536 0 0 0 0.43 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_14620_10466"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_14620_10466" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/packages/mantine/src/components/prompt/icons/warning.svg
+++ b/packages/mantine/src/components/prompt/icons/warning.svg
@@ -1,19 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 88 88">
-  <g filter="url(#a)">
-    <path fill="url(#b)" d="M38.827 17.951c1.795-3.383 6.643-3.383 8.438 0L70.37 61.495c1.688 3.181-.618 7.015-4.22 7.015H19.942c-3.6 0-5.907-3.834-4.219-7.015L38.827 17.95Z"/>
-    <path stroke="url(#c)" stroke-linecap="round" d="M39.269 18.186c1.607-3.03 5.947-3.03 7.555 0l23.104 43.543c1.511 2.848-.553 6.28-3.777 6.28H19.94c-3.224 0-5.288-3.432-3.777-6.28l23.105-43.543Z"/>
+  <g filter="url(#warning-icon-a)">
+    <path fill="url(#warning-icon-b)" d="M38.827 17.951c1.795-3.383 6.643-3.383 8.438 0L70.37 61.495c1.688 3.181-.618 7.015-4.22 7.015H19.942c-3.6 0-5.907-3.834-4.219-7.015L38.827 17.95Z"/>
+    <path stroke="url(#warning-icon-c)" stroke-linecap="round" d="M39.269 18.186c1.607-3.03 5.947-3.03 7.555 0l23.104 43.543c1.511 2.848-.553 6.28-3.777 6.28H19.94c-3.224 0-5.288-3.432-3.777-6.28l23.105-43.543Z"/>
   </g>
   <path stroke="#493B08" stroke-linecap="round" d="M43 50.986v-22M43 58.151v2"/>
   <defs>
-    <linearGradient id="b" x1="74.046" x2="37.546" y1="68.839" y2="4.839" gradientUnits="userSpaceOnUse">
+    <linearGradient id="warning-icon-b" x1="74.046" x2="37.546" y1="68.839" y2="4.839" gradientUnits="userSpaceOnUse">
       <stop stop-color="#E2B104"/>
       <stop offset="1" stop-color="#FFE300"/>
     </linearGradient>
-    <linearGradient id="c" x1="29" x2="51" y1="10" y2="72" gradientUnits="userSpaceOnUse">
+    <linearGradient id="warning-icon-c" x1="29" x2="51" y1="10" y2="72" gradientUnits="userSpaceOnUse">
       <stop stop-color="#E2B104"/>
       <stop offset="1" stop-color="#F5D029"/>
     </linearGradient>
-    <filter id="a" width="73.775" height="71.096" x="6.158" y="10.414" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+    <filter id="warning-icon-a" width="73.775" height="71.096" x="6.158" y="10.414" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
       <feOffset dy="4"/>

--- a/packages/mantine/src/components/prompt/icons/warning.svg
+++ b/packages/mantine/src/components/prompt/icons/warning.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 88 88">
+  <g filter="url(#a)">
+    <path fill="url(#b)" d="M38.827 17.951c1.795-3.383 6.643-3.383 8.438 0L70.37 61.495c1.688 3.181-.618 7.015-4.22 7.015H19.942c-3.6 0-5.907-3.834-4.219-7.015L38.827 17.95Z"/>
+    <path stroke="url(#c)" stroke-linecap="round" d="M39.269 18.186c1.607-3.03 5.947-3.03 7.555 0l23.104 43.543c1.511 2.848-.553 6.28-3.777 6.28H19.94c-3.224 0-5.288-3.432-3.777-6.28l23.105-43.543Z"/>
+  </g>
+  <path stroke="#493B08" stroke-linecap="round" d="M43 50.986v-22M43 58.151v2"/>
+  <defs>
+    <linearGradient id="b" x1="74.046" x2="37.546" y1="68.839" y2="4.839" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E2B104"/>
+      <stop offset="1" stop-color="#FFE300"/>
+    </linearGradient>
+    <linearGradient id="c" x1="29" x2="51" y1="10" y2="72" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E2B104"/>
+      <stop offset="1" stop-color="#F5D029"/>
+    </linearGradient>
+    <filter id="a" width="73.775" height="71.096" x="6.158" y="10.414" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dy="4"/>
+      <feGaussianBlur stdDeviation="4.5"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix values="0 0 0 0 0.8875 0 0 0 0 0.695504 0 0 0 0 0.0147917 0 0 0 0.47 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_14620_10171"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_14620_10171" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -46,8 +46,6 @@ import {
     Tooltip,
 } from '@mantine/core';
 import {DatePicker} from '@mantine/dates';
-import {Prompt} from '../components';
-import PromptClasses from '../components/prompt/Prompt.module.css';
 import ActionIconClasses from '../styles/ActionIcon.module.css';
 import AlertClasses from '../styles/Alert.module.css';
 import AnchorClasses from '../styles/Anchor.module.css';
@@ -235,9 +233,6 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 shadow: 'md',
                 withArrow: true,
             },
-        }),
-        Prompt: Prompt.extend({
-            classNames: PromptClasses,
         }),
         Radio: Radio.extend({
             classNames: {labelWrapper: RadioClasses.labelWrapper},

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -20,6 +20,7 @@ import {
     ColorSwatch,
     Combobox,
     ComboboxSearch,
+    createTheme,
     Divider,
     Input,
     InputWrapper,
@@ -43,9 +44,10 @@ import {
     Text,
     TextInput,
     Tooltip,
-    createTheme,
 } from '@mantine/core';
 import {DatePicker} from '@mantine/dates';
+import {Prompt} from '../components';
+import PromptClasses from '../components/prompt/Prompt.module.css';
 import ActionIconClasses from '../styles/ActionIcon.module.css';
 import AlertClasses from '../styles/Alert.module.css';
 import AnchorClasses from '../styles/Anchor.module.css';
@@ -233,6 +235,9 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 shadow: 'md',
                 withArrow: true,
             },
+        }),
+        Prompt: Prompt.extend({
+            classNames: PromptClasses,
         }),
         Radio: Radio.extend({
             classNames: {labelWrapper: RadioClasses.labelWrapper},

--- a/packages/mantine/src/types/svg/index.d.ts
+++ b/packages/mantine/src/types/svg/index.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+    const content: string;
+    export default content;
+}

--- a/packages/website/src/examples/layout/Prompt/PromptCritical.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptCritical.demo.tsx
@@ -2,14 +2,23 @@ import {Button, Prompt, useDisclosure} from '@coveord/plasma-mantine';
 
 const Demo = () => {
     const [opened, {open, close}] = useDisclosure();
+    const onCancel = () => {
+        console.log('User clicked on cancel');
+        close();
+    };
+    const onConfirm = () => {
+        console.log('User clicked on confirm');
+        close();
+    };
 
     return (
         <>
-            <Prompt opened={opened} title="Prompt title" onClose={close}>
+            <Prompt variant="critical" opened={opened} title="Prompt title" onClose={close}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
                 <Prompt.Footer>
-                    <Prompt.ConfirmButton onClick={close}>Continue</Prompt.ConfirmButton>
+                    <Prompt.CancelButton onClick={onCancel}>Cancel</Prompt.CancelButton>
+                    <Prompt.ConfirmButton onClick={onConfirm}>Continue</Prompt.ConfirmButton>
                 </Prompt.Footer>
             </Prompt>
             <Button onClick={open}>Open Prompt</Button>

--- a/packages/website/src/examples/layout/Prompt/PromptSuccess.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptSuccess.demo.tsx
@@ -5,7 +5,7 @@ const Demo = () => {
 
     return (
         <>
-            <Prompt opened={opened} title="Prompt title" onClose={close}>
+            <Prompt variant="success" opened={opened} title="Prompt title" onClose={close}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
                 <Prompt.Footer>

--- a/packages/website/src/examples/layout/Prompt/PromptWarning.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptWarning.demo.tsx
@@ -2,14 +2,23 @@ import {Button, Prompt, useDisclosure} from '@coveord/plasma-mantine';
 
 const Demo = () => {
     const [opened, {open, close}] = useDisclosure();
+    const onCancel = () => {
+        console.log('User clicked on cancel');
+        close();
+    };
+    const onConfirm = () => {
+        console.log('User clicked on confirm');
+        close();
+    };
 
     return (
         <>
-            <Prompt opened={opened} title="Prompt title" onClose={close}>
+            <Prompt variant="warning" opened={opened} title="Prompt title" onClose={close}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
                 <Prompt.Footer>
-                    <Prompt.ConfirmButton onClick={close}>Continue</Prompt.ConfirmButton>
+                    <Prompt.CancelButton onClick={onCancel}>Cancel</Prompt.CancelButton>
+                    <Prompt.ConfirmButton onClick={onConfirm}>Continue</Prompt.ConfirmButton>
                 </Prompt.Footer>
             </Prompt>
             <Button onClick={open}>Open Prompt</Button>

--- a/packages/website/src/pages/layout/Prompt.tsx
+++ b/packages/website/src/pages/layout/Prompt.tsx
@@ -1,5 +1,8 @@
 import {PromptMetadata} from '@coveord/plasma-components-props-analyzer';
-import PromptDemo from '@examples/layout/Prompt/Prompt.demo?demo';
+import PromptInfoDemo from '@examples/layout/Prompt/Prompt.demo?demo';
+import PromptSuccessDemo from '@examples/layout/Prompt/PromptSuccess.demo?demo';
+import PromptWarningDemo from '@examples/layout/Prompt/PromptWarning.demo?demo';
+import PromptCriticalDemo from '@examples/layout/Prompt/PromptCritical.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -11,6 +14,11 @@ export default () => (
         description="A Prompt is a visual communication from the system to the user."
         id="Prompt"
         propsMetadata={PromptMetadata}
-        demo={<PromptDemo />}
+        demo={<PromptInfoDemo />}
+        examples={{
+            success: <PromptSuccessDemo title="Success prompt" />,
+            warning: <PromptWarningDemo title="Warning prompt" />,
+            critical: <PromptCriticalDemo title="Critical prompt" />,
+        }}
     />
 );


### PR DESCRIPTION
### Proposed Changes

Updated the look of the prompt component

| Before | After | Mockup |
| --- | --- | --- |
| <img width="687" alt="image" src="https://github.com/coveo/plasma/assets/260007/8a6e1213-381d-48a7-b2f4-9e158c17e017"> | <img width="685" alt="image" src="https://github.com/coveo/plasma/assets/260007/315e32a8-d3d0-400d-a43d-9d3544ea0041"> | <img width="720" alt="image" src="https://github.com/coveo/plasma/assets/260007/bd06a499-7d0e-4e13-be01-269d8757e028"> |

### Potential Breaking Changes

The prompt now uses the compound components (Modal.Root, Modal.Header, etc) from Mantine's Modal instead of using Modal

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
