### PR TITLE
fix(mantine, table): change the pagination boundaries

### DIFF
--- a/packages/mantine/src/components/table/table-pagination/TablePagination.tsx
+++ b/packages/mantine/src/components/table/table-pagination/TablePagination.tsx
@@ -27,7 +27,7 @@ export const TablePagination: FunctionComponent<TablePaginationProps> = ({onPage
             value={store.state.pagination.pageIndex + 1}
             onChange={updatePage}
             total={total}
-            boundaries={0}
+            boundaries={1}
             size="md"
             gap="xs"
             getControlProps={(control) => {


### PR DESCRIPTION
### Proposed Changes

Updated the pagination boundaries to match UX's suggestion.

<img width="1303" alt="image" src="https://github.com/user-attachments/assets/721c5578-9d8f-4c3c-be25-50bb3c6af2a3">
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/4d0e7ec3-0719-429e-9f32-c0e30df9fb94">


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
