### PR TITLE
fix(mantine, prompt): center the prompt component by default

### DIFF
--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -62,6 +62,7 @@ const PROMPT_VARIANT_ICONS_SRC: Record<PromptVariant, string> = {
 
 const defaultProps: Partial<PromptProps> = {
     variant: 'info',
+    centered: true,
 };
 
 const varsResolver = createVarsResolver<PromptFactory>((_theme, {icon}) => ({


### PR DESCRIPTION
### Proposed Changes

Center the prompt component by default.

### Potential Breaking Changes

No

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
