### PR TITLE
fix(mantine): select asterisk color is too light

### DIFF
--- a/packages/mantine/src/components/read-only/ReadOnlyInputStyles.ts
+++ b/packages/mantine/src/components/read-only/ReadOnlyInputStyles.ts
@@ -7,6 +7,9 @@ export const readOnlyInputStyles = (theme: MantineTheme) => ({
         '--input-color': theme.colors.gray[7],
         '--input-placeholder-color': theme.colors.gray[7],
     },
+    label: {
+        '--input-asterisk-color': theme.colors.red[2],
+    },
     input: {
         cursor: 'text',
     },

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -206,7 +206,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             classNames: InputWrapperClasses,
             vars: (theme, props) => {
                 const anyProps = props as any;
-                if (anyProps.readOnly || anyProps.disabled) {
+                if (anyProps.disabled || (anyProps.readOnly && !['Select'].includes(anyProps.__staticSelector))) {
                     return {
                         label: {'--input-asterisk-color': theme.colors.red[2]},
                         error: {},


### PR DESCRIPTION
### Proposed Changes

The required asterisk of Select components had a shade too light when not in read only.

|| Before | After |
|---| --- | --- |
| Normal | ![image](https://github.com/user-attachments/assets/5053c5ce-c215-4644-af7d-d7c7a88135fc) | ![image](https://github.com/user-attachments/assets/2fd3c0b2-c769-46c2-be5f-d7a97248c87c) |
| Read only | ![image](https://github.com/user-attachments/assets/0ded319e-b944-419a-9def-f5a8628926c6) | ![image](https://github.com/user-attachments/assets/050f6869-958b-4d26-beec-cdddd7f3040e) |




### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
