### PR TITLE
chore: replace pnpm/action-setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,10 +7,9 @@ runs:
           with:
               registry-url: 'https://registry.npmjs.org'
               node-version: 20.9.0
-        - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
-          with:
-              version: 9
-              run_install: false
+        - name: Enable corepack
+          shell: bash
+          run: corepack enable
         - name: Get pnpm store directory
           id: pnpm-cache
           shell: bash


### PR DESCRIPTION
### Proposed Changes

The pnpm-setup action is broken. We cannot update to latest version. Leverage corepack instead

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
