### PR TITLE
fix(mantine): make EllipsisText style more adaptable

### DIFF
--- a/packages/mantine/src/components/ellipsis-text/EllipsisText.module.css
+++ b/packages/mantine/src/components/ellipsis-text/EllipsisText.module.css
@@ -1,3 +1,8 @@
+.root {
+    display: flex;
+    width: 100%;
+}
+
 .noWrap {
     white-space: nowrap;
 }

--- a/packages/mantine/src/components/ellipsis-text/EllipsisText.tsx
+++ b/packages/mantine/src/components/ellipsis-text/EllipsisText.tsx
@@ -66,14 +66,14 @@ export const EllipsisText = polymorphicFactory<EllipsisTextFactory>((props, ref)
                 }
             }}
             onMouseLeave={() => setShowTooltip(false)}
-            display="flex"
-            w="100%"
             className={clsx(rootClass, {[classes.noWrap]: !lineClamp})}
             {...rootStyles}
             {...others}
         >
             <Tooltip label={children} opened={showTooltip} {...tooltipProps} {...getStyles('tooltip')}>
                 <Text
+                    span
+                    inherit
                     variant={variant}
                     ref={textRef}
                     className={clsx(textClass, {[classes.ellipsis]: !lineClamp})}


### PR DESCRIPTION
### Proposed Changes

When using the EllipsisText component inside other components like buttons or nav links, I realized that its style was sometimes creating unwanted overrides.

This PR makes the component more adaptable to its parent style:
- Changing the Text node to be a `span` instead of a `p`
- Adding `inherit` prop on the text node, so that it can take its parent text styles
- Ensuring `width` and `display` can easily be overridden via the styles API

### Potential Breaking Changes

None, the component should look exactly as it did before

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
