### PR TITLE
feat(code-editor): support custom tabSize

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -72,6 +72,12 @@ interface CodeEditorProps
      * @default 'local'
      */
     monacoLoader?: 'cdn' | 'local';
+    /**
+     * Options to pass to the monaco editor.
+     * Currently only supporting [`tabSize`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html#tabSize).
+     *
+     */
+    options?: Pick<monacoEditor.IStandaloneEditorConstructionOptions, 'tabSize'>;
 }
 
 const defaultProps: Partial<CodeEditorProps> = {
@@ -101,6 +107,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         maxHeight,
         disabled,
         monacoLoader,
+        options: {tabSize} = {tabSize: 2},
         ...others
     } = useProps('CodeEditor', defaultProps, props);
     const [loaded, setLoaded] = useState(false);
@@ -230,7 +237,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                     formatOnPaste: true,
                     fontSize: px(theme.fontSizes.xs) as number,
                     readOnly: disabled,
-                    tabSize: 2,
+                    tabSize,
                 }}
                 value={_value}
                 onChange={handleChange}

--- a/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
@@ -11,8 +11,9 @@ const Demo = () => {
         <CodeEditor
             language="python"
             label="Extension"
-            description="Define an extension using Python"
+            description="Define an extension using Python and a custom tab size."
             monacoLoader="cdn"
+            options={{tabSize: 4}}
             {...form.getInputProps('code')}
         />
     );

--- a/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
@@ -3,7 +3,7 @@ import {CodeEditor, useForm} from '@coveord/plasma-mantine';
 const Demo = () => {
     const form = useForm({
         initialValues: {
-            code: 'def my_extension():\n\tprint("Not implemented yet.")\n\nmy_extension()',
+            code: 'def my_extension():\n    print("Not implemented yet.")\n\nmy_extension()',
         },
     });
 

--- a/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
@@ -3,7 +3,7 @@ import {CodeEditor, useForm} from '@coveord/plasma-mantine';
 const Demo = () => {
     const form = useForm({
         initialValues: {
-            code: 'def my_extension():\n\t\tprint("Not implemented yet.")\n\nmy_extension()',
+            code: 'def my_extension():\n\tprint("Not implemented yet.")\n\nmy_extension()',
         },
     });
 

--- a/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
+++ b/packages/website/src/examples/form/code-editor/CodeEditorPython.demo.tsx
@@ -3,7 +3,7 @@ import {CodeEditor, useForm} from '@coveord/plasma-mantine';
 const Demo = () => {
     const form = useForm({
         initialValues: {
-            code: 'def my_extension():\n\tprint("Not implemented yet.")\n\nmy_extension()',
+            code: 'def my_extension():\n\t\tprint("Not implemented yet.")\n\nmy_extension()',
         },
     });
 


### PR DESCRIPTION
## Proposed Changes

Allow setting a custom `tabSize` in the `CodeEditor` component.

Previously, it was hardcoded to `2` but let's say for example you use the editor to write Python code and want to follow the `PEP8` guidelines, you need to set `4`.

Demo [here](https://plasma.coveo.com/feature/SEARCHAPI-11667-code-editor-tabs/form/CodeEditor). 🧪 

### Documentation

📖 This prop is supported by the `Monaco Editor` and documented [here](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html#tabSize).

⚠️ Note: According to the Monaco Editor's documentation on `tabSize`:

> This setting is overridden based on the file contents when detectIndentation is on. 

So this means that if you set a `tabSize` of 4, but the content of the editor is using 2 spaces, it will enforce a `tabSize` of 2. However, if you erase everything and start from scratch, it will fallback on the `tabSize` property.

### Potential Breaking Changes

None. The new prop is optional and the default behaviour with a `tabSize` of 2 is preserved.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
