### PR TITLE
fix(mantine): change Radio label color to gray-7

### DIFF
--- a/packages/mantine/src/styles/Radio.module.css
+++ b/packages/mantine/src/styles/Radio.module.css
@@ -1,4 +1,10 @@
 .labelWrapper {
     display: flex;
     align-items: flex-start;
+
+    &:not([data-disabled]) {
+        .label {
+            color: var(--mantine-color-gray-7);
+        }
+    }
 }

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -234,9 +234,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 withArrow: true,
             },
         }),
-        Radio: Radio.extend({
-            classNames: {labelWrapper: RadioClasses.labelWrapper},
-        }),
+        Radio: Radio.extend({classNames: RadioClasses}),
         ScrollArea: ScrollArea.extend({
             classNames: {viewport: ScrollAreaClasses.viewport},
         }),


### PR DESCRIPTION
### Proposed Changes

As per designers demand, we are changing the Radio label color from default gray-9 to gray-7.

Before
![image](https://github.com/user-attachments/assets/7c838a5c-1414-49c7-a0ce-cafee952f01d)

After
![image](https://github.com/user-attachments/assets/ebabdb44-79ee-4168-9017-f165d5d2e7dc)



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
