### PR TITLE
fix(mantine): make Table.Predicate label prop required

### DIFF
--- a/packages/mantine/src/components/table/__tests__/TablePredicate.spec.tsx
+++ b/packages/mantine/src/components/table/__tests__/TablePredicate.spec.tsx
@@ -20,6 +20,7 @@ describe('Table.Predicate', () => {
                     <Table.Header>
                         <Table.Predicate
                             id="rank"
+                            label="Rank"
                             data={[
                                 {value: 'first', label: 'First'},
                                 {value: 'second', label: 'Second'},
@@ -35,7 +36,7 @@ describe('Table.Predicate', () => {
         };
         render(<Fixture />);
         expect(screen.getByRole('button', {name: '2', current: 'page'})).toBeVisible();
-        await user.click(screen.getByRole('textbox', {name: 'rank'}));
+        await user.click(screen.getByRole('textbox', {name: 'Rank'}));
         await user.click(screen.getByRole('option', {name: 'First'}));
         expect(screen.getByRole('button', {name: '1', current: 'page'})).toBeVisible();
     });

--- a/packages/mantine/src/components/table/table-predicate/TablePredicate.tsx
+++ b/packages/mantine/src/components/table/table-predicate/TablePredicate.tsx
@@ -31,11 +31,10 @@ export interface TablePredicateProps
      */
     data: ComboboxData;
     /**
-     * Input label (not displayed for now)
+     * The label to display next to the Select
      *
-     * @default default to the predicate id
      */
-    label?: string;
+    label: string;
 }
 
 export type TablePredicateFactory = Factory<{


### PR DESCRIPTION
### Proposed Changes

BREAKING CHANGE: the Table.Predicate label prop is now required.

We are making the Table.Predicate prop `label` required so that users always know what they are filtering on. We have seen implementations where the implementer forgot to add a label and it was unclear for the user.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
