### PR TITLE
fix(mantine): hide table more menu if no actions are visible

### DIFF
--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -20,14 +20,34 @@
 }
 
 /* Table.Actions */
+
+/* Hide empty menus */
+.actionsTarget {
+    display: none;
+
+    &:has(+ .actionsDropdown :global(.mantine-Menu-item)) {
+        display: block;
+    }
+}
+
 .actionsDropdown {
     text-align: left;
+}
+
+.actionsGroupDivider {
+    display: none;
 }
 
 .actionsGroup {
     &:has(.actionsGroupItems:empty) {
         /* Hide empty groups */
         display: none;
+    }
+
+    &:has(~ .actionsGroup :global(.mantine-Menu-item)) {
+        .actionsGroupDivider {
+            display: block;
+        }
     }
 }
 

--- a/packages/mantine/src/components/table/table-actions/TableActionsList.tsx
+++ b/packages/mantine/src/components/table/table-actions/TableActionsList.tsx
@@ -129,7 +129,7 @@ export const TableActionsList = (props: TableActionsListProps) => {
                 <TableActionProvider value={{primary: true}}>{primaryActions}</TableActionProvider>
                 {secondaryActionGroups.length > 0 ? (
                     <TableActionProvider value={{primary: false}}>
-                        <Menu withinPortal={false} {...others}>
+                        <Menu withinPortal={false} {...others} keepMounted>
                             <Menu.Target>
                                 <Button
                                     {...getStyles('actionsTarget', {styles, classNames})}
@@ -156,13 +156,13 @@ export const TableActionsList = (props: TableActionsListProps) => {
         <InlineConfirm>
             {confirmPrompts}
             <TableActionProvider value={{primary: false}}>
-                <Menu opened={opened} onChange={onChange} {...others}>
+                <Menu opened={opened} onChange={onChange} {...others} keepMounted>
                     <Menu.Target>
                         <Tooltip label={label} {...getStyles('actionsTooltip', {styles, classNames})}>
                             <ActionIcon
+                                {...getStyles('actionsTarget', {styles, classNames})}
                                 onClick={onClick}
                                 variant="subtle"
-                                {...getStyles('actionsTarget', {styles, classNames})}
                             >
                                 {icon}
                             </ActionIcon>


### PR DESCRIPTION
### Proposed Changes

When a table has secondary actions that render nothing, the "More" menu would still show up.

<img width="239" alt="image" src="https://github.com/user-attachments/assets/70fc399c-b252-4e12-8881-1bc6bdb355a1">


The current PR solves that problem, by hiding the menu target if the menu dropdown does not render any menu item. For this to work, the menu dropdown has to always be rendered so that the CSS can properly query the DOM nodes of its content

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
