### PR TITLE
chore(renovate): only split major versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,13 +18,15 @@
         },
         {
             groupName: '@tanstack table',
-            description: 'Group @tanstack table packages together because they need to be updated at the same time',
+            description: 'Group major updates of @tanstack packages together because they need to be updated at the same time',
             matchPackagePrefixes: ['@tanstack/'],
+            updateTypes: ['major'],
         },
         {
             groupName: 'ui-kit',
-            description: 'Group ui-kit packages together because they need to be updated at the same time',
+            description: 'Group major updates of ui-kit packages together because they need to be updated at the same time',
             matchPackagePrefixes: ['@coveo/atomic-react', '@coveo/headless'],
+            updateTypes: ['major'],
         },
     ],
     lockFileMaintenance: {


### PR DESCRIPTION
### Proposed Changes

Currently renovate creates a separate PR from the minor/patch one for ui-kit (headless, atomic) and tanstack (query, table, etc) packages even if the bump is a patch or a minor which creates a lot of noise. I updated the config to only group the major of those packages

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
