### PR TITLE
feat(mantine,website): create the EllipsisText component

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -97,6 +97,11 @@ const components: Component[] = [
         name: 'Alert',
         packageName: '@coveord/plasma-mantine',
     },
+    {
+        name: 'EllipsisText',
+        packageName: '@coveord/plasma-mantine',
+        propsType: 'EllipsisTextProps',
+    },
 ];
 
 export default components;

--- a/packages/mantine/src/components/ellipsis-text/EllipsisText.module.css
+++ b/packages/mantine/src/components/ellipsis-text/EllipsisText.module.css
@@ -1,0 +1,9 @@
+.root {
+    white-space: nowrap;
+}
+
+.text {
+    flex-basis: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/packages/mantine/src/components/ellipsis-text/EllipsisText.tsx
+++ b/packages/mantine/src/components/ellipsis-text/EllipsisText.tsx
@@ -2,13 +2,12 @@ import {
     Box,
     type BoxProps,
     type Factory,
-    type FloatingPosition,
-    type MantineColor,
     polymorphicFactory,
     type StylesApiProps,
     Text,
     type TextProps,
     Tooltip,
+    type TooltipProps,
     useProps,
     useStyles,
 } from '@mantine/core';
@@ -22,14 +21,7 @@ export interface EllipsisTextProps
         Pick<TextProps, 'variant'>,
         Omit<StylesApiProps<EllipsisTextFactory>, 'variant'> {
     children: ReactNode;
-    /**
-     * The background color of the tooltip shown when the content is truncated.
-     */
-    tooltipColor?: MantineColor;
-    /**
-     * The position of the tooltip shown when the content is truncated.
-     */
-    tooltipPosition?: FloatingPosition;
+    tooltipProps: Omit<TooltipProps, 'label' | 'opened'>;
 }
 
 type EllipsisTextFactory = Factory<{
@@ -42,18 +34,11 @@ type EllipsisTextFactory = Factory<{
 const defaultProps: Partial<EllipsisTextProps> = {};
 
 export const EllipsisText = polymorphicFactory<EllipsisTextFactory>((props, ref) => {
-    const {
-        className,
-        children,
-        style,
-        classNames,
-        styles,
-        unstyled,
-        variant,
-        tooltipColor,
-        tooltipPosition,
-        ...others
-    } = useProps('EllipsisText', defaultProps, props);
+    const {className, children, style, classNames, styles, unstyled, variant, tooltipProps, ...others} = useProps(
+        'EllipsisText',
+        defaultProps,
+        props,
+    );
     const getStyles = useStyles<EllipsisTextFactory>({
         name: 'EllipsisText',
         classes,
@@ -82,13 +67,7 @@ export const EllipsisText = polymorphicFactory<EllipsisTextFactory>((props, ref)
             {...getStyles('root')}
             {...others}
         >
-            <Tooltip
-                label={children}
-                opened={showTooltip}
-                color={tooltipColor}
-                position={tooltipPosition}
-                {...getStyles('tooltip')}
-            >
+            <Tooltip label={children} opened={showTooltip} {...tooltipProps} {...getStyles('tooltip')}>
                 <Text variant={variant} ref={textRef} {...getStyles('text')}>
                     {children}
                 </Text>

--- a/packages/mantine/src/components/ellipsis-text/EllipsisText.tsx
+++ b/packages/mantine/src/components/ellipsis-text/EllipsisText.tsx
@@ -1,0 +1,100 @@
+import {
+    Box,
+    type BoxProps,
+    type Factory,
+    type FloatingPosition,
+    type MantineColor,
+    polymorphicFactory,
+    type StylesApiProps,
+    Text,
+    type TextProps,
+    Tooltip,
+    useProps,
+    useStyles,
+} from '@mantine/core';
+import {ReactNode, useRef, useState} from 'react';
+import classes from './EllipsisText.module.css';
+
+export type EllipsisTextStylesNames = 'root' | 'tooltip' | 'text';
+
+export interface EllipsisTextProps
+    extends BoxProps,
+        Pick<TextProps, 'variant'>,
+        Omit<StylesApiProps<EllipsisTextFactory>, 'variant'> {
+    children: ReactNode;
+    /**
+     * The background color of the tooltip shown when the content is truncated.
+     */
+    tooltipColor?: MantineColor;
+    /**
+     * The position of the tooltip shown when the content is truncated.
+     */
+    tooltipPosition?: FloatingPosition;
+}
+
+type EllipsisTextFactory = Factory<{
+    props: EllipsisTextProps;
+    defaultRef: HTMLDivElement;
+    defaultComponent: 'div';
+    stylesNames: EllipsisTextStylesNames;
+}>;
+
+const defaultProps: Partial<EllipsisTextProps> = {};
+
+export const EllipsisText = polymorphicFactory<EllipsisTextFactory>((props, ref) => {
+    const {
+        className,
+        children,
+        style,
+        classNames,
+        styles,
+        unstyled,
+        variant,
+        tooltipColor,
+        tooltipPosition,
+        ...others
+    } = useProps('EllipsisText', defaultProps, props);
+    const getStyles = useStyles<EllipsisTextFactory>({
+        name: 'EllipsisText',
+        classes,
+        props,
+        className,
+        style,
+        classNames,
+        styles,
+        unstyled,
+    });
+
+    const [showTooltip, setShowTooltip] = useState(false);
+    const textRef = useRef<HTMLDivElement>();
+
+    return (
+        <Box
+            ref={ref}
+            onMouseEnter={() => {
+                if (textRef.current && isOverflowing(textRef.current)) {
+                    setShowTooltip(true);
+                }
+            }}
+            onMouseLeave={() => setShowTooltip(false)}
+            display="flex"
+            w="100%"
+            {...getStyles('root')}
+            {...others}
+        >
+            <Tooltip
+                label={children}
+                opened={showTooltip}
+                color={tooltipColor}
+                position={tooltipPosition}
+                {...getStyles('tooltip')}
+            >
+                <Text variant={variant} ref={textRef} {...getStyles('text')}>
+                    {children}
+                </Text>
+            </Tooltip>
+        </Box>
+    );
+});
+
+const isOverflowing = (h: HTMLDivElement) => h.scrollWidth > h.clientWidth;

--- a/packages/mantine/src/components/ellipsis-text/index.ts
+++ b/packages/mantine/src/components/ellipsis-text/index.ts
@@ -1,0 +1,1 @@
+export * from './EllipsisText';

--- a/packages/mantine/src/components/index.ts
+++ b/packages/mantine/src/components/index.ts
@@ -6,6 +6,7 @@ export * from './code-editor';
 export * from './collection';
 export * from './copyToClipboard';
 export * from './date-range-picker';
+export * from './ellipsis-text';
 export * from './header';
 export * from './inline-confirm';
 export * from './menu';

--- a/packages/mantine/src/styles/Tooltip.module.css
+++ b/packages/mantine/src/styles/Tooltip.module.css
@@ -1,0 +1,3 @@
+.tooltip {
+    word-break: break-word;
+}

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -74,6 +74,7 @@ import SkeletonClasses from '../styles/Skeleton.module.css';
 import StepperClasses from '../styles/Stepper.module.css';
 import TabsClasses from '../styles/Tabs.module.css';
 import TextClasses from '../styles/Text.module.css';
+import TooltipClasses from '../styles/Tooltip.module.css';
 import {NotificationVars} from '../vars/Notification.vars';
 import {TextVars} from '../vars/Text.vars';
 import {PlasmaColors} from './PlasmaColors';
@@ -371,6 +372,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 withArrow: true,
                 zIndex: 10000,
             },
+            classNames: TooltipClasses,
         }),
     },
 });

--- a/packages/website/src/Navigation.tsx
+++ b/packages/website/src/Navigation.tsx
@@ -48,6 +48,7 @@ export const Navigation = () => (
         </NavLink>
         <NavLink label="Layout" leftSection={<RichUiSize16Px height={16} />} defaultOpened>
             <InternalNavLink to="/layout/BrowserPreview" label="Browser Preview" />
+            <InternalNavLink to="/layout/EllipsisText" label="Ellipsis text" />
             <InternalNavLink to="/layout/Header" label="Header" />
             <InternalNavLink to="/layout/Modal" label="Modal" />
             <InternalNavLink to="/layout/Prompt" label="Prompt" />

--- a/packages/website/src/examples/layout/EllipsisText/EllipsisText.demo.tsx
+++ b/packages/website/src/examples/layout/EllipsisText/EllipsisText.demo.tsx
@@ -1,0 +1,11 @@
+import {EllipsisText} from '@coveord/plasma-mantine';
+
+const Demo = () => (
+    <>
+        <EllipsisText maw={250}>
+            This is a very long text that is truncated with an ellipsis. The rest is shown on hover.
+        </EllipsisText>
+        <EllipsisText maw={250}>This short text is not truncated.</EllipsisText>
+    </>
+);
+export default Demo;

--- a/packages/website/src/pages/layout/EllipsisText.tsx
+++ b/packages/website/src/pages/layout/EllipsisText.tsx
@@ -1,0 +1,18 @@
+import {EllipsisTextMetadata} from '@coveord/plasma-components-props-analyzer';
+import EllipsisTextDemo from '@examples/layout/EllipsisText/EllipsisText.demo?demo';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
+
+const Page = () => (
+    <PageLayout
+        section="Layout"
+        title="EllipsisText"
+        sourcePath="/packages/mantine/src/components/ellipsis-text/EllipsisText.tsx"
+        description="Allows to display text that will automatically truncate and shows a tooltip on hover if it overflows the max width."
+        id="EllipsisText"
+        propsMetadata={EllipsisTextMetadata}
+        demo={<EllipsisTextDemo />}
+    />
+);
+
+export default Page;


### PR DESCRIPTION
### Proposed Changes

Created the `EllipsisText` component that allows to truncate content and show a tooltip with the full length of the content if it overflows the max width.

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/85fe2165-04cc-444e-a613-e9dbfc9aa57e">




### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
