### PR TITLE
fix: improve List component style

### DIFF
--- a/packages/mantine/src/styles/List.module.css
+++ b/packages/mantine/src/styles/List.module.css
@@ -1,3 +1,7 @@
-.root {
+ul.root {
     list-style-type: disc;
+}
+
+ol.root {
+    list-style-type: decimal;
 }


### PR DESCRIPTION
### Proposed Changes

If we want to use the ordered type on the List component, then `list-style-type` is set to `disc` by default instead of `decimal`.

I've simply defined a root class for each HTML tag (ul and ol)

```
    <List type="ordered">
      <List.Item>Clone or download repository from GitHub</List.Item>
      <List.Item>Install dependencies with yarn</List.Item>
      <List.Item>To start development server run npm start command</List.Item>
      <List.Item>Run tests to make sure your changes do not break the build</List.Item>
      <List.Item>Submit a pull request once you are done</List.Item>
    </List>
```
https://mantine.dev/core/list/

### Potential Breaking Changes

By the way, this `<List type=“ordered”>` is only used in the documentation website, so the impact is to delete the documentation website theme update.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
