### PR TITLE
chore: fix eslint configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ import vitest from 'eslint-plugin-vitest';
 import reactRefresh from 'eslint-plugin-react-refresh';
 
 export default tsEslint.config(
-    {ignores: ['**/dist', '**/.turbo', 'packages/react-icons/mock/index.js']},
+    {ignores: ['**/dist', '**/.turbo', 'packages/react-icons/mock/index.js', 'packages/website/src/examples/mantine']},
     {
         files: ['**/*.js', '**/*.jsx', '**/*.mjs', '**/*.cjs', '**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
         extends: [tsEslint.configs.base, reactJsxRuntime, eslintConfigPrettier],
@@ -28,11 +28,7 @@ export default tsEslint.config(
         languageOptions: {
             parserOptions: {
                 projectService: {
-                    allowDefaultProject: [
-                        '*.js',
-                        'packages/react-icons/mock/index.tsx',
-                        'packages/mantine/vitest.config.ts',
-                    ],
+                    allowDefaultProject: ['*.js'],
                 },
                 jsxPragma: 'React',
             },

--- a/packages/components-props-analyzer/bin/getPropsOfComponent.ts
+++ b/packages/components-props-analyzer/bin/getPropsOfComponent.ts
@@ -1,5 +1,5 @@
 import {VirtualTypeScriptEnvironment} from '@typescript/vfs';
-import ts from 'typescript';
+import ts, {CompletionEntry} from 'typescript';
 
 import {Component, ComponentMetadata} from '../src/ComponentsList';
 
@@ -17,7 +17,7 @@ export const getPropsOfComponent = (component: Component, env: VirtualTypeScript
     env.createFile(fileName, content);
     const {entries} = env.languageService.getCompletionsAtPosition(fileName, content.length + 1, {
         triggerKind: ts.CompletionTriggerKind.Invoked,
-    }) ?? {entries: []};
+    }) ?? {entries: [] as CompletionEntry[]};
 
     const checker = env.languageService.getProgram()!.getTypeChecker();
     const accumulator: ComponentMetadata[] = [];

--- a/packages/components-props-analyzer/package.json
+++ b/packages/components-props-analyzer/package.json
@@ -19,7 +19,7 @@
         "clean": "rimraf dist",
         "compile": "node ../../scripts/build",
         "gen:props": "ts-node --project ./bin/tsconfig.json ./bin/index.ts",
-        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"src/**/*.{ts,tsx}\" --fix",
+        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"**/*.{ts,tsx}\" --fix",
         "prettify": "prettier --write \"src/components/*.ts\"",
         "start": "nodemon"
     },

--- a/packages/components-props-analyzer/tsconfig.build.json
+++ b/packages/components-props-analyzer/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["./src"]
+}

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -29,7 +29,7 @@
     "scripts": {
         "build": "node ../../scripts/build",
         "clean": "rimraf dist",
-        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"src/**/*.{ts,tsx}\" --fix",
+        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"**/*.{ts,tsx}\" --fix",
         "prepublishOnly": "publint",
         "start": "node ../../scripts/start",
         "test": "TZ=UTC vitest run",

--- a/packages/mantine/tsconfig.build.json
+++ b/packages/mantine/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["./src"],
+    "exclude": ["./src/__tests__", "**/*.spec.*"]
+}

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -39,6 +39,7 @@
         "build:mock": "swc ./mock/index.tsx -o ./mock/index.js --config-file ./mock/.swcrc",
         "clean": "rimraf dist",
         "generate": "node ./bin/index.js",
+        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"**/*.{ts,tsx}\" --fix",
         "prepublishOnly": "publint"
     },
     "dependencies": {

--- a/packages/react-icons/tsconfig.build.json
+++ b/packages/react-icons/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["./src"]
+}

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -29,7 +29,7 @@
     ],
     "scripts": {
         "build": "rimraf dist && node ../../scripts/build",
-        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"bin/**/*.{ts,tsx}\" --fix",
+        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"**/*.{ts,tsx}\" --fix",
         "prepublishOnly": "publint",
         "tokens:build": "ts-node ./bin/build.ts --project ./bin/tsconfig.json && pnpm tokens:lint",
         "tokens:fetch": "ts-node -r dotenv-safe/config --project ./bin/tsconfig.json ./bin/fetch.ts",

--- a/packages/tokens/tsconfig.build.json
+++ b/packages/tokens/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["./src"]
+}

--- a/packages/tsconfig-base.json
+++ b/packages/tsconfig-base.json
@@ -7,7 +7,7 @@
         "lib": ["ESNext", "DOM"],
 
         "outDir": "${configDir}/dist",
-        "rootDir": "${configDir}/src",
+        "rootDirs": ["${configDir}/src", "${configDir}/__mocks__"],
         "tsBuildInfoFile": "${configDir}/dist/.tsbuildinfo",
         "baseUrl": "${configDir}",
 
@@ -33,5 +33,5 @@
         "esModuleInterop": true,
         "importHelpers": true
     },
-    "include": ["${configDir}/src"]
+    "exclude": ["${configDir}/dist", "${configDir}/node_modules"]
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "scripts": {
         "build": "tsc && vite build",
+        "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"**/*.{ts,tsx}\" --fix",
         "mantine:fetch": "ts-node --project ./bin/tsconfig.json ./bin/index.ts",
         "preview": "vite preview",
         "start": "vite"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const {spawn} = require('child_process');
 const path = require('path');
-const {writeFileSync} = require('node:fs');
+const {existsSync, writeFileSync} = require('node:fs');
 process.on('unhandledRejection', (err) => {
     throw err;
 });
@@ -22,6 +22,9 @@ const build = async ({watch = false}) => {
     // compile with swc and tsc
     try {
         const tscArgs = ['--emitDeclarationOnly'];
+        if (existsSync('./tsconfig.build.json')) {
+            tscArgs.push('--project', './tsconfig.build.json');
+        }
         const tscESMArgs = [...tscArgs, '--declarationDir', './dist/esm'];
         const tscCJSArgs = [...tscArgs, '--declarationDir', './dist/cjs', '--target', 'es5', '--module', 'commonjs'];
         const swcArgs = ['./src', '--copy-files', '--config-file', path.resolve(__dirname, '..', 'build.swcrc')];


### PR DESCRIPTION
### Proposed Changes

I saw that renovate PRs [were failling](https://github.com/coveo/plasma/actions/runs/10345730745/job/28633183570) due to an ESLint error. I made sure our tsconfig included all relevant files and added a tsconfig.build.json to exclude files when we build

<img width="587" alt="image" src="https://github.com/user-attachments/assets/366f470b-bbbe-4015-ae33-54dec6786024">
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/7c73ccdc-7726-4c16-9ec7-cd6fbb26a35e">


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
