### PR TITLE
Fix Prompt title and Modal demo

### DIFF
--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -25,7 +25,7 @@ import {PromptConfirmButton, PromptConfirmButtonStylesNamesVariant} from './Prom
 export type PromptVariant = 'success' | 'warning' | 'critical' | 'info';
 export type PromptVars = {root: '--prompt-icon-size'};
 export type PromptStylesNames =
-    | Omit<ModalStylesNames, 'title'>
+    | Exclude<ModalStylesNames, 'title'>
     | 'icon'
     | PromptCancelButtonStylesNamesVariant
     | PromptConfirmButtonStylesNamesVariant;

--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -11,6 +11,7 @@ import {
     useStyles,
 } from '@mantine/core';
 import {Children, ReactElement, ReactNode} from 'react';
+import {Header} from '../header';
 import {Modal} from '../modal';
 import Critical from './icons/critical.svg';
 import Info from './icons/info.svg';
@@ -24,7 +25,7 @@ import {PromptConfirmButton, PromptConfirmButtonStylesNamesVariant} from './Prom
 export type PromptVariant = 'success' | 'warning' | 'critical' | 'info';
 export type PromptVars = {root: '--prompt-icon-size'};
 export type PromptStylesNames =
-    | ModalStylesNames
+    | Omit<ModalStylesNames, 'title'>
     | 'icon'
     | PromptCancelButtonStylesNamesVariant
     | PromptConfirmButtonStylesNamesVariant;
@@ -98,6 +99,8 @@ export const Prompt = factory<PromptFactory>((_props, ref) => {
         (child.type === Modal.Footer ? footers : otherChildren).push(child);
     });
 
+    const titleContent = typeof title === 'string' ? <Header variant="secondary">{title}</Header> : title;
+
     return (
         <PromptContextProvider value={{variant, getStyles}}>
             <Modal.Root ref={ref} variant="prompt" size="sm" {...others} {...getStyles('root')}>
@@ -114,7 +117,7 @@ export const Prompt = factory<PromptFactory>((_props, ref) => {
                                 src={PROMPT_VARIANT_ICONS_SRC[variant]}
                             />
                         )}
-                        <Modal.Title {...getStyles('title', stylesApiProps)}>{title}</Modal.Title>
+                        {titleContent}
                         <Modal.CloseButton {...getStyles('close', stylesApiProps)} />
                     </Modal.Header>
                     <Modal.Body {...getStyles('body', stylesApiProps)}>

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
@@ -10,12 +10,10 @@ const Demo = () => {
                 <Modal.Overlay />
                 <Modal.Content>
                     <Modal.Header className={classes.headerWithTabs}>
-                        <Modal.Title>
-                            <Header variant="secondary" description="Modal description">
-                                Modal Title
-                                <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
-                            </Header>
-                        </Modal.Title>
+                        <Header variant="secondary" description="Modal description">
+                            Modal Title
+                            <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
+                        </Header>
                         <Modal.CloseButton />
                     </Modal.Header>
                     <Tabs defaultValue="tab-1">

--- a/packages/website/src/examples/layout/Prompt/Prompt.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/Prompt.demo.tsx
@@ -5,7 +5,7 @@ const Demo = () => {
 
     return (
         <>
-            <Prompt opened={opened} title={<Header variant="secondary">Prompt title</Header>} onClose={close}>
+            <Prompt opened={opened} title="Prompt title" onClose={close}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
                 <Prompt.Footer>

--- a/packages/website/src/examples/layout/Prompt/Prompt.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/Prompt.demo.tsx
@@ -1,4 +1,4 @@
-import {Button, Header, Prompt, useDisclosure} from '@coveord/plasma-mantine';
+import {Button, Prompt, useDisclosure} from '@coveord/plasma-mantine';
 
 const Demo = () => {
     const [opened, {open, close}] = useDisclosure();

--- a/packages/website/src/examples/layout/Prompt/PromptCritical.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptCritical.demo.tsx
@@ -13,12 +13,7 @@ const Demo = () => {
 
     return (
         <>
-            <Prompt
-                variant="critical"
-                opened={opened}
-                title={<Header variant="secondary">Prompt title</Header>}
-                onClose={close}
-            >
+            <Prompt variant="critical" opened={opened} title="Prompt title" onClose={close}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
                 <Prompt.Footer>

--- a/packages/website/src/examples/layout/Prompt/PromptCritical.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptCritical.demo.tsx
@@ -1,4 +1,4 @@
-import {Button, Header, Prompt, useDisclosure} from '@coveord/plasma-mantine';
+import {Button, Prompt, useDisclosure} from '@coveord/plasma-mantine';
 
 const Demo = () => {
     const [opened, {open, close}] = useDisclosure();

--- a/packages/website/src/examples/layout/Prompt/PromptSuccess.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptSuccess.demo.tsx
@@ -5,12 +5,7 @@ const Demo = () => {
 
     return (
         <>
-            <Prompt
-                variant="success"
-                opened={opened}
-                title={<Header variant="secondary">Prompt title</Header>}
-                onClose={close}
-            >
+            <Prompt variant="success" opened={opened} title="Prompt title" onClose={close}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
                 <Prompt.Footer>

--- a/packages/website/src/examples/layout/Prompt/PromptSuccess.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptSuccess.demo.tsx
@@ -1,4 +1,4 @@
-import {Button, Header, Prompt, useDisclosure} from '@coveord/plasma-mantine';
+import {Button, Prompt, useDisclosure} from '@coveord/plasma-mantine';
 
 const Demo = () => {
     const [opened, {open, close}] = useDisclosure();

--- a/packages/website/src/examples/layout/Prompt/PromptWarning.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptWarning.demo.tsx
@@ -13,12 +13,7 @@ const Demo = () => {
 
     return (
         <>
-            <Prompt
-                variant="warning"
-                opened={opened}
-                title={<Header variant="secondary">Prompt title</Header>}
-                onClose={close}
-            >
+            <Prompt variant="warning" opened={opened} title="Prompt title" onClose={close}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim.
                 <Prompt.Footer>

--- a/packages/website/src/examples/layout/Prompt/PromptWarning.demo.tsx
+++ b/packages/website/src/examples/layout/Prompt/PromptWarning.demo.tsx
@@ -1,4 +1,4 @@
-import {Button, Header, Prompt, useDisclosure} from '@coveord/plasma-mantine';
+import {Button, Prompt, useDisclosure} from '@coveord/plasma-mantine';
 
 const Demo = () => {
     const [opened, {open, close}] = useDisclosure();


### PR DESCRIPTION
### Proposed Changes

Updated the prompt to display the title in a `<Header variant="secondary">` if the title is a string
Updated the Modal example to omit the Modal.Title since it renders a `H2` and we put a complex component inside it

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
