### PR TITLE
fix(table): prevent double click action on row selection checkboxes

### DIFF
--- a/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/table/layouts/__tests__/RowLayout.spec.tsx
@@ -402,6 +402,32 @@ describe('RowLayout', () => {
 
             expect(onClick).not.toHaveBeenCalled();
         });
+
+        it('does not trigger the double click action when double clicking on the selection checkbox', async () => {
+            const user = userEvent.setup();
+            const doubleClickSpy = vi.fn();
+            const data: RowData[] = [
+                {id: '🆔-1', firstName: 'Mario'},
+                {id: '🆔-2', firstName: 'Luigi'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({enableMultiRowSelection: true});
+                return (
+                    <Table<RowData>
+                        store={store}
+                        getRowId={({id}) => id}
+                        data={data}
+                        columns={columns}
+                        layoutProps={{onRowDoubleClick: doubleClickSpy}}
+                    />
+                );
+            };
+            render(<Fixture />);
+            await user.dblClick(
+                within(screen.getByRole('row', {name: /Mario/i})).getByRole('checkbox', {name: /select row/i}),
+            );
+            expect(doubleClickSpy).not.toHaveBeenCalled();
+        });
     });
 
     it('passes down attributes given by getRowAttributes function to the row element', () => {

--- a/packages/mantine/src/components/table/table-column/TableSelectableColumn.tsx
+++ b/packages/mantine/src/components/table/table-column/TableSelectableColumn.tsx
@@ -32,6 +32,10 @@ export const TableSelectableColumn: ColumnDef<unknown> = {
             onChange={row.getToggleSelectedHandler()}
             flex={1}
             aria-label="Select row"
+            onDoubleClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+            }}
         />
     ),
 };

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -69,6 +69,7 @@ const Demo = () => {
             getRowId={({id}) => id}
             columns={columns}
             options={options}
+            layoutProps={{onRowDoubleClick: (row) => alert(`Row double clicked: ${row.title}`)}}
             getRowActions={(selected: IExampleRowData[]): TableAction[] =>
                 selected.length === 1
                     ? [


### PR DESCRIPTION
### Proposed Changes

Prevent table double click action from being triggered when the user double clicks on a row selection checkbox. 

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
