### PR TITLE
feat(mantine): improve CopyToClipboard component

### DIFF
--- a/packages/mantine/src/components/copyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/copyToClipboard/CopyToClipboard.tsx
@@ -1,8 +1,8 @@
-import {CheckSize16Px, CopySize16Px} from '@coveord/plasma-react-icons';
-import {ActionIcon, CopyButton, MantineColor, TextInput, Tooltip} from '@mantine/core';
-import {FunctionComponent} from 'react';
+import {IconClipboardCheck, IconClipboardText} from '@coveord/plasma-react-icons';
+import {ActionIcon, ActionIconProps, CopyButton, MantineColor, TextInput, Tooltip} from '@mantine/core';
+import {FunctionComponent, MouseEventHandler} from 'react';
 
-export interface CopyToClipboardProps {
+export interface CopyToClipboardProps extends ActionIconProps {
     /**
      * The value to be copied to the clipboard.
      */
@@ -16,28 +16,49 @@ export interface CopyToClipboardProps {
     /**
      * Called each time the value is copied to the clipboard
      */
-    onCopy?: () => void;
+    onCopy?: MouseEventHandler<HTMLButtonElement>;
     /**
      * The color of the icon when idle
      *
      * @default 'gray'
      */
     color?: MantineColor | (string & {});
+    /**
+     * The text displayed when hovering over the button
+     *
+     * @default 'Copy to clipboard'
+     */
+    tooltipLabelCopy?: string;
+    /**
+     * The text displayed when the value is copied to the clipboard
+     *
+     * @default 'Copied'
+     */
+    tooltipLabelCopied?: string;
 }
 
-const CopyToClipboardButton: FunctionComponent<Omit<CopyToClipboardProps, 'withLabel'>> = ({value, onCopy, color}) => (
+const CopyToClipboardButton: FunctionComponent<Omit<CopyToClipboardProps, 'withLabel'>> = ({
+    value,
+    onCopy,
+    color,
+    tooltipLabelCopy = 'Copy to clipboard',
+    tooltipLabelCopied = 'Copied',
+    ...others
+}) => (
     <CopyButton value={value} timeout={2000}>
         {({copied, copy}) => (
-            <Tooltip label={copied ? 'Copied' : 'Copy'}>
+            <Tooltip label={copied ? tooltipLabelCopied : tooltipLabelCopy}>
                 <ActionIcon
+                    aria-label={tooltipLabelCopy}
                     variant="subtle"
                     color={copied ? 'success' : color}
-                    onClick={() => {
+                    onClick={(clickEvent) => {
                         copy();
-                        onCopy?.();
+                        onCopy?.(clickEvent);
                     }}
+                    {...others}
                 >
-                    {copied ? <CheckSize16Px height={16} /> : <CopySize16Px height={16} />}
+                    {copied ? <IconClipboardCheck size={20} /> : <IconClipboardText size={20} />}
                 </ActionIcon>
             </Tooltip>
         )}


### PR DESCRIPTION
### Proposed Changes

Making improvements to the CopyToClipboard component:
- add access to the click event from the `onCopy` prop
- extend ActionIcon props
- allow overriding tooltip texts
- update icons using the new iconography

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
