### PR TITLE
fix(mantine, skeleton): increase z-index

### DIFF
--- a/packages/mantine/src/styles/Skeleton.module.css
+++ b/packages/mantine/src/styles/Skeleton.module.css
@@ -1,11 +1,11 @@
 .root {
-    &[data-visible] {
+    &:where([data-visible]) {
         &::before {
-            z-index: unset;
+            z-index: var(--mantine-z-index-overlay);
         }
 
         &::after {
-            z-index: unset;
+            z-index: calc(var(--mantine-z-index-overlay) + 1);
         }
     }
 }


### PR DESCRIPTION
### Proposed Changes

This fixes the issue with buttons, indicator, etc being visible when wrapped by a Skeleton 

https://mantine.dev/styles/css-variables/#z-index-variables

### Potential Breaking Changes

The z-index changed but it shouldn't break anything ™️ 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
