### PR TITLE
Breadscrumbs styles

### DIFF
--- a/packages/mantine/src/components/header/Header.module.css
+++ b/packages/mantine/src/components/header/Header.module.css
@@ -19,12 +19,3 @@
     margin-left: var(--mantine-spacing-xs);
     vertical-align: middle;
 }
-
-.breadcrumbs {
-    font-size: var(--mantine-font-size-sm);
-    font-weight: 400;
-}
-
-.breadcrumbsSeparator {
-    color: var(--mantine-color-dimmed);
-}

--- a/packages/mantine/src/styles/Breadcrumbs.module.css
+++ b/packages/mantine/src/styles/Breadcrumbs.module.css
@@ -1,0 +1,8 @@
+.breadcrumb {
+    font-size: var(--mantine-font-size-xs);
+    font-weight: var(--mantine-heading-font-weight);
+
+    &:not(a) {
+        color: var(--coveo-color-title);
+    }
+}

--- a/packages/mantine/src/styles/Checkbox.module.css
+++ b/packages/mantine/src/styles/Checkbox.module.css
@@ -4,6 +4,6 @@
 
 .input {
     @mixin where-light {
-        border-color: var(--mantine-color-input-border);
+        border-color: var(--coveo-color-input-border);
     }
 }

--- a/packages/mantine/src/styles/CheckboxIndicator.module.css
+++ b/packages/mantine/src/styles/CheckboxIndicator.module.css
@@ -1,5 +1,5 @@
 .indicator {
     @mixin where-light {
-        border-color: var(--mantine-color-input-border);
+        border-color: var(--coveo-color-input-border);
     }
 }

--- a/packages/mantine/src/styles/Input.module.css
+++ b/packages/mantine/src/styles/Input.module.css
@@ -1,7 +1,7 @@
 .wrapper {
     @mixin light {
         &[data-variant='default'] {
-            --input-bd: var(--mantine-color-input-border);
+            --input-bd: var(--coveo-color-input-border);
         }
     }
 }

--- a/packages/mantine/src/styles/Pagination.module.css
+++ b/packages/mantine/src/styles/Pagination.module.css
@@ -1,5 +1,5 @@
 .control {
     @mixin where-light {
-        border-color: var(--mantine-color-input-border);
+        border-color: var(--coveo-color-input-border);
     }
 }

--- a/packages/mantine/src/styles/Radio.module.css
+++ b/packages/mantine/src/styles/Radio.module.css
@@ -5,6 +5,6 @@
 
 .radio {
     @mixin where-light {
-        border-color: var(--mantine-color-input-border);
+        border-color: var(--coveo-color-input-border);
     }
 }

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -11,6 +11,7 @@ import {
     Alert,
     AppShell,
     Badge,
+    Breadcrumbs,
     Button,
     Checkbox,
     CloseButton,
@@ -43,9 +44,11 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
+import {IconSlash} from '@tabler/icons-react';
 import {InfoToken} from '../components';
 import AlertClasses from '../styles/Alert.module.css';
 import BadgeClasses from '../styles/Badge.module.css';
+import BreadcrumbsClasses from '../styles/Breadcrumbs.module.css';
 import ButtonClasses from '../styles/Button.module.css';
 import CheckboxClasses from '../styles/Checkbox.module.css';
 import CheckboxIndicatorClasses from '../styles/CheckboxIndicator.module.css';
@@ -139,6 +142,13 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             classNames: BadgeClasses,
             defaultProps: {
                 variant: 'light',
+            },
+        }),
+        Breadcrumbs: Breadcrumbs.extend({
+            classNames: BreadcrumbsClasses,
+            defaultProps: {
+                separator: <IconSlash size={16} color="var(--mantine-color-dimmed)" />,
+                separatorMargin: 'xxs',
             },
         }),
         Button: Button.extend({

--- a/packages/mantine/src/theme/__tests__/plasmaCSSVariablesResolver.spec.ts
+++ b/packages/mantine/src/theme/__tests__/plasmaCSSVariablesResolver.spec.ts
@@ -7,7 +7,7 @@ describe('plasmaCSSVariablesResolver', () => {
         const variables = plasmaCSSVariablesResolver({colors: PlasmaColors} as unknown as MantineTheme);
         expect(variables.light['--mantine-color-error']).toBe('#d2271b');
         expect(variables.light['--mantine-color-default-border']).toBe('#dddfe3');
-        expect(variables.light['--mantine-color-input-border']).toBe('#b9bdc7');
+        expect(variables.light['--coveo-color-input-border']).toBe('#b9bdc7');
         expect(variables.light['--mantine-color-text']).toBe('#3b3e46');
         expect(variables.light['--mantine-color-dimmed']).toBe('#676d7a');
         expect(variables.light['--mantine-color-gray-filled']).toBe('#959cab');

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -5,6 +5,7 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
         variables: {},
         dark: {},
         light: {
+            '--coveo-color-title': theme.colors.gray[8],
             '--mantine-color-default-border': theme.colors.gray[2],
             '--mantine-color-input-border': theme.colors.gray[3],
             '--mantine-color-error': theme.colors.red[5],

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -5,9 +5,9 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
         variables: {},
         dark: {},
         light: {
+            '--coveo-color-input-border': theme.colors.gray[3],
             '--coveo-color-title': theme.colors.gray[8],
             '--mantine-color-default-border': theme.colors.gray[2],
-            '--mantine-color-input-border': theme.colors.gray[3],
             '--mantine-color-error': theme.colors.red[5],
             '--mantine-color-text': theme.colors.gray[6],
             '--mantine-color-dimmed': theme.colors.gray[5],

--- a/packages/website/src/examples/layout/Header/Header.demo.tsx
+++ b/packages/website/src/examples/layout/Header/Header.demo.tsx
@@ -1,11 +1,11 @@
-import {Anchor, Button, Header} from '@coveord/plasma-mantine';
+import {Anchor, Button, Header, Text} from '@coveord/plasma-mantine';
 
 const Demo = () => (
     <Header description="The header description" borderBottom>
         <Header.Breadcrumbs>
-            <Anchor>One</Anchor>
+            <Anchor>Back</Anchor>
             <Anchor>Two</Anchor>
-            <Anchor>Three</Anchor>
+            <Text>This</Text>
         </Header.Breadcrumbs>
         Title
         <Header.DocAnchor href="https://about:blank" label="Tooltip text" />


### PR DESCRIPTION
### Proposed Changes

Adjusted breadcrumbs style to match Figma
Renamed a custom variable I created to `--coveo-...` instead of `--mantine-...` to make it clear it's us that define it

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
