### PR TITLE
fix(mantine): make table root have 100% width

### DIFF
--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -1,3 +1,7 @@
+.root {
+    width: 100%;
+}
+
 .table {
     width: 100%;
     padding-bottom: var(--mantine-spacing-sm);


### PR DESCRIPTION
### Proposed Changes

For most implementations, this fix will be transparent. It mostly impacts tables that are displayed within a flex container. In this situation, the table will take the full with of that flex container instead of minimally fitting the content of the table.

Example

If we imagine the following component:

```tsx
<Box display="flex">
    <Table {...} />
</Box>
```

Before

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/71c6d7db-58e9-49f7-b0a8-42b2aa44e819">

After

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/d2e2f8a6-7ac7-43f1-8f3a-c9fccaab9f44">



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
