### PR TITLE
feat(mantine, loader): custom loader to match figma

### DIFF
--- a/packages/mantine/src/components/loader/CircleLoader.module.css
+++ b/packages/mantine/src/components/loader/CircleLoader.module.css
@@ -1,0 +1,29 @@
+.root {
+    --loader-light-color: var(--mantine-primary-color-light);
+
+    display: inline-block;
+    width: var(--loader-size);
+    height: var(--loader-size);
+
+    &::after {
+        content: '';
+        display: block;
+        width: var(--loader-size);
+        height: var(--loader-size);
+        border-radius: 10000px;
+        border-width: calc(var(--loader-size) / 8);
+        border-style: solid;
+        border-color: var(--loader-light-color) var(--loader-light-color) var(--loader-light-color) var(--loader-color);
+        animation: circle-loader-animation 1.2s linear infinite;
+    }
+}
+
+@keyframes circle-loader-animation {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
+}

--- a/packages/mantine/src/components/loader/CircleLoader.tsx
+++ b/packages/mantine/src/components/loader/CircleLoader.tsx
@@ -1,0 +1,8 @@
+import {Box, MantineLoaderComponent} from '@mantine/core';
+import cx from 'clsx';
+import {forwardRef} from 'react';
+import classes from './CircleLoader.module.css';
+
+export const CircleLoader: MantineLoaderComponent = forwardRef(({className, ...others}, ref) => (
+    <Box component="span" className={cx(classes.root, className)} {...others} ref={ref} />
+));

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -47,6 +47,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import {InfoToken} from '../components';
+import {CircleLoader} from '../components/loader/CircleLoader';
 import ActionIconClasses from '../styles/ActionIcon.module.css';
 import AlertClasses from '../styles/Alert.module.css';
 import BadgeClasses from '../styles/Badge.module.css';
@@ -261,7 +262,8 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         }),
         Loader: Loader.extend({
             defaultProps: {
-                type: 'dots',
+                loaders: {...Loader.defaultLoaders, circle: CircleLoader},
+                type: 'circle',
                 role: 'presentation',
             },
         }),


### PR DESCRIPTION
### Proposed Changes

| Before | After | Figma |
| --- | --- | --- |
| <img width="51" alt="image" src="https://github.com/user-attachments/assets/e6cf32ba-7b29-44d5-8864-19e3e62a7fe9" /> | <img width="50" alt="image" src="https://github.com/user-attachments/assets/14ed0fe6-6e66-497f-89b5-0dbac1c1355f" /> | <img width="50" alt="image" src="https://github.com/user-attachments/assets/e7dccac9-6202-4269-95f8-85d3e6c71bce" /> |

Demo: https://plasma.coveo.com/feature/feat-ADUI-10692-loader-style/mantine/Loader

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
