### PR TITLE
fix(CodeEditor): do not format if editor closed

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -252,7 +252,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                         // monaco editor has a timeout of 500ms populating errors, we want to ensure that checking errors happen after that
                         setTimeout(async () => {
                             if (!hasMonacoErrorRef.current) {
-                                await editor.getAction('editor.action.formatDocument').run();
+                                await editor?.getAction('editor.action.formatDocument')?.run();
                             }
                         }, 550);
                     });


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

Since the code formatting now has a timeout, we no longer have guarantee that the editor is still mounted by the time the formatting code is executed. We thus need to make sure that the code doesn't break on undefined or null values.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
