### PR TITLE
fix(mantine, date picker): scroll one month instead of two

### DIFF
--- a/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
+++ b/packages/mantine/src/components/date-range-picker/DateRangePickerInlineCalendar.tsx
@@ -92,6 +92,7 @@ export const DateRangePickerInlineCalendar = ({
             <Center py="sm" px="md">
                 <DatePicker
                     numberOfColumns={2}
+                    columnsToScroll={1}
                     type="range"
                     styles={{day: {textAlign: 'center'}}}
                     firstDayOfWeek={0}

--- a/packages/mantine/src/components/date-range-picker/DateRangePickerPopoverCalendar.tsx
+++ b/packages/mantine/src/components/date-range-picker/DateRangePickerPopoverCalendar.tsx
@@ -86,6 +86,7 @@ export const DateRangePickerPopoverCalendar = ({
                         type="range"
                         styles={{day: {textAlign: 'center'}}}
                         numberOfColumns={2}
+                        columnsToScroll={1}
                         firstDayOfWeek={0}
                         allowSingleDateInRange
                         value={_value}


### PR DESCRIPTION
### Proposed Changes

Applied requested changes to the date picker. It now scroll month by month even if it shows two months


https://github.com/user-attachments/assets/d53b5d85-518a-4ccb-b167-8d16f5202ac0


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
