### PR TITLE
fix(CodeEditor): format text only on valid input

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -249,9 +249,12 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                     registerThemes(monaco);
                     editor.onDidFocusEditorText(() => onFocus?.());
                     editor.onDidBlurEditorText(async () => {
-                        if (!hasMonacoErrorRef.current) {
-                            await editor.getAction('editor.action.formatDocument').run();
-                        }
+                        // monaco editor has a timeout of 500ms populating errors, we want to ensure that checking errors happen after that
+                        setTimeout(async () => {
+                            if (!hasMonacoErrorRef.current) {
+                                await editor.getAction('editor.action.formatDocument').run();
+                            }
+                        }, 550);
                     });
                 }}
             />

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -249,6 +249,17 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                     editor.onDidBlurEditorText(async () => {
                         await editor.getAction('editor.action.formatDocument').run();
                     });
+
+                    if (language === 'json') {
+                        monaco.languages.registerDocumentFormattingEditProvider('json', {
+                            provideDocumentFormattingEdits: (model) => [
+                                {
+                                    range: model.getFullModelRange(),
+                                    text: JSON.stringify(JSON.parse(model.getValue()), null, tabSize),
+                                },
+                            ],
+                        });
+                    }
                 }}
             />
         </Box>

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mantine/core';
 import {useUncontrolled} from '@mantine/hooks';
 import Editor, {Monaco, loader} from '@monaco-editor/react';
-import {editor as monacoEditor} from 'monaco-editor';
+import {editor as monacoEditor, MarkerSeverity} from 'monaco-editor';
 import {FunctionComponent, useEffect, useRef, useState} from 'react';
 
 import cx from 'clsx';
@@ -172,9 +172,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     }, []);
 
     const handleValidate = (markers: monacoEditor.IMarker[]) => {
-        setHasMonacoError(
-            markers.some((marker) => marker.severity === loader.__getMonacoInstance().MarkerSeverity.Error),
-        );
+        setHasMonacoError(markers.some((marker) => marker.severity === MarkerSeverity.Error));
     };
 
     const _label = label ? (
@@ -247,19 +245,10 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                     registerThemes(monaco);
                     editor.onDidFocusEditorText(() => onFocus?.());
                     editor.onDidBlurEditorText(async () => {
-                        await editor.getAction('editor.action.formatDocument').run();
+                        if (!hasMonacoError) {
+                            await editor.getAction('editor.action.formatDocument').run();
+                        }
                     });
-
-                    if (language === 'json') {
-                        monaco.languages.registerDocumentFormattingEditProvider('json', {
-                            provideDocumentFormattingEdits: (model) => [
-                                {
-                                    range: model.getFullModelRange(),
-                                    text: JSON.stringify(JSON.parse(model.getValue()), null, tabSize),
-                                },
-                            ],
-                        });
-                    }
                 }}
             />
         </Box>

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -159,6 +159,10 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     };
 
     const [hasMonacoError, setHasMonacoError] = useState(false);
+    const hasMonacoErrorRef = useRef(false);
+
+    hasMonacoErrorRef.current = hasMonacoError;
+
     const renderErrorOutline = !!error || hasMonacoError;
     const theme = useMantineTheme();
     const {colorScheme} = useMantineColorScheme();
@@ -245,7 +249,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                     registerThemes(monaco);
                     editor.onDidFocusEditorText(() => onFocus?.());
                     editor.onDidBlurEditorText(async () => {
-                        if (!hasMonacoError) {
+                        if (!hasMonacoErrorRef.current) {
                             await editor.getAction('editor.action.formatDocument').run();
                         }
                     });


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

Currently, the `CodeEditor` uses the default formatting provided by the Monaco Editor. For `json` language, the editor inherently relies on `vscode-json-languageservice`, which does a best-effort formatting of the text regardless whether the JSON is valid or not.

However, in the scenario where the JSON is invalid, we've observed UI issues caused by the formatting, where the mouse pointer is relocated to the end of the text:

https://github.com/user-attachments/assets/d5766c42-2259-4f30-af3c-32519328475f


Thus we want to disable the best-effort formatting. This is done by overriding the default formatter with a simple `JSON.stringify(JSON.parse(model.getValue()), null, tabSize)`, which will fail in invalid scenarios and thus does nothing.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

None since change is behavioral.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
