### PR TITLE
Ad UI 10593 apply style radio

### DIFF
--- a/packages/mantine/src/styles/Radio.module.css
+++ b/packages/mantine/src/styles/Radio.module.css
@@ -16,7 +16,7 @@
 
 .radio {
     @mixin light {
-        &[data-error='false'] {
+        &:not([data-disabled]) {
             border-color: var(--coveo-color-input-border);
         }
 

--- a/packages/mantine/src/styles/Radio.module.css
+++ b/packages/mantine/src/styles/Radio.module.css
@@ -1,17 +1,38 @@
 .labelWrapper {
     display: flex;
     align-items: flex-start;
+
+    @mixin light {
+        color: var(--coveo-color-title);
+
+        &[data-disabled] {
+            .label,
+            .description {
+                color: var(--coveo-color-text-disabled);
+            }
+        }
+    }
 }
 
 .radio {
-    @mixin where-light {
+    @mixin light {
         &[data-error='false'] {
             border-color: var(--coveo-color-input-border);
         }
-    }
 
-    &:disabled {
-        background-color: var(--coveo-color-bg-default-disabled);
-        border: none;
+        &:disabled {
+            background-color: var(--coveo-color-bg-disabled);
+        }
+
+        /* mantine hardcodes disabled styles so we need to write custom styles */
+        &[readonly] {
+            border-color: var(--mantine-color-default-border);
+            background-color: var(--coveo-color-bg-readonly);
+            color: var(--coveo-color-text-readonly);
+
+            & + .icon {
+                color: var(--coveo-color-text-readonly);
+            }
+        }
     }
 }

--- a/packages/mantine/src/styles/Radio.module.css
+++ b/packages/mantine/src/styles/Radio.module.css
@@ -2,3 +2,16 @@
     display: flex;
     align-items: flex-start;
 }
+
+.radio {
+    @mixin where-light {
+        &[data-error='false'] {
+            border-color: var(--coveo-color-input-border);
+        }
+    }
+
+    &:disabled {
+        background-color: var(--coveo-color-bg-default-disabled);
+        border: none;
+    }
+}

--- a/packages/mantine/src/styles/Radio.module.css
+++ b/packages/mantine/src/styles/Radio.module.css
@@ -2,9 +2,3 @@
     display: flex;
     align-items: flex-start;
 }
-
-.radio {
-    @mixin where-light {
-        border-color: var(--coveo-color-input-border);
-    }
-}

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -1,4 +1,4 @@
-import {ConvertCSSVariablesInput, CSSVariablesResolver, rgba} from '@mantine/core';
+import {alpha, ConvertCSSVariablesInput, CSSVariablesResolver} from '@mantine/core';
 
 export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
     const result: ConvertCSSVariablesInput = {
@@ -9,7 +9,7 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             '--coveo-color-input-border': theme.colors.gray[3],
             '--coveo-color-title': theme.colors.gray[8],
             '--coveo-color-text-disabled': theme.colors.gray[3],
-            '--coveo-color-bg-default-disabled': rgba(theme.colors.gray[4], 0.1),
+            '--coveo-color-bg-default-disabled': alpha(theme.colors.gray[4], 0.1),
 
             // mantine overrides
             '--mantine-color-default-border': theme.colors.gray[2],

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -1,4 +1,4 @@
-import {ConvertCSSVariablesInput, CSSVariablesResolver} from '@mantine/core';
+import {ConvertCSSVariablesInput, CSSVariablesResolver, rgba} from '@mantine/core';
 
 export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
     const result: ConvertCSSVariablesInput = {
@@ -9,6 +9,7 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             '--coveo-color-input-border': theme.colors.gray[3],
             '--coveo-color-title': theme.colors.gray[8],
             '--coveo-color-text-disabled': theme.colors.gray[3],
+            '--coveo-color-bg-default-disabled': rgba(theme.colors.gray[4], 0.1),
 
             // mantine overrides
             '--mantine-color-default-border': theme.colors.gray[2],

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -9,7 +9,9 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             '--coveo-color-input-border': theme.colors.gray[3],
             '--coveo-color-title': theme.colors.gray[8],
             '--coveo-color-text-disabled': theme.colors.gray[3],
-            '--coveo-color-bg-default-disabled': alpha(theme.colors.gray[4], 0.1),
+            '--coveo-color-bg-disabled': alpha(theme.colors.gray[4], 0.1),
+            '--coveo-color-text-readonly': 'var(--mantine-color-text)',
+            '--coveo-color-bg-readonly': theme.colors.gray[1],
 
             // mantine overrides
             '--mantine-color-default-border': theme.colors.gray[2],


### PR DESCRIPTION
### Proposed Changes

This removes some previous custom style that would remove the builtin visual behavior of the error radio button to reflect mantine better. The ux request cannot be fulfilled completely because of lack of css variable accessible from mantine to cover their demands.

[discussion](https://www.figma.com/design/lFjxQoLHYzdLObC0g4HdWd?node-id=9038-234373&m=dev#1244897930)

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
