### PR TITLE
feat(mantine): add xxs spacing size to plasma theme

### DIFF
--- a/packages/mantine/src/styles/Badge.module.css
+++ b/packages/mantine/src/styles/Badge.module.css
@@ -1,5 +1,5 @@
 .root {
     text-transform: none;
-    padding: 4px 8px;
+    padding: var(--mantine-spacing-xxs) var(--mantine-spacing-xs);
     font-weight: 500;
 }

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -81,6 +81,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
     defaultRadius: 8,
     lineHeights: {md: '1.5'},
     spacing: {
+        xxs: '4px',
         xs: '8px',
         sm: '16px',
         md: '24px',

--- a/packages/website/src/pages/foundations/Colors.tsx
+++ b/packages/website/src/pages/foundations/Colors.tsx
@@ -2,7 +2,7 @@ import {Group, Stack, Title} from '@coveord/plasma-mantine';
 import {ExternalSize16Px} from '@coveord/plasma-react-icons';
 import {color} from '@coveord/plasma-tokens';
 import {InlineCodeHighlight} from '@mantine/code-highlight';
-import {Table as MantineTable} from '@mantine/core';
+import {Anchor, Box, Table as MantineTable} from '@mantine/core';
 import kebabCase from 'lodash.kebabcase';
 import {FunctionComponent} from 'react';
 import {PageLayout} from '../../building-blocs/PageLayout';
@@ -123,14 +123,10 @@ export const ColorsExamples = () => (
         <div className="plasma-page-layout__section pl5">
             <p>
                 All colors are exposed through the{' '}
-                <a
-                    href="https://github.com/coveo/plasma/tree/master/packages/tokens#readme"
-                    target="_blank"
-                    className="link inline-flex flex-center"
-                >
+                <Anchor href="https://github.com/coveo/plasma/tree/master/packages/tokens#readme" target="_blank">
                     @coveord/plasma-tokens
-                    <ExternalSize16Px style={{marginLeft: '4px'}} />
-                </a>{' '}
+                    <Box component={ExternalSize16Px} height={16} ml="xxs" />
+                </Anchor>{' '}
                 package in 3 formats: TypeScript, Sass and CSS. Hover over any color to see its name in any of those
                 formats.
             </p>

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import {Anchor, AppShell, Container, Title, Stack, Text} from '@coveord/plasma-mantine';
+import {Anchor, AppShell, Container, Title, Stack, Text, Box} from '@coveord/plasma-mantine';
 import {ExternalSize16Px} from '@coveord/plasma-react-icons';
 import {FunctionComponent} from 'react';
 import {Tile} from '../building-blocs/Tile';
@@ -29,14 +29,16 @@ const WelcomeToPlasma: FunctionComponent = () => (
             <Text>
                 Learn more about our brand, our values and our story by visiting our{' '}
                 <Anchor href="https://brand.coveo.com/">
-                    brand page <ExternalSize16Px style={{marginLeft: '4px'}} />
+                    brand page
+                    <Box component={ExternalSize16Px} height={16} ml="xxs" />
                 </Anchor>
                 .
             </Text>
             <Text>
                 Be part of the progress! Contribute to Plasma on{' '}
                 <Anchor href="https://github.com/coveo/plasma#readme">
-                    GitHub <ExternalSize16Px style={{marginLeft: '4px'}} />
+                    GitHub
+                    <Box component={ExternalSize16Px} height={16} ml="xxs" />
                 </Anchor>
                 .
             </Text>


### PR DESCRIPTION
### Proposed Changes

Designs we receive sometimes require spacing of 4px, which is smaller than xs (8px). Having a `xxs` size variant avoids resorting to a custom css module with custom css rules for those cases.

This PR adds the `xxs` sapcing to the Plasma theme.

![image](https://github.com/user-attachments/assets/6cd5061c-3fa3-4bac-81a9-e5b55f9d93e6)


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
