### PR TITLE
fix(multi-select): truncate long custom values

### DIFF
--- a/packages/style/scss/components/multiselect-input.scss
+++ b/packages/style/scss/components/multiselect-input.scss
@@ -33,6 +33,12 @@
     .selected-option,
     .sortable-selected-option {
         margin: 0 $dropdown-multiselect-margin $dropdown-multiselect-margin 0;
+        overflow: hidden;
+
+        .selected-option-value {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 
     &.readOnly {


### PR DESCRIPTION
### Proposed Changes

[SEARCHAPI-9091
](https://coveord.atlassian.net/browse/SEARCHAPI-9091)

There was a display issue in the legacy Plasma-React multi-select. When in you added a long custom value, it would sometime hide the clear button.

📷 Before

![Screenshot 2025-03-31 at 1 42 12 PM](https://github.com/user-attachments/assets/5b28c499-66f6-44cf-8902-6aea384c38fb)


📷 After

![Screenshot 2025-03-31 at 1 40 43 PM](https://github.com/user-attachments/assets/87564025-c70d-4313-893f-68144c7416b5)

Demo [link](https://plasma.coveo.com/feature/SEARCHAPI-9091-fix-multiselect-truncate/legacy/form/MultiSelect). 🧪 

### Potential Breaking Changes

None.

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
