### PR TITLE
fix(mantine, tabs): apply changes to style

### DIFF
--- a/packages/mantine/src/styles/Tabs.module.css
+++ b/packages/mantine/src/styles/Tabs.module.css
@@ -5,6 +5,12 @@
         }
 
         --tabs-list-border-width: 1px;
+
+        &[data-orientation='horizontal'] {
+            .list {
+                margin-bottom: calc(-1 * var(--tabs-list-border-width));
+            }
+        }
     }
 }
 

--- a/packages/mantine/src/styles/Tabs.module.css
+++ b/packages/mantine/src/styles/Tabs.module.css
@@ -1,45 +1,13 @@
-.list {
-    &[data-orientation='horizontal'] {
-        &::before {
-            border-style: none;
+.root {
+    &[data-variant='default'] {
+        @mixin light {
+            --tab-hover-color: var(--mantine-color-gray-1);
         }
 
-        border-bottom: rem(1) solid var(--mantine-color-gray-3);
-    }
-
-    &[data-orientation='vertical'] {
-        &::before {
-            border-style: none;
-        }
-
-        border-right: rem(1) solid var(--mantine-color-gray-3);
+        --tabs-list-border-width: 1px;
     }
 }
 
 .tab {
-    &[data-orientation='horizontal'] {
-        border-bottom: rem(1) solid transparent;
-        margin-bottom: rem(-1);
-
-        &[data-active] {
-            border-bottom: rem(1) solid var(--mantine-primary-color-6);
-        }
-    }
-
-    &[data-orientation='vertical'] {
-        border-right: rem(1) solid transparent;
-        margin-right: rem(-1);
-
-        &[data-active] {
-            border-bottom: rem(1) solid var(--mantine-primary-color-6);
-        }
-    }
-
-    & :hover {
-        background-color: var(--mantine-color-gray-0);
-    }
-
-    &:not([data-active]):hover {
-        border-color: var(--mantine-color-gray-3);
-    }
+    line-height: 1.5;
 }

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -265,7 +265,12 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             },
         }),
         Tabs: Tabs.extend({
-            classNames: {list: TabsClasses.list, tab: TabsClasses.tab},
+            classNames: TabsClasses,
+        }),
+        TabsTab: Tabs.Tab.extend({
+            defaultProps: {
+                px: 'sm',
+            },
         }),
         Text: Text.extend({
             classNames: TextClasses,


### PR DESCRIPTION
### Proposed Changes

Fixed the look of the Tabs component.
- Increased line height
- Used css variables to override border width and color
- Changed the default padding of Tab

| Before | After |
| --- | --- |
| <img width="373" alt="image" src="https://github.com/user-attachments/assets/4e9e7a35-3a36-446c-af99-3c067711a06e"> | <img width="303" alt="image" src="https://github.com/user-attachments/assets/32687e46-d9fc-4272-87c9-9ed8d8eadfb6"> |
| <img width="240" alt="image" src="https://github.com/user-attachments/assets/42472db9-ac84-47f3-bdc1-b01822db3e3d"> | <img width="212" alt="image" src="https://github.com/user-attachments/assets/31208c2a-651a-4d8d-bf32-7de29cf16af1"> |

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
