### PR TITLE
feat(mantine): export useUrlSyncedState and support hash router [ADUI-10457]

### DIFF
--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -4,3 +4,4 @@ export {type TablePredicateProps} from './table-predicate/TablePredicate';
 export {type TableAction, type TableLayout, type TableLayoutProps, type TableProps} from './Table.types';
 export {useTableContext} from './TableContext';
 export {useTable, type TableState, type TableStore, type UseTableOptions} from './use-table';
+export {useUrlSyncedState} from './use-url-synced-state';

--- a/packages/mantine/src/components/table/use-table.ts
+++ b/packages/mantine/src/components/table/use-table.ts
@@ -218,6 +218,11 @@ const defaultState: Partial<TableState> = {
 export const useTable = <TData>(userOptions: UseTableOptions<TData> = {}): TableStore<TData> => {
     const options = defaultsDeep({}, userOptions, defaultOptions) as UseTableOptions<TData>;
     const initialState = defaultsDeep({}, options.initialState, defaultState) as TableState<TData>;
+    /**
+     * The `useUrlSyncedState` hook defaults to synchronize, but the table wants to default to not synchronize,
+     * so always pass the sync option as a resolved boolean value.
+     */
+    const sync = !!options.syncWithUrl;
 
     // synced with url
     const [pagination, setPagination] = useUrlSyncedState<TableState<TData>['pagination']>({
@@ -234,7 +239,7 @@ export const useTable = <TData>(userOptions: UseTableOptions<TData> = {}): Table
                 },
                 initialState.pagination,
             ),
-        sync: options.syncWithUrl,
+        sync,
     });
     const [sorting, setSorting] = useUrlSyncedState<TableState<TData>['sorting']>({
         initialState: initialState.sorting,
@@ -251,13 +256,13 @@ export const useTable = <TData>(userOptions: UseTableOptions<TData> = {}): Table
                 return {id, desc: order === 'desc'};
             });
         },
-        sync: options.syncWithUrl,
+        sync,
     });
     const [globalFilter, setGlobalFilter] = useUrlSyncedState<TableState<TData>['globalFilter']>({
         initialState: initialState.globalFilter,
         serializer: (filter) => [['filter', filter]],
         deserializer: (params) => params.get('filter') ?? initialState.globalFilter,
-        sync: options.syncWithUrl,
+        sync,
     });
     const [predicates, setPredicates] = useUrlSyncedState<TableState<TData>['predicates']>({
         initialState: initialState.predicates,
@@ -270,13 +275,13 @@ export const useTable = <TData>(userOptions: UseTableOptions<TData> = {}): Table
                 },
                 {} as TableState<TData>['predicates'],
             ),
-        sync: options.syncWithUrl,
+        sync,
     });
     const [layout, setLayout] = useUrlSyncedState<TableState<TData>['layout']>({
         initialState: initialState.layout,
         serializer: (_layout) => [['layout', _layout]],
         deserializer: (params) => params.get('layout') ?? initialState.layout,
-        sync: options.syncWithUrl,
+        sync,
     });
     const [dateRange, setDateRange] = useUrlSyncedState<TableState<TData>['dateRange']>({
         initialState: initialState.dateRange,
@@ -288,7 +293,7 @@ export const useTable = <TData>(userOptions: UseTableOptions<TData> = {}): Table
             params.get('from') ? new Date(params.get('from') as string) : initialState.dateRange[0],
             params.get('to') ? new Date(params.get('to') as string) : initialState.dateRange[1],
         ],
-        sync: options.syncWithUrl,
+        sync,
     });
     const [columnVisibility, setColumnVisibility] = useUrlSyncedState<TableState<TData>['columnVisibility']>({
         initialState: initialState.columnVisibility,
@@ -323,7 +328,7 @@ export const useTable = <TData>(userOptions: UseTableOptions<TData> = {}): Table
             });
             return columns;
         },
-        sync: options.syncWithUrl,
+        sync,
     });
 
     // unsynced

--- a/packages/mantine/src/components/table/use-url-synced-state.ts
+++ b/packages/mantine/src/components/table/use-url-synced-state.ts
@@ -1,35 +1,75 @@
-import {useMemo, useState} from 'react';
+import {Dispatch, SetStateAction, useMemo, useState} from 'react';
 
-const setSearchParam = (key: string, value: string, initial: string) => {
-    const url = new URL(window.location.href);
-    if (value === '' || value === initial) {
-        url.searchParams.delete(key);
-    } else {
-        url.searchParams.set(key, value);
+/**
+ * A search param entry defines the key (index 0) and value (index 1) of a search parameter.
+ */
+export type SearchParamEntry = [string, string | null | undefined];
+
+/**
+ * Iterates over the `SearchParamEntry` values, and applies them to `target`, optionally filtering values.
+ *
+ * @param target The target to write values to, can be a Map (for the initial values) or `URLSearchParams`.
+ * @param entries The entries to apply (as returned by the serializer).
+ * @param filter Optional filter that allows to treat non-empty values as empty (e.g. to not set default values).
+ */
+const applyValues = (
+    target: Map<string, string> | URLSearchParams,
+    entries: Iterable<SearchParamEntry>,
+    filter: (entry: Readonly<SearchParamEntry>) => boolean,
+): void => {
+    for (const entry of entries) {
+        if (entry[1] && filter(entry)) {
+            target.set(entry[0], entry[1]);
+        } else {
+            target.delete(entry[0]);
+        }
     }
-    window.history.replaceState(null, '', url.toString());
 };
 
-const getSearchParams = (): URLSearchParams => {
-    const url = new URL(window.location.href);
-    return url.searchParams;
+/**
+ * Read the **current** search params from `window.location`, with support for detecting React's HashRouter.
+ * Also returns a method that will yield the href (string) value, after any changes made on the params object.
+ *
+ * @returns The `URLSearchParams` instance, and a function that can be used to get an updated href.
+ */
+const getSearchParams = (): [URLSearchParams, () => string] => {
+    const href = window.location.href;
+    // Search for '#/' to detect hash router urls
+    const searchStart = href.indexOf('?', href.indexOf('#/') + 1);
+    const params = new URLSearchParams(searchStart < 0 ? '' : href.substring(searchStart));
+    return [
+        params,
+        () => {
+            let result = searchStart < 0 ? href : href.substring(0, searchStart);
+            if (params.size > 0) {
+                result = result.concat('?', params.toString());
+            }
+            return result;
+        },
+    ];
 };
 
 export interface UseUrlSyncedStateOptions<T> {
     /**
-     * The initial state
+     * The initial state to use, if there would be no search params to deserialize from.
+     * These values are also treated as defaults, and if the current state matches the initialState,
+     * no value will be written to the search params.
      */
-    initialState: T;
+    initialState: T extends object ? Readonly<T> : T;
     /**
      * The serializer function is used to determine how the state is translated to url search parameters.
      * Called each time the state changes.
+     * Note that the serializer should always return entries for keys it controls, also if the current value is "unset" (`null` or empty).
+     * This ensures params get removed from the search when they are being unset.
+     *
      * @param stateValue The new state value to serialize.
-     * @returns A list of [key, value] to set as url search parameters.
+     * @returns An iterable of `[key, value]` to set as url search parameters.
      * @example (filterValue) => [['filter', filterValue]] // ?filter=filterValue
      */
-    serializer: (stateValue: T) => Array<[string, string]>;
+    serializer: (stateValue: T) => Iterable<SearchParamEntry>;
     /**
      * The deserializer function is used to determine how the url parameters influence the initial state.
+     * May return a partial state, values that are not deserialed are taken from the `initialState`.
      * Called only once when initializing the state.
      * @param params All the search parameters of the current url.
      * @returns The initial state based on the current url.
@@ -37,34 +77,44 @@ export interface UseUrlSyncedStateOptions<T> {
      */
     deserializer: (params: URLSearchParams) => T;
     /**
-     * Whether the state should be synced with the url.
-     * When set to false, the hook behaves just like a regular useState hook from react.
+     * Whether the state should be synced with the url, defaults to `true`.
+     * When set to `false`, the hook behaves just like a regular `useState` hook from react.
      */
     sync?: boolean;
 }
 
-export const useUrlSyncedState = <T>({initialState, serializer, deserializer, sync}: UseUrlSyncedStateOptions<T>) => {
-    const [state, setState] = useState<T>(sync ? deserializer(getSearchParams()) : initialState);
-    const enhancedSetState = useMemo(() => {
-        if (sync) {
-            const initialSerialized = serializer(initialState).reduce(
-                (acc, [key, value]) => {
-                    acc[key] = value;
-                    return acc;
-                },
-                {} as Record<string, string>,
-            );
-            return (updater: T | ((old: T) => T)) => {
-                setState((old) => {
-                    const newValue = updater instanceof Function ? updater(old) : updater;
-                    serializer(newValue).forEach(([key, value]) => setSearchParam(key, value, initialSerialized[key]));
-                    return newValue;
-                });
-            };
-        }
-
-        return setState;
-    }, [sync]);
+export const useUrlSyncedState = <T>(options: UseUrlSyncedStateOptions<T>) => {
+    const sync = options.sync !== false;
+    const initialState = useMemo(
+        () => (sync ? options.deserializer(getSearchParams()[0]) : options.initialState),
+        [options.initialState, options.sync],
+    );
+    const [state, setState] = useState<T>(initialState);
+    // Capture the initial state as a map, to compare values and not set them if they match.
+    const initialStateSerialized = useMemo(() => {
+        const v = new Map<string, string>();
+        applyValues(v, options.serializer(options.initialState), (_) => true);
+        return v;
+    }, [initialState, options.serializer]);
+    const enhancedSetState = useMemo<Dispatch<SetStateAction<T>>>(
+        () =>
+            sync
+                ? (updater: SetStateAction<T>) => {
+                      setState((old) => {
+                          const [search, getUrl] = getSearchParams();
+                          const newValue = updater instanceof Function ? updater(old) : updater;
+                          applyValues(
+                              search,
+                              options.serializer(newValue),
+                              ([key, value]) => initialStateSerialized.get(key) !== value,
+                          );
+                          window.history.replaceState(null, '', getUrl());
+                          return newValue;
+                      });
+                  }
+                : setState,
+        [sync],
+    );
 
     return [state, enhancedSetState] as const;
 };


### PR DESCRIPTION
## Related ticket(s)

[ADUI-10457](https://coveord.atlassian.net/browse/ADUI-10457)

### Proposed Changes

> ⚠️ The scope of these changes is a bit more than strictly required for the mentioned defect fix, since this fix was done as part of an effort to use `useUrlSyncedState` from Admin-UI.

The short summary:
  - Export `useUrlSyncedState`, so it can be used from Admin-UI too.
    _(It appears to be the best way forward for Data Platform Foundation to fix another state + search parameters related issue)._
  - Support the "hash router", that puts the page path inside the hash (`#`) section of the URL.
    Officially the 'search' part comes before the 'hash', but for page hashes there should be a "fake" search inside the hash path too. This makes sense when you realize that the whole reason for using the HashRouter is making sure you don't send the actual visited pages to the server (including the client-side search params).
  - Refactored the code to have behavior I think was "better" to make this hook public.

My team (Data Platform Foundation) has a defect which boils down to unfortunate (or just bad) state management related to search params. One of the issues is that we're tracking states in 3 different places, and we made the search parameters leading. Another issue is that we're not replacing the history like this hook is, so going back is like undo-ing your last filter/date range change. While this seemed like a nice feature when developing it, it is actually a dark pattern (back/forward buttons should be navigation, not undo/redo).

Long story short, I started prototyping replacing the state management we had with using the `useUrlSyncedState` hook. To do so I copied the hook to Admin-UI, and started using it. I ran into the same issue with the incorrect URL update, but fixed it differently as what was proposed in #3991. I basically kept using `window.location.href`, but just made the code sensitive to detect the hash route pattern (to my knowledge, it's always a `#` hash followed by a `/` forward slash). This keeps the benefits of the code always operating on the current URL, even though it doesn't have access to the `useSearchParameters` hook.

Arguably it is a bit cleaner to mutate through `useSearchParameters`, but also more cumbersome, so I will leave it to reviewers to judge if they're as confident in this approach as I am.

To make the hook more general purpose and hopefully also well behaved and performant, I changed some details as opposed to the previous version:
  - Make the optional `sync` parameter default to `true` (instead of `false`).
    To me this is the only logical choice; if you use `useUrlSyncedParameters`, the default behavior should be that it synchronizes. Otherwise you could just use `setState`.
    Of course the `useTable` hook is a bit of an exception, as it wants provide this feature as an **option**, and default to not syncing. So the `useTable` code had to be updated to always resolves the `sync` parameter to a boolean value, defaulting to `false` for `undefined`.
  - Only serialize the `initialState` once (provided it doesn't change), using `useMemo`.
  - Apply the changes caused by a serialize in a single "replaceState".
    This is a minor detail, but the previous version of the code would apply the state to the location per field that changed, instead of per state update.
  - Improved the TypeScript signatures a bit more, for example by using React signatures where we mimic `setState`.


### Potential Breaking Changes

These changes fix the linked defect (usage with HashRouter), and adds the export of this hook (so it is an additive change). While there are some behavioral changes to the `useUrlSyncedState` hook, it was only internal before this PR, so there is no behavior breaking change.

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [X] ~[README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)~

☝️ I didn't really see a README that should be updated, and did my best to add clear TSDoc. Still, please point out if there is a readme that should be updated.


[ADUI-10457]: https://coveord.atlassian.net/browse/ADUI-10457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ