### PR TITLE
feat(mantine): ChildForm component

### DIFF
--- a/packages/components-props-analyzer/src/ComponentsList.ts
+++ b/packages/components-props-analyzer/src/ComponentsList.ts
@@ -102,6 +102,11 @@ const components: Component[] = [
         packageName: '@coveord/plasma-mantine',
         propsType: 'EllipsisTextProps',
     },
+    {
+        name: 'ChildForm',
+        packageName: '@coveord/plasma-mantine',
+        propsType: 'ChildFormProps',
+    },
 ];
 
 export default components;

--- a/packages/mantine/src/components/child-form/ChildForm.module.css
+++ b/packages/mantine/src/components/child-form/ChildForm.module.css
@@ -1,4 +1,5 @@
 .paper {
+    border-top: 1px var(--mantine-color-gray-3);
     border-radius: 0 0 var(--mantine-radius-default) var(--mantine-radius-default);
     box-shadow:
         inset 0 1px 0 -1px #e5e8e8,

--- a/packages/mantine/src/components/child-form/ChildForm.module.css
+++ b/packages/mantine/src/components/child-form/ChildForm.module.css
@@ -1,5 +1,5 @@
 .paper {
-    border-top: 1px var(--mantine-color-gray-3);
+    border: 1px var(--mantine-color-gray-3);
     border-radius: 0 0 var(--mantine-radius-default) var(--mantine-radius-default);
     box-shadow:
         inset 0 1px 0 -1px #e5e8e8,

--- a/packages/mantine/src/components/child-form/ChildForm.module.css
+++ b/packages/mantine/src/components/child-form/ChildForm.module.css
@@ -1,3 +1,6 @@
 .paper {
     border-radius: 0 0 var(--mantine-radius-default) var(--mantine-radius-default);
+    box-shadow:
+        inset 0 1px 0 -1px #e5e8e8,
+        inset 0 4px 2px -2px rgb(55 55 55 / 3%);
 }

--- a/packages/mantine/src/components/child-form/ChildForm.module.css
+++ b/packages/mantine/src/components/child-form/ChildForm.module.css
@@ -1,7 +1,7 @@
 .paper {
-    border: 1px var(--mantine-color-gray-3);
-    border-radius: 0 0 var(--mantine-radius-default) var(--mantine-radius-default);
+    border: 1px solid var(--mantine-color-gray-3);
+    border-radius: var(--mantine-radius-default);
     box-shadow:
-        inset 0 1px 0 -1px #e5e8e8,
-        inset 0 4px 2px -2px rgb(55 55 55 / 3%);
+        0 1px 0 -1px var(--mantine-color-gray-3) inset,
+        0 4px 2px -2px rgb(55 55 55 / 3%) inset;
 }

--- a/packages/mantine/src/components/child-form/ChildForm.module.css
+++ b/packages/mantine/src/components/child-form/ChildForm.module.css
@@ -1,0 +1,3 @@
+.paper {
+    border-radius: 0 0 var(--mantine-radius-default) var(--mantine-radius-default);
+}

--- a/packages/mantine/src/components/child-form/ChildForm.tsx
+++ b/packages/mantine/src/components/child-form/ChildForm.tsx
@@ -50,10 +50,10 @@ export const ChildForm = polymorphicFactory<ChildFormFactory>((props, ref) => {
 
     return (
         <Collapse ref={ref} {...others} {...getStyles('root')}>
-            <Paper bg="gray.1" shadow="sm" p="lg" {...getStyles('paper')}>
+            <Paper bg="gray.1" p="md" {...getStyles('paper')}>
                 {(title || description) && (
                     <Stack gap={0} mb="md">
-                        {title && <Title order={4}>{title}</Title>}
+                        {title && <Title order={5}>{title}</Title>}
                         {description && <Text c="gray.7">{description}</Text>}
                     </Stack>
                 )}

--- a/packages/mantine/src/components/child-form/ChildForm.tsx
+++ b/packages/mantine/src/components/child-form/ChildForm.tsx
@@ -4,7 +4,10 @@ import {
     Factory,
     Paper,
     polymorphicFactory,
+    Stack,
     StylesApiProps,
+    Text,
+    Title,
     useProps,
     useStyles,
 } from '@mantine/core';
@@ -12,7 +15,10 @@ import classes from './ChildForm.module.css';
 
 export type ChildFormStylesNames = 'root' | 'paper';
 
-export interface ChildFormProps extends CollapseProps, StylesApiProps<ChildFormFactory> {}
+export interface ChildFormProps extends CollapseProps, StylesApiProps<ChildFormFactory> {
+    title?: string;
+    description?: string;
+}
 
 type ChildFormFactory = Factory<{
     props: ChildFormProps;
@@ -24,7 +30,7 @@ type ChildFormFactory = Factory<{
 const defaultProps: Partial<ChildFormProps> = {};
 
 export const ChildForm = polymorphicFactory<ChildFormFactory>((props, ref) => {
-    const {className, children, style, classNames, styles, unstyled, vars, ...others} = useProps(
+    const {className, children, style, classNames, styles, unstyled, vars, title, description, ...others} = useProps(
         'ChildForm',
         defaultProps,
         props,
@@ -45,7 +51,13 @@ export const ChildForm = polymorphicFactory<ChildFormFactory>((props, ref) => {
     return (
         <Collapse ref={ref} {...others} {...getStyles('root')}>
             <Paper bg="gray.1" shadow="sm" p="lg" {...getStyles('paper')}>
-                {children}
+                {(title || description) && (
+                    <Stack gap={0} mb="md">
+                        {title && <Title order={4}>{title}</Title>}
+                        {description && <Text c="gray.7">{description}</Text>}
+                    </Stack>
+                )}
+                <Stack gap="md">{children}</Stack>
             </Paper>
         </Collapse>
     );

--- a/packages/mantine/src/components/child-form/ChildForm.tsx
+++ b/packages/mantine/src/components/child-form/ChildForm.tsx
@@ -1,0 +1,52 @@
+import {
+    Collapse,
+    CollapseProps,
+    Factory,
+    Paper,
+    polymorphicFactory,
+    StylesApiProps,
+    useProps,
+    useStyles,
+} from '@mantine/core';
+import classes from './ChildForm.module.css';
+
+export type ChildFormStylesNames = 'root' | 'paper';
+
+export interface ChildFormProps extends CollapseProps, StylesApiProps<ChildFormFactory> {}
+
+type ChildFormFactory = Factory<{
+    props: ChildFormProps;
+    defaultRef: HTMLDivElement;
+    defaultComponent: 'div';
+    stylesNames: ChildFormStylesNames;
+}>;
+
+const defaultProps: Partial<ChildFormProps> = {};
+
+export const ChildForm = polymorphicFactory<ChildFormFactory>((props, ref) => {
+    const {className, children, style, classNames, styles, unstyled, vars, ...others} = useProps(
+        'ChildForm',
+        defaultProps,
+        props,
+    );
+
+    const getStyles = useStyles<ChildFormFactory>({
+        name: 'ChildForm',
+        classes,
+        props,
+        className,
+        style,
+        classNames,
+        styles,
+        unstyled,
+        vars,
+    });
+
+    return (
+        <Collapse ref={ref} {...others} {...getStyles('root')}>
+            <Paper bg="gray.1" shadow="sm" p="lg" {...getStyles('paper')}>
+                {children}
+            </Paper>
+        </Collapse>
+    );
+});

--- a/packages/mantine/src/components/child-form/ChildForm.tsx
+++ b/packages/mantine/src/components/child-form/ChildForm.tsx
@@ -16,7 +16,13 @@ import classes from './ChildForm.module.css';
 export type ChildFormStylesNames = 'root' | 'paper';
 
 export interface ChildFormProps extends CollapseProps, StylesApiProps<ChildFormFactory> {
+    /**
+     * Title of the child form.
+     */
     title?: string;
+    /**
+     * Description of the child form.
+     */
     description?: string;
 }
 

--- a/packages/mantine/src/components/child-form/ChildForm.tsx
+++ b/packages/mantine/src/components/child-form/ChildForm.tsx
@@ -50,7 +50,7 @@ export const ChildForm = polymorphicFactory<ChildFormFactory>((props, ref) => {
 
     return (
         <Collapse ref={ref} {...others} {...getStyles('root')}>
-            <Paper bg="gray.1" p="md" {...getStyles('paper')}>
+            <Paper bg="gray.0" p="md" {...getStyles('paper')}>
                 {(title || description) && (
                     <Stack gap={0} mb="md">
                         {title && <Title order={5}>{title}</Title>}

--- a/packages/mantine/src/components/child-form/__tests__/ChildForm.spec.tsx
+++ b/packages/mantine/src/components/child-form/__tests__/ChildForm.spec.tsx
@@ -1,0 +1,30 @@
+import {TextInput} from '@mantine/core';
+import {render, screen} from '../../../__tests__/Utils';
+import {ChildForm} from '../ChildForm';
+
+describe('ChildForm', () => {
+    it('renders the provided title and description', async () => {
+        render(<ChildForm in={true} title="This is a title" description="This is a description" />);
+
+        expect(screen.getByText(/this is a title/i)).toBeInTheDocument();
+        expect(screen.getByText(/this is a description/i)).toBeInTheDocument();
+    });
+    it('renders the content', () => {
+        render(
+            <ChildForm in={true}>
+                <TextInput label="Text input" />
+            </ChildForm>,
+        );
+
+        expect(screen.getByRole('textbox', {name: /text input/i})).toBeInTheDocument();
+    });
+    it('hides the container', () => {
+        render(
+            <ChildForm in={false}>
+                <TextInput label="Text input" />
+            </ChildForm>,
+        );
+
+        expect(screen.queryByRole('textbox', {name: /text input/i})).not.toBeInTheDocument();
+    });
+});

--- a/packages/mantine/src/components/child-form/index.ts
+++ b/packages/mantine/src/components/child-form/index.ts
@@ -1,0 +1,1 @@
+export * from './ChildForm';

--- a/packages/mantine/src/components/index.ts
+++ b/packages/mantine/src/components/index.ts
@@ -14,3 +14,4 @@ export * from './prompt';
 export * from './read-only';
 export * from './sticky-footer';
 export * from './table';
+export * from './child-form';

--- a/packages/website/src/Navigation.tsx
+++ b/packages/website/src/Navigation.tsx
@@ -62,6 +62,7 @@ export const Navigation = () => (
             <InternalNavLink to="/form/Collection" label="Collection" />
             <InternalNavLink to="/form/CopyToClipboard" label="Copy to Clipboard" />
             <InternalNavLink to="/form/Form" label="Form" />
+            <InternalNavLink to="/form/ChildForm" label="Child Form" />
             <InternalNavLink to="/form/InlineConfirm" label="Inline confirm" />
         </NavLink>
         <NavLink label="Feedback" leftSection={<AnnouncementSize16Px height={16} />} defaultOpened>

--- a/packages/website/src/examples/form/child-form/ChildForm.demo.tsx
+++ b/packages/website/src/examples/form/child-form/ChildForm.demo.tsx
@@ -1,4 +1,4 @@
-import {ChildForm, Header, Stack, Switch, TextInput, useForm} from '@coveord/plasma-mantine';
+import {ChildForm, Stack, Switch, TextInput, useForm} from '@coveord/plasma-mantine';
 const Demo = () => {
     const form = useForm({
         initialValues: {
@@ -11,14 +11,13 @@ const Demo = () => {
     return (
         <Stack gap="md">
             <Switch {...form.getInputProps('provideInfo')} label="Provide information" />
-            <ChildForm in={!!form.values.provideInfo}>
-                <Stack gap="md">
-                    <Header variant="secondary" description="Provide the user's personal information">
-                        Personal information
-                    </Header>
-                    <TextInput label="First name" placeholder="John" required {...form.getInputProps('firstName')} />
-                    <TextInput label="Last name" placeholder="Doe" required {...form.getInputProps('lastName')} />
-                </Stack>
+            <ChildForm
+                in={!!form.values.provideInfo}
+                title="Personal information"
+                description="Provide the user's personal information"
+            >
+                <TextInput label="First name" placeholder="John" required {...form.getInputProps('firstName')} />
+                <TextInput label="Last name" placeholder="Doe" required {...form.getInputProps('lastName')} />
             </ChildForm>
         </Stack>
     );

--- a/packages/website/src/examples/form/child-form/ChildForm.demo.tsx
+++ b/packages/website/src/examples/form/child-form/ChildForm.demo.tsx
@@ -1,0 +1,26 @@
+import {ChildForm, Header, Stack, Switch, TextInput, useForm} from '@coveord/plasma-mantine';
+const Demo = () => {
+    const form = useForm({
+        initialValues: {
+            provideInfo: false,
+            firstName: '',
+            lastName: '',
+        },
+    });
+
+    return (
+        <Stack gap="md">
+            <Switch {...form.getInputProps('provideInfo')} label="Provide information" />
+            <ChildForm in={!!form.values.provideInfo}>
+                <Stack gap="md">
+                    <Header variant="secondary" description="Provide the user's personal information">
+                        Personal information
+                    </Header>
+                    <TextInput label="First name" placeholder="John" required {...form.getInputProps('firstName')} />
+                    <TextInput label="Last name" placeholder="Doe" required {...form.getInputProps('lastName')} />
+                </Stack>
+            </ChildForm>
+        </Stack>
+    );
+};
+export default Demo;

--- a/packages/website/src/examples/form/child-form/ChildFormWithForm.demo.tsx
+++ b/packages/website/src/examples/form/child-form/ChildFormWithForm.demo.tsx
@@ -1,0 +1,21 @@
+import {ChildForm, Stack, Switch, TextInput, useForm} from '@coveord/plasma-mantine';
+const Demo = () => {
+    const form = useForm({
+        initialValues: {
+            provideInfo: false,
+            firstName: '',
+            lastName: '',
+        },
+    });
+
+    return (
+        <Stack gap="md">
+            <Switch {...form.getInputProps('provideInfo')} label="Provide information" />
+            <ChildForm in={!!form.values.provideInfo}>
+                <TextInput label="First name" required {...form.getInputProps('firstName')} />
+                <TextInput label="Last name" required {...form.getInputProps('lastName')} />
+            </ChildForm>
+        </Stack>
+    );
+};
+export default Demo;

--- a/packages/website/src/examples/form/child-form/ChildFormWithTitleAndDescription.demo.tsx
+++ b/packages/website/src/examples/form/child-form/ChildFormWithTitleAndDescription.demo.tsx
@@ -1,6 +1,6 @@
 import {ChildForm, TextInput} from '@coveord/plasma-mantine';
 const Demo = () => (
-    <ChildForm in={true}>
+    <ChildForm in={true} title="Personal information" description="Provide the user's personal information">
         <TextInput label="First name" required />
         <TextInput label="Last name" required />
     </ChildForm>

--- a/packages/website/src/pages/form/ChildForm.tsx
+++ b/packages/website/src/pages/form/ChildForm.tsx
@@ -1,4 +1,6 @@
 import ChildFormDemo from '@examples/form/child-form/ChildForm.demo?demo';
+import ChildFormWithForm from '@examples/form/child-form/ChildFormWithForm.demo?demo';
+import ChildFormWithTitleAndDescription from '@examples/form/child-form/ChildFormWithTitleAndDescription.demo?demo';
 
 import {PageLayout} from '../../building-blocs/PageLayout';
 
@@ -9,6 +11,10 @@ const Page = () => (
         description="A container part of a form that can be used to group fields that are conditionally displayed together."
         id="ChildFrom"
         demo={<ChildFormDemo />}
+        examples={{
+            withToggle: <ChildFormWithForm title="Display bound to another form field" />,
+            withTitleAndDescription: <ChildFormWithTitleAndDescription title="Title and description" />,
+        }}
     />
 );
 

--- a/packages/website/src/pages/form/ChildForm.tsx
+++ b/packages/website/src/pages/form/ChildForm.tsx
@@ -10,7 +10,7 @@ const Page = () => (
         section="Form"
         title="Child Form"
         propsMetadata={ChildFormMetadata}
-        description="A container part of a form that can be used to group fields that are conditionally displayed together."
+        description="A container, part of a form, that can be used to group fields which are conditionally displayed together."
         id="ChildFrom"
         demo={<ChildFormDemo />}
         examples={{

--- a/packages/website/src/pages/form/ChildForm.tsx
+++ b/packages/website/src/pages/form/ChildForm.tsx
@@ -1,0 +1,15 @@
+import ChildFormDemo from '@examples/form/child-form/ChildForm.demo?demo';
+
+import {PageLayout} from '../../building-blocs/PageLayout';
+
+const Page = () => (
+    <PageLayout
+        section="Form"
+        title="Child Form"
+        description="A container part of a form that can be used to group fields that are conditionally displayed together."
+        id="ChildFrom"
+        demo={<ChildFormDemo />}
+    />
+);
+
+export default Page;

--- a/packages/website/src/pages/form/ChildForm.tsx
+++ b/packages/website/src/pages/form/ChildForm.tsx
@@ -1,3 +1,4 @@
+import {ChildFormMetadata} from '@coveord/plasma-components-props-analyzer';
 import ChildFormDemo from '@examples/form/child-form/ChildForm.demo?demo';
 import ChildFormWithForm from '@examples/form/child-form/ChildFormWithForm.demo?demo';
 import ChildFormWithTitleAndDescription from '@examples/form/child-form/ChildFormWithTitleAndDescription.demo?demo';
@@ -8,6 +9,7 @@ const Page = () => (
     <PageLayout
         section="Form"
         title="Child Form"
+        propsMetadata={ChildFormMetadata}
         description="A container part of a form that can be used to group fields that are conditionally displayed together."
         id="ChildFrom"
         demo={<ChildFormDemo />}


### PR DESCRIPTION
### Proposed Changes

Added a new `ChildForm` component. This pattern for forms is used at a couple of places in the Admin-UI but each place has its own implementation with different styling. 

On our side, we have a need for it for two features we are currently working on, so I thought it would be a good time to add it.

I validated with UX to make sure the styling was up to their liking. 

[Figma](https://www.figma.com/design/NRBnfgMxgVs7h6qwP6ADBV/Elevation-%26-Focus-FX---PDS?node-id=804-297&node-type=frame&m=dev).🎨 

<img width="500" alt="Screenshot 2024-11-07 at 10 43 51 AM" src="https://github.com/user-attachments/assets/1c90c1bd-09c8-4031-9317-535e00d5f7f8">

[Demo](https://plasma.coveo.com/feature/SEARCHAPI-11252-child-form/form/ChildForm). 🧪 

<img width="599" alt="Screenshot 2024-11-07 at 10 48 37 AM" src="https://github.com/user-attachments/assets/c5784ee1-e9e1-450f-8d23-2748c1597121">

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
