### PR TITLE
chore(renovate): remove automerge from config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,15 +4,10 @@
     schedule: ['at any time'],
     semanticCommitScope: 'deps',
     commitBody: 'UITOOL-284',
-    ignoreDeps: [
-        // security only approved one version of the pnpm/action-setup action. Cannot be bumped
-        'pnpm/action-setup',
-    ],
     packageRules: [
         {
             description: 'Automatically merge minor and patch-level updates',
             updateTypes: ['minor', 'patch'],
-            automerge: true,
             semanticCommitType: 'chore',
             internalChecksFilter: 'strict',
         },
@@ -32,7 +27,6 @@
     lockFileMaintenance: {
         description: 'Regenerate the pnpm-lock.yaml file',
         enabled: true,
-        automerge: true,
         extends: ['schedule:weekly'],
     },
 }


### PR DESCRIPTION
### Proposed Changes

Renovate has gained some powers and doesn't wait anymore for approvals. I removed the `automerge` property so we can review the changes.
I also removed the ignore of the `pnpm/action-setup` since we don't use it anymore

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
