### PR TITLE
fix(table): type only import for table predicate props

### DIFF
--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -1,6 +1,6 @@
 export {flexRender as renderTableCell} from '@tanstack/react-table';
 export * from './Table';
-export {TablePredicateProps} from './table-predicate/TablePredicate';
+export {type TablePredicateProps} from './table-predicate/TablePredicate';
 export {type TableAction, type TableLayout, type TableLayoutProps, type TableProps} from './Table.types';
 export {useTableContext} from './TableContext';
 export {useTable, type TableState, type TableStore, type UseTableOptions} from './use-table';


### PR DESCRIPTION
### Proposed Changes

This [PR](https://github.com/coveo/plasma/pull/3885) did not export `TablePredicateProps` using type-only so it throws an error when running the admin

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
