### PR TITLE
feat(mantine): allow table url sync custom functions

### DIFF
--- a/packages/mantine/src/components/table/__tests__/use-url-synced-state.unit.spec.ts
+++ b/packages/mantine/src/components/table/__tests__/use-url-synced-state.unit.spec.ts
@@ -110,4 +110,22 @@ describe('useUrlSyncedState', () => {
         );
         expect(result.current[0]).toBe('initial');
     });
+
+    it('uses the custom url sync functions provided in the sync parameter', () => {
+        const setSearchParamSpy = vi.fn();
+        const {result} = renderHook(() =>
+            useUrlSyncedState({
+                initialState: 'initial',
+                serializer: (state) => [['key', state]],
+                deserializer: (params) => params.get('key') ?? '',
+                sync: {
+                    getSearchParams: () => new URLSearchParams('?key=value'),
+                    setSearchParam: setSearchParamSpy,
+                },
+            }),
+        );
+        expect(result.current[0]).toBe('value');
+        act(() => result.current[1]('new'));
+        expect(setSearchParamSpy).toHaveBeenCalledWith('key', 'new', 'initial');
+    });
 });

--- a/packages/mantine/src/components/table/use-table.ts
+++ b/packages/mantine/src/components/table/use-table.ts
@@ -3,7 +3,7 @@ import {type ExpandedState, type PaginationState, type SortingState} from '@tans
 import defaultsDeep from 'lodash.defaultsdeep';
 import {Dispatch, SetStateAction, useCallback, useMemo, useState} from 'react';
 import {type DateRangePickerValue} from '../date-range-picker';
-import {useUrlSyncedState} from './use-url-synced-state';
+import {useUrlSyncedState, UseUrlSyncedStateOptions} from './use-url-synced-state';
 
 // Create a deeply optional version of another type
 type DeepPartial<T> = {
@@ -187,10 +187,11 @@ export interface UseTableOptions<TData = unknown> {
     forceSelection?: boolean;
     /**
      * Whether to sync the table state with the URL.
+     * You can provide a custom implementation of the getSearchParams and setSearchParam functions.
      *
      * @default false
      */
-    syncWithUrl?: boolean;
+    syncWithUrl?: UseUrlSyncedStateOptions<unknown>['sync'];
 }
 
 const defaultOptions: UseTableOptions = {


### PR DESCRIPTION
### Proposed Changes

In applications where a custom router is used, for instance a hash router from react-router-dom, you need the ability to customize how search params are set in the url when syncing the table state with the url.

In this PR, I added a possibility of passing down custom functions to the useTable hook to control how search params are set in the url.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
