### PR TITLE
fix(WEB-7276): avoid sliver of content being viewable below the `StickyFooter`

### DIFF
--- a/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
@@ -1,6 +1,6 @@
 .root {
     position: sticky;
-    bottom: 0;
+    bottom: -1px;
     z-index: 10;
     background-color: white;
     padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);


### PR DESCRIPTION
### Proposed Changes
Put down the sticky footer down by one pixel to avoid the visual issue reported [here](https://github.com/coveo-platform/admin-ui/pull/13077#pullrequestreview-2430781237)