### PR TITLE
fix(table-date-picker): date range picker end date at end of day

### DIFF
--- a/packages/mantine/src/components/date-range-picker/__tests__/DateRangePickerInlineCalendar.spec.tsx
+++ b/packages/mantine/src/components/date-range-picker/__tests__/DateRangePickerInlineCalendar.spec.tsx
@@ -3,6 +3,8 @@ import dayjs from 'dayjs';
 
 import {DateRangePickerInlineCalendar} from '../DateRangePickerInlineCalendar';
 
+const endOfDay = (year: number, month: number, day: number): Date => new Date(year, month, day, 23, 59, 59, 999);
+
 describe('DateRangePickerInlineCalendar', () => {
     it('calls onApply when the user clicks on the apply button', async () => {
         const user = userEvent.setup({delay: null});
@@ -37,7 +39,7 @@ describe('DateRangePickerInlineCalendar', () => {
         render(
             <DateRangePickerInlineCalendar
                 presets={{
-                    year2k: {label: 'select me', range: [new Date(1999, 11, 31), new Date(2000, 0, 1)]},
+                    year2k: {label: 'select me', range: [new Date(1999, 11, 31), endOfDay(2000, 0, 1)]},
                 }}
                 initialRange={[null, null]}
                 onApply={onApply}
@@ -53,7 +55,7 @@ describe('DateRangePickerInlineCalendar', () => {
         await user.click(screen.getByRole('option', {name: 'select me'}));
         await user.click(screen.getByRole('button', {name: 'Apply'}));
 
-        expect(onApply).toHaveBeenCalledWith([new Date(1999, 11, 31), new Date(2000, 0, 1)]);
+        expect(onApply).toHaveBeenCalledWith([new Date(1999, 11, 31), endOfDay(2000, 0, 1)]);
     });
 
     it('calls onApply with the selected dates when clicking in the calendar', async () => {
@@ -68,7 +70,7 @@ describe('DateRangePickerInlineCalendar', () => {
 
         await user.click(screen.getByRole('button', {name: 'Apply'}));
 
-        expect(onApply).toHaveBeenCalledWith([new Date(2022, 0, 8), new Date(2022, 0, 14)]);
+        expect(onApply).toHaveBeenCalledWith([new Date(2022, 0, 8), endOfDay(2022, 0, 14)]);
 
         vi.useRealTimers();
     });
@@ -81,7 +83,7 @@ describe('DateRangePickerInlineCalendar', () => {
         await user.click(screen.getAllByRole('button', {name: /8 january 2022/i})[0]);
         await user.click(screen.getByRole('button', {name: 'Apply'}));
 
-        expect(onApply).toHaveBeenCalledWith([new Date(2022, 0, 8), new Date(2022, 0, 8)]);
+        expect(onApply).toHaveBeenCalledWith([new Date(2022, 0, 8), endOfDay(2022, 0, 8)]);
 
         vi.useRealTimers();
     });


### PR DESCRIPTION
### Proposed Changes

**TL;DR**: change the time part of the end value of the Date (range) picker to be "end-of-day" (`23:59:59.999`) instead of "start-of-day" (`00:00:00.000`).

The change in itself isn't that involved, but explaining why I think it is necessary and why I chose this particular solution does require some background. What follows is the long explanation, so grab your favorite beverage and settle in.

#### A series of unfortunate events/choices
When you encode a range, you have to decide whether the upper bound is **inclusive** or **exclusive**. Which one you prefer and/or use ultimately comes down to personal preference. Things go bad when you mix up the two concepts though, as you are very likely to run into an off-by-one error. (More specifically, it can lead to ["fencepost errors"](https://en.wikipedia.org/wiki/Off-by-one_error#Fencepost_error)). In programming, upper bounds are most often **exclusive**, because it has some advantages. Specifically, that the length of a slice is equal to "end - start". If end were inclusive, you'd have to add 1, because the size of range `3‥=3` is 1. You'd also have to use a negative (inclusive) end, to encode an empty slice at index `0`, which is even more awkward: `0‥=-1`.

You may be wondering why I'm going into such detail about inclusive versus exclusive upper bounds, but that's because Mantine chose to use an **inclusive** upper bound for their [DatePicker](https://mantine.dev/dates/date-picker/) component (in "range" mode). This in itself isn't too bad, but combined with two other facts it leads to an annoying combination:
 1. JavaScript's [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object is actually a "timestamp" (date and time).
     - This means that when you want to represent a date (only), you still have to specify _some_ value for the time part.
       It's conventional to use "midnight" (`00:00:00.000`) for this.
 2. While Mantine has a [DateTimePicker](https://mantine.dev/dates/date-time-picker/), Coveo's Table only supports `DatePicker`.

If you use the date picker to actually work with dates, and just use inclusive upper bounds, all is good. Say you select December 25th and December 26th in the UI. You will get this range:
```typescript
const range = [new Date(2024, 11, 25), new Date(2024, 11, 26)];
/* This looks like this (your time zone may differ, obviously):
[
    Wed Dec 25 2024 00:00:00 GMT+0100 (Central European Standard Time),
    Thu Dec 26 2024 00:00:00 GMT+0100 (Central European Standard Time)
]
*/
```

If you take the date parts of these values, and make sure you do an inclusive check, everything is fine. This is the case for SQL BETWEEN, which is **inclusive** by default:
```sql
    select * from example where date between '2024-12-25' and '2024-12-26';
```

However, some usage of the `Table` component uses the date picker combined with data that has timestamps instead of dates. Now see what happens if you translate this same range to SQL:
```sql
    select * from example where date between '2024-12-25 00:00:00.000' and '2024-12-26 00:00:00.000';
```

Even though the upper bound is treated as inclusive, it's only including records that fall exactly on midnight, any record starting from `2024-12-26 00:00:00.001` will not be included. This is very confusing, as the date picker rendered the selection showing the 25th and 26th colored in.

#### Multiple solutions

Hopefully I explained the combinations of factors that lead to the proposed fix (`DatePicker` used with timestamp values, unexpected behavior of "excluding" the last day). There are multiple ways to go about fixing this, of course:
 1. Leave the behavior as-is, and require custom handling on the integration sites to "fix" the end value, if timestamps are used.
 2. Implement and provide a `Table.DateTimePicker` next to `Table.DatePicker`, with proper support for timestamp values (up to milliseconds level).
 3. In our component, patch the end value to be "end-of-day".
    Effectively: move the end value's time to be `23:59:59.999`.
 4. In our component, switch from an inclusive upper bound to an exclusive upper bound.
    Effectively: add 1 day to the end value (assuming it is at midnight).

I went with the third option: move the end value to be end of day. I want to stress that this was already done in [the textual input, EditableDateRangePicker.tsx](https://github.com/coveo/plasma/blob/master/packages/mantine/src/components/date-range-picker/EditableDateRangePicker.tsx#L30). This leads to inconsistent behavior: if you type the date, you get end-of-day, but if you select the end by clicking, you get start-of-day.

I want to clarify that all options are equally valid, although I'd personally advice against switching to an exclusive upper bound (as it is doing a "sneaky" change compared to Mantine's behavior). The reason I ultimately went with the second option, is because I think it gives us best migration path to any other implementation in the future:
  - If you only use the date, you're ignoring the time part of the end value anyway.
    (So effectively, the now end-of-day time doesn't really matter).
  - If you use timestamps, you'll get the full selected end day, up to the last millisecond.
  - No custom patching of the `Date` values required if you use the time parts too.
    (This also allows easier transition to a `DateTimePicker` later on…)
  - Not as involved as implementing a whole `DateTimePicker` UI (that would be a new feature).

Feel free to express your opinion if you think we should go for any other option though, and basically reject these changes. If we go for any other option though, we **should** change the behavior of `EditableDateRangePicker` to produce start-of-day values too.

#### About time zones
Technically, moving the end date to "end-of-day" means that the switch to DST for the end happens "one day sooner". That's because the switch from and to DST always happens "between" 02:00 and 03:00, so midnight of the day of the switch is in the "before switch offset" (for example `2025-03-09 00:00:00.000` will be `-05:00` for EST), but end-of-day is guaranteed to be "after switch offset" (for example `2025-03-09 23:59:59.999` will be `-04:00` for EDT). In practice it doesn't matter. The Mantine components produce dates in the user's local time zone, so you can't use [toISOString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) combined with substring to generate the (date) representation of `yyyy-MM-dd` anyway. Doing so would move the day on >0 offsets, for example `2025-01-01 00:00:00.000` in CET (`+01:00` in winter) is `2024-12-31 23:00:00.000Z`.

If you use timestamps, the absolute moment in time will always be correct, either represented in local time (given that it is not interpreted in a different time zone after transmission), or represented in UTC time.

### Potential Breaking Changes

Technically, this change is "behavior breaking"; there are some nuances to that though. If the Date picker is used to truly select dates (not timestamps), the time value of the end Date should be ignored, and nothing changes. If the time value is used too, this will change behavior, but at least it will be consistent (unlike the difference between writing the value in the end range input, or clicking in the calendar).

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [X] [README.md](https://github.com/coveo/plasma/blob/master/README.md) ~is adjusted to reflect the proposed changes (if relevant)~ _Not applicable_
