### PR TITLE
chore: simplify tsconfig files

### DIFF
--- a/packages/components-props-analyzer/tsconfig.build.json
+++ b/packages/components-props-analyzer/tsconfig.build.json
@@ -1,3 +1,0 @@
-{
-    "extends": "./tsconfig.json"
-}

--- a/packages/components-props-analyzer/tsconfig.json
+++ b/packages/components-props-analyzer/tsconfig.json
@@ -1,9 +1,3 @@
 {
-    "extends": "../tsconfig-base.json",
-    "compilerOptions": {
-        "outDir": "./dist",
-        "rootDir": "src",
-        "tsBuildInfoFile": "./dist/.tsbuildinfo"
-    },
-    "include": ["src"]
+    "extends": "../tsconfig-base.json"
 }

--- a/packages/mantine/tsconfig.build.json
+++ b/packages/mantine/tsconfig.build.json
@@ -1,5 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "exclude": ["**/*.spec.*", "**/__tests__"],
-    "include": ["src"]
-}

--- a/packages/mantine/tsconfig.json
+++ b/packages/mantine/tsconfig.json
@@ -1,14 +1,12 @@
 {
     "extends": "../tsconfig-base.json",
     "compilerOptions": {
-        "outDir": "./dist",
-        "rootDir": "src",
-        "tsBuildInfoFile": "./dist/.tsbuildinfo",
-        "baseUrl": ".",
+        "rootDir": ".",
         "paths": {
             "@test-utils": ["./src/__tests__/Utils.tsx"]
         },
         "types": ["vitest/globals"]
     },
-    "include": ["src", "__mocks__"]
+    "include": ["src", "__mocks__"],
+    "exclude": ["**/*.spec.*", "**/__tests__"]
 }

--- a/packages/react-icons/tsconfig.build.json
+++ b/packages/react-icons/tsconfig.build.json
@@ -1,3 +1,0 @@
-{
-    "extends": "./tsconfig.json"
-}

--- a/packages/react-icons/tsconfig.json
+++ b/packages/react-icons/tsconfig.json
@@ -1,9 +1,3 @@
 {
-    "extends": "../tsconfig-base.json",
-    "compilerOptions": {
-        "outDir": "./dist",
-        "rootDir": "src",
-        "tsBuildInfoFile": "./dist/.tsbuildinfo"
-    },
-    "include": ["src"]
+    "extends": "../tsconfig-base.json"
 }

--- a/packages/tokens/tsconfig.build.json
+++ b/packages/tokens/tsconfig.build.json
@@ -1,3 +1,0 @@
-{
-    "extends": "./tsconfig.json"
-}

--- a/packages/tokens/tsconfig.json
+++ b/packages/tokens/tsconfig.json
@@ -1,9 +1,3 @@
 {
-    "extends": "../tsconfig-base.json",
-    "compilerOptions": {
-        "outDir": "./dist",
-        "rootDir": "src",
-        "tsBuildInfoFile": "./dist/.tsbuildinfo"
-    },
-    "include": ["src"]
+    "extends": "../tsconfig-base.json"
 }

--- a/packages/tsconfig-base.json
+++ b/packages/tsconfig-base.json
@@ -6,6 +6,11 @@
         "jsx": "react-jsx",
         "lib": ["ESNext", "DOM"],
 
+        "outDir": "${configDir}/dist",
+        "rootDir": "${configDir}/src",
+        "tsBuildInfoFile": "${configDir}/dist/.tsbuildinfo",
+        "baseUrl": "${configDir}",
+
         "composite": false,
         "incremental": true,
         "sourceMap": true,
@@ -27,5 +32,6 @@
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "importHelpers": true
-    }
+    },
+    "include": ["${configDir}/src"]
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -22,7 +22,7 @@ const onExit = (childProcess) => {
 const build = async ({watch = false}) => {
     // compile with swc and tsc
     try {
-        const tscArgs = ['-p', './tsconfig.build.json', '--emitDeclarationOnly'];
+        const tscArgs = ['--emitDeclarationOnly'];
         const tscESMArgs = [...tscArgs, '--declarationDir', './dist/esm'];
         const tscCJSArgs = [...tscArgs, '--declarationDir', './dist/cjs', '--target', 'es5', '--module', 'commonjs'];
         const swcArgs = ['./src', '--copy-files', '--config-file', path.resolve(__dirname, '..', 'build.swcrc')];


### PR DESCRIPTION
### Proposed Changes

With the new TypeScript 5.5 we can leverage the ${configDir} variable in tsconfig. This simplifies our tsconfig quite a lot and allowed me to even delete the tsconfig.build.json

ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
