### PR TITLE
feat(pagination): +active-bg +active-color

### DIFF
--- a/packages/mantine/src/styles/Pagination.module.css
+++ b/packages/mantine/src/styles/Pagination.module.css
@@ -1,6 +1,7 @@
 .root {
     --pagination-active-bg: var(--mantine-primary-color-light);
     --pagination-active-color: var(--mantine-primary-color-filled);
+    --pagination-control-fz: var(--mantine-font-size-sm);
 }
 
 .control {

--- a/packages/mantine/src/styles/Pagination.module.css
+++ b/packages/mantine/src/styles/Pagination.module.css
@@ -1,7 +1,6 @@
 .root {
     --pagination-active-bg: var(--mantine-primary-color-light);
     --pagination-active-color: var(--mantine-primary-color-filled);
-    --pagination-control-fz: var(--mantine-font-size-sm);
 }
 
 .control {

--- a/packages/mantine/src/styles/Pagination.module.css
+++ b/packages/mantine/src/styles/Pagination.module.css
@@ -1,6 +1,6 @@
 .root {
     --pagination-active-bg: var(--mantine-primary-color-light);
-    --pagination-active-color: var(--mantine-primary-color-5);
+    --pagination-active-color: var(--mantine-primary-color-filled);
 }
 
 .control {

--- a/packages/mantine/src/styles/Pagination.module.css
+++ b/packages/mantine/src/styles/Pagination.module.css
@@ -1,3 +1,8 @@
+.root {
+    --pagination-active-bg: var(--mantine-primary-color-light);
+    --pagination-active-color: var(--mantine-primary-color-5);
+}
+
 .control {
     @mixin where-light {
         border-color: var(--coveo-color-input-border);

--- a/packages/mantine/src/styles/Pagination.module.css
+++ b/packages/mantine/src/styles/Pagination.module.css
@@ -5,6 +5,10 @@
 
 .control {
     @mixin where-light {
-        border-color: var(--coveo-color-input-border);
+        border-color: var(--mantine-color-default-border);
+    }
+
+    &[data-active] {
+        border: none;
     }
 }


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-10590

Added root variables override for active bg-color and active-color with respect to UX recommendations.

[figma](https://www.figma.com/design/lFjxQoLHYzdLObC0g4HdWd/Pretine-7-for-Coveo?node-id=8613-333163&m=dev&focus-id=10073-410423)

Even though UX requested changes for Hover & disabled, we want to make adjustments only through css variables and mantine does not provide any for these two use case. So as a first iteration, we will keep it like this, as close to mantine as possible.

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
