### PR TITLE
feat(prompt): +disabledwithtooltip on confirm button

### DIFF
--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -12,19 +12,23 @@ import {
     useStyles,
 } from '@mantine/core';
 import {Children, ReactElement, ReactNode} from 'react';
-import classes from './Prompt.module.css';
 import Critical from './icons/critical.svg';
 import Info from './icons/info.svg';
 import Success from './icons/success.svg';
 import Warning from './icons/warning.svg';
 import {PromptContextProvider} from './Prompt.context';
+import classes from './Prompt.module.css';
 import {PromptCancelButton, PromptCancelButtonStylesNamesVariant} from './PromptCancelButton';
-import {PromptConfirmButton} from './PromptConfirmButton';
+import {PromptConfirmButton, PromptConfirmButtonStylesNamesVariant} from './PromptConfirmButton';
 import {PromptFooter} from './PromptFooter';
 
 export type PromptVariant = 'success' | 'warning' | 'critical' | 'info';
 export type PromptVars = {root: '--prompt-icon-size'};
-export type PromptStylesNames = ModalStylesNames | 'icon' | PromptCancelButtonStylesNamesVariant;
+export type PromptStylesNames =
+    | ModalStylesNames
+    | 'icon'
+    | PromptCancelButtonStylesNamesVariant
+    | PromptConfirmButtonStylesNamesVariant;
 
 export interface PromptProps
     extends StylesApiProps<PromptFactory>,

--- a/packages/mantine/src/components/prompt/PromptConfirmButton.tsx
+++ b/packages/mantine/src/components/prompt/PromptConfirmButton.tsx
@@ -1,6 +1,5 @@
-import {Button, CompoundStylesApiProps, factory, Factory, useProps} from '@mantine/core';
-import {ButtonProps} from '../button/Button';
-import {ButtonWithDisabledTooltip} from '../button/ButtonWithDisabledTooltip';
+import {CompoundStylesApiProps, factory, Factory, useProps} from '@mantine/core';
+import {Button, ButtonProps} from '../button/Button';
 import {PromptVariant} from './Prompt';
 import {usePromptContext} from './Prompt.context';
 
@@ -43,18 +42,15 @@ export const PromptConfirmButton = factory<PromptConfirmButtonFactory>((_props, 
     } = props;
 
     return (
-        <ButtonWithDisabledTooltip
+        <Button
+            ref={ref}
+            variant="filled"
+            color={COLOR_BY_VARIANT[variant]}
             disabled={disabled}
             disabledTooltip={disabledTooltip}
             disabledTooltipProps={disabledTooltipProps}
-        >
-            <Button
-                ref={ref}
-                variant="filled"
-                color={COLOR_BY_VARIANT[variant]}
-                {...others}
-                {...getStyles('confirm', {style, styles, className, classNames})}
-            />
-        </ButtonWithDisabledTooltip>
+            {...others}
+            {...getStyles('confirm', {style, styles, className, classNames})}
+        />
     );
 });

--- a/packages/mantine/src/components/prompt/PromptConfirmButton.tsx
+++ b/packages/mantine/src/components/prompt/PromptConfirmButton.tsx
@@ -1,5 +1,6 @@
 import {Button, CompoundStylesApiProps, factory, Factory, useProps} from '@mantine/core';
 import {ButtonProps} from '../button/Button';
+import {ButtonWithDisabledTooltip} from '../button/ButtonWithDisabledTooltip';
 import {PromptVariant} from './Prompt';
 import {usePromptContext} from './Prompt.context';
 
@@ -28,15 +29,32 @@ const defaultProps: Partial<PromptConfirmButtonProps> = {};
 export const PromptConfirmButton = factory<PromptConfirmButtonFactory>((_props, ref) => {
     const {variant, getStyles} = usePromptContext();
     const props = useProps('PromptConfirmButton', defaultProps, _props);
-    const {className, classNames, style, styles, unstyled, vars, ...others} = props;
+    const {
+        className,
+        classNames,
+        style,
+        styles,
+        unstyled,
+        vars,
+        disabled,
+        disabledTooltip,
+        disabledTooltipProps,
+        ...others
+    } = props;
 
     return (
-        <Button
-            ref={ref}
-            variant="filled"
-            color={COLOR_BY_VARIANT[variant]}
-            {...others}
-            {...getStyles('cancel', {style, styles, className, classNames})}
-        />
+        <ButtonWithDisabledTooltip
+            disabled={disabled}
+            disabledTooltip={disabledTooltip}
+            disabledTooltipProps={disabledTooltipProps}
+        >
+            <Button
+                ref={ref}
+                variant="filled"
+                color={COLOR_BY_VARIANT[variant]}
+                {...others}
+                {...getStyles('confirm', {style, styles, className, classNames})}
+            />
+        </ButtonWithDisabledTooltip>
     );
 });


### PR DESCRIPTION
### Proposed Changes

This feature will unblock this task
https://coveord.atlassian.net/browse/ADUI-10365

This PR adds the ButtonDisabledTooltip to the Prompt.Confirm button so that we can use the button component with the functionality of the tooltips

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
