### PR TITLE
feat(codeEditor): front the editor instance

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mantine/core';
 import {useUncontrolled} from '@mantine/hooks';
 import Editor, {Monaco, loader} from '@monaco-editor/react';
-import {editor as monacoEditor, MarkerSeverity} from 'monaco-editor';
+import {MarkerSeverity, editor as monacoEditor} from 'monaco-editor';
 import {FunctionComponent, useEffect, useRef, useState} from 'react';
 
 import cx from 'clsx';
@@ -48,6 +48,8 @@ interface CodeEditorProps
     onCopy?(): void;
     /** Called whenever the code editor gets the focus */
     onFocus?(): void;
+    /** Ref object that provides access to the editor's functionality */
+    editorHandle?: React.MutableRefObject<monacoEditor.IStandaloneCodeEditor | null>;
     /**
      * The minimal height of the CodeEditor (label and description included)
      *
@@ -108,6 +110,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         disabled,
         monacoLoader,
         options: {tabSize} = {tabSize: 2},
+        editorHandle,
         ...others
     } = useProps('CodeEditor', defaultProps, props);
     const [loaded, setLoaded] = useState(false);
@@ -119,6 +122,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     });
     const [parentHeight, ref] = useParentHeight();
     const editorRef = useRef(null);
+
     const loadLocalMonaco = async () => {
         const monacoInstance = await import('monaco-editor');
         loader.config({monaco: monacoInstance});
@@ -245,6 +249,9 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                 onChange={handleChange}
                 onMount={(editor, monaco) => {
                     editorRef.current = editor;
+                    if (editorHandle) {
+                        editorHandle.current = editor;
+                    }
                     registerLanguages(monaco);
                     registerThemes(monaco);
                     editor.onDidFocusEditorText(() => onFocus?.());

--- a/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
+++ b/packages/mantine/src/components/code-editor/__tests__/CodeEditor.spec.tsx
@@ -1,6 +1,8 @@
 import {useForm} from '@mantine/form';
 import {loader} from '@monaco-editor/react';
 import {render, screen, userEvent, waitForElementToBeRemoved} from '@test-utils';
+import type {editor} from 'monaco-editor';
+import {useRef} from 'react';
 import {CodeEditor} from '../CodeEditor';
 import {XML} from '../languages/xml';
 
@@ -87,5 +89,19 @@ describe('CodeEditor', () => {
         await user.click(screen.getByRole('button', {name: /search/i}));
 
         expect(onSearchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('defines editorHandle on mount', async () => {
+        let editorHandle: React.MutableRefObject<editor.IStandaloneCodeEditor> = null;
+        const EditorWrapper = () => {
+            editorHandle = useRef<editor.IStandaloneCodeEditor | null>(null);
+            return <CodeEditor editorHandle={editorHandle} />;
+        };
+
+        render(<EditorWrapper />);
+
+        await waitForElementToBeRemoved(screen.queryByRole('presentation'));
+
+        expect(editorHandle.current).not.toBeNull();
     });
 });


### PR DESCRIPTION
### Proposed Changes
#### Context
We had an issue where the switch tabs and code editor doesn't play well together when doing `ctrl-z`, since we change the content of the editor based on the  selected tab. Doing an "undo(ctrl-z)" after switching tab would set the content to the content of the previous tab. We added the `clearUndoStack` method to be able to clear the stack when switching tabs and prevent this behaviour
Here's an example of an issue we have.

![web-7521](https://github.com/user-attachments/assets/22758fb6-27af-49f4-bdaf-32af32c31ed8)

Here I pressed `ctrl-z` after switching tab and it sets the value to the old tab content.

#### Code
- Added a new optional `editorRef` prop to the `CodeEditor` component, allowing external access to the editor instance. Specifically, the `editorRef` exposes a `clearUndoStack` method that, when called, resets the editor's content to its current value, effectively clearing the undo stack. This functionality is set up using a `useEffect` hook to ensure the `editorRef` is properly updated with the `clearUndoStack` method.


Potential Breaking Changes
None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
