### PR TITLE
fix(mantine, input): only add margin top if there's a title or description

### DIFF
--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -221,9 +221,10 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 }
                 return InputClasses;
             },
-            vars: (theme) => ({
+            vars: (theme, props) => ({
                 wrapper: {
-                    '--input-margin-top': theme.spacing.xxs,
+                    '--input-margin-top':
+                        props.wrapperProps?.label || props.wrapperProps?.description ? theme.spacing.xxs : undefined,
                 },
             }),
         }),


### PR DESCRIPTION
### Proposed Changes

Remove the margin-top on Inputs if they don't have a description or label

Before
<img width="596" alt="image" src="https://github.com/user-attachments/assets/abbc6fc6-79ab-4a55-8ca2-56f072ab8bcc" />

After
<img width="594" alt="image" src="https://github.com/user-attachments/assets/eeb6d910-2395-4a64-ad48-22a3b9e23105" />

The difference is minor (4px)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
