### PR TITLE
feat(header): refactor of the Header.Actions compound to become Header.Right

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -14,11 +14,11 @@ import {
 import {Children, ReactElement, ReactNode} from 'react';
 import {HeaderProvider} from './Header.context';
 import classes from './Header.module.css';
-import {HeaderActions, HeaderActionsStyleNames} from './HeaderActions/HeaderActions';
+import {HeaderRight, HeaderRightStyleNames} from './HeaderRight/HeaderRight';
 import {HeaderBreadcrumbs, HeaderBreadcrumbsStyleNames} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
 import {HeaderDocAnchor, HeaderDocAnchorStyleNames} from './HeaderDocAnchor/HeaderDocAnchor';
 
-export type {HeaderActionsProps} from './HeaderActions/HeaderActions';
+export type {HeaderRightProps} from './HeaderRight/HeaderRight';
 export type {HeaderBreadcrumbsProps} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
 export type {HeaderDocAnchorProps} from './HeaderDocAnchor/HeaderDocAnchor';
 
@@ -28,9 +28,10 @@ export type HeaderStyleNames =
     | 'title'
     | 'description'
     | 'divider'
+    | 'body'
     | HeaderDocAnchorStyleNames
     | HeaderBreadcrumbsStyleNames
-    | HeaderActionsStyleNames;
+    | HeaderRightStyleNames;
 
 export interface HeaderProps extends StylesApiProps<HeaderFactory>, Omit<GroupProps, 'classNames' | 'styles' | 'vars'> {
     /**
@@ -60,8 +61,12 @@ export type HeaderFactory = Factory<{
     stylesNames: HeaderStyleNames;
     staticComponents: {
         Breadcrumbs: typeof HeaderBreadcrumbs;
-        Actions: typeof HeaderActions;
+        Right: typeof HeaderRight;
         DocAnchor: typeof HeaderDocAnchor;
+        /**
+         * @deprecated use Header.Right instead
+         */
+        Actions: typeof HeaderRight;
     };
 }>;
 
@@ -101,10 +106,10 @@ export const Header = factory<HeaderFactory>((_props, ref) => {
 
     const convertedChildren = Children.toArray(children) as ReactElement[];
     const breadcrumbs = convertedChildren.find((child) => child.type === HeaderBreadcrumbs);
-    const actions = convertedChildren.find((child) => child.type === HeaderActions);
+    const right = convertedChildren.find((child) => child.type === HeaderRight);
     const docAnchor = convertedChildren.find((child) => child.type === HeaderDocAnchor);
     const otherChildren = convertedChildren.filter(
-        (child) => child.type !== HeaderBreadcrumbs && child.type !== HeaderActions && child.type !== HeaderDocAnchor,
+        (child) => child.type !== HeaderBreadcrumbs && child.type !== HeaderRight && child.type !== HeaderDocAnchor,
     );
     return (
         <HeaderProvider value={{getStyles}}>
@@ -123,7 +128,7 @@ export const Header = factory<HeaderFactory>((_props, ref) => {
                         {description}
                     </Text>
                 </Stack>
-                {actions}
+                {right}
             </Group>
             {borderBottom ? <Divider {...getStyles('divider', stylesApiProps)} size="xs" /> : null}
         </HeaderProvider>
@@ -131,5 +136,9 @@ export const Header = factory<HeaderFactory>((_props, ref) => {
 });
 
 Header.Breadcrumbs = HeaderBreadcrumbs;
-Header.Actions = HeaderActions;
+Header.Right = HeaderRight;
 Header.DocAnchor = HeaderDocAnchor;
+/**
+ * @deprecated use Header.Right instead
+ */
+Header.Actions = HeaderRight;

--- a/packages/mantine/src/components/header/HeaderRight/HeaderRight.tsx
+++ b/packages/mantine/src/components/header/HeaderRight/HeaderRight.tsx
@@ -2,27 +2,27 @@ import {CompoundStylesApiProps, Factory, Group, GroupProps, factory, useProps} f
 import {ReactNode} from 'react';
 import {useHeaderContext} from '../Header.context';
 
-export type HeaderActionsStyleNames = 'actions';
+export type HeaderRightStyleNames = 'right';
 
-export interface HeaderActionsProps
+export interface HeaderRightProps
     extends Omit<GroupProps, 'classNames' | 'styles' | 'vars' | 'children'>,
-        CompoundStylesApiProps<HeaderActionsFactory> {
+        CompoundStylesApiProps<HeaderRightFactory> {
     children: ReactNode;
 }
 
-export type HeaderActionsFactory = Factory<{
-    props: HeaderActionsProps;
+export type HeaderRightFactory = Factory<{
+    props: HeaderRightProps;
     ref: HTMLDivElement;
-    stylesNames: HeaderActionsStyleNames;
+    stylesNames: HeaderRightStyleNames;
     compound: true;
 }>;
 
-const defaultProps: Partial<HeaderActionsProps> = {
+const defaultProps: Partial<HeaderRightProps> = {
     gap: 'sm',
 };
 
-export const HeaderActions = factory<HeaderActionsFactory>((_props, ref) => {
-    const props = useProps('HeaderActions', defaultProps, _props);
+export const HeaderRight = factory<HeaderRightFactory>((_props, ref) => {
+    const props = useProps('HeaderRight', defaultProps, _props);
     const {gap, className, classNames, styles, style, children, vars, ...others} = props;
     const ctx = useHeaderContext();
 
@@ -30,7 +30,7 @@ export const HeaderActions = factory<HeaderActionsFactory>((_props, ref) => {
         <Group
             ref={ref}
             gap={gap}
-            {...ctx.getStyles('actions', {className, style, classNames, styles, props})}
+            {...ctx.getStyles('right', {className, style, classNames, styles, props})}
             {...others}
         >
             {children}

--- a/packages/mantine/src/components/header/__tests__/Header.spec.tsx
+++ b/packages/mantine/src/components/header/__tests__/Header.spec.tsx
@@ -86,7 +86,7 @@ describe('Header', () => {
         expect(screen.getByText('action 2')).toBeInTheDocument();
     });
 
-    it('renders provided components in Table.Right when called as Table.Actions', () => {
+    it('renders provided components in Header.Right when called as Header.Actions', () => {
         render(
             <Header>
                 title

--- a/packages/mantine/src/components/header/__tests__/Header.spec.tsx
+++ b/packages/mantine/src/components/header/__tests__/Header.spec.tsx
@@ -71,7 +71,7 @@ describe('Header', () => {
         expect(screen.getByText('description')).toBeInTheDocument();
     });
 
-    it('renders provided components in Table.Right', () => {
+    it('renders provided components in Header.Right', () => {
         render(
             <Header>
                 title

--- a/packages/mantine/src/components/header/__tests__/Header.spec.tsx
+++ b/packages/mantine/src/components/header/__tests__/Header.spec.tsx
@@ -71,7 +71,22 @@ describe('Header', () => {
         expect(screen.getByText('description')).toBeInTheDocument();
     });
 
-    it('renders provided actions in the header', () => {
+    it('renders provided components in Table.Right', () => {
+        render(
+            <Header>
+                title
+                <Header.Right>
+                    <span>action 1</span>
+                    <span>action 2</span>
+                </Header.Right>
+            </Header>,
+        );
+
+        expect(screen.getByText('action 1')).toBeInTheDocument();
+        expect(screen.getByText('action 2')).toBeInTheDocument();
+    });
+
+    it('renders provided components in Table.Right when called as Table.Actions', () => {
         render(
             <Header>
                 title

--- a/packages/website/src/examples/layout/Header/Header.demo.tsx
+++ b/packages/website/src/examples/layout/Header/Header.demo.tsx
@@ -9,10 +9,10 @@ const Demo = () => (
         </Header.Breadcrumbs>
         Title
         <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
-        <Header.Actions>
+        <Header.Right wrap="nowrap">
             <Button>Primary</Button>
             <Button variant="outline">Secondary</Button>
-        </Header.Actions>
+        </Header.Right>
     </Header>
 );
 export default Demo;

--- a/packages/website/src/examples/layout/Header/HeaderSecondary.demo.tsx
+++ b/packages/website/src/examples/layout/Header/HeaderSecondary.demo.tsx
@@ -4,9 +4,9 @@ const Demo = () => (
     <Header variant="secondary">
         Title
         <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
-        <Header.Actions>
+        <Header.Right>
             <CloseButton />
-        </Header.Actions>
+        </Header.Right>
     </Header>
 );
 export default Demo;


### PR DESCRIPTION
### Proposed Changes

#### Context
We need to achieve something like :point_down: in the Coveo Knowledge Hub
![image](https://github.com/user-attachments/assets/9e5db72e-e588-40dc-93bd-ec57ce562ff7)

I think I could achieve this throught the `Header.Action` compound, since its location is proper and it can take any react node.
But it wouldn't feel right and make the implementation code confusing.

#### The code

Renamed `Header.Actions` to Header.Right in order to reflect that the compound component can render more than just actions.
Header.Actions can still be used in order to keep retro compatibility. But its future usage will be discouraged in favor of the renamed version.

### Potential Breaking Changes

None of the actually implemented header should be impacted.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
