### PR TITLE
feat(collection): add-data-testid-param-to-collection

### DIFF
--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -243,7 +243,7 @@ export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<H
             draggable={draggable}
             onRemove={() => onRemoveItem?.(index)}
             removable={!(required && hasOnlyOneItem)}
-            data_index={index}
+            testId={`item-${item.id}`}
         >
             {children(item.data, index)}
         </CollectionItem>

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -243,6 +243,7 @@ export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<H
             draggable={draggable}
             onRemove={() => onRemoveItem?.(index)}
             removable={!(required && hasOnlyOneItem)}
+            data_index={index}
         >
             {children(item.data, index)}
         </CollectionItem>

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -243,7 +243,6 @@ export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<H
             draggable={draggable}
             onRemove={() => onRemoveItem?.(index)}
             removable={!(required && hasOnlyOneItem)}
-            testId={`item-${item.id}`}
         >
             {children(item.data, index)}
         </CollectionItem>

--- a/packages/mantine/src/components/collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/collection/CollectionItem.tsx
@@ -8,23 +8,21 @@ import {ActionIcon} from '../action-icon';
 import {useCollectionContext} from './CollectionContext';
 
 interface CollectionItemProps extends CollectionItemSharedProps {
-    data_index: number;
     draggable?: boolean;
     disabled: boolean;
 }
 
 interface CollectionItemSharedProps extends GroupProps {
     id: string;
-    data_index: number;
+    testId: string;
     onRemove?: React.MouseEventHandler<HTMLButtonElement>;
     removable?: boolean;
 }
 
 const RemoveButton: FunctionComponent<{
-    data_index: number;
     onClick: React.MouseEventHandler<HTMLButtonElement>;
-}> = ({onClick, data_index}) => (
-    <ActionIcon.Quaternary data-testid={`remove-${data_index}`} style={{alignSelf: 'center'}} onClick={onClick}>
+}> = ({onClick}) => (
+    <ActionIcon.Quaternary style={{alignSelf: 'center'}} onClick={onClick}>
         <IconCircleMinus aria-label="Remove" size={20} />
     </ActionIcon.Quaternary>
 );
@@ -33,46 +31,49 @@ const RemoveButtonPlaceholder = () => <div style={{width: 28}} />;
 
 const StaticCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
     onRemove,
-    data_index,
     removable = true,
+    testId,
     children,
 }) => {
     const ctx = useCollectionContext();
-    const removeButton =
-        removable && onRemove ? (
-            <RemoveButton data_index={data_index} onClick={onRemove} />
-        ) : (
-            <RemoveButtonPlaceholder />
-        );
+    const removeButton = removable && onRemove ? <RemoveButton onClick={onRemove} /> : <RemoveButtonPlaceholder />;
 
     return (
-        <Group {...ctx.getStyles('item')}>
+        <Group data-testid={testId} {...ctx.getStyles('item')}>
             {children}
             {removeButton}
         </Group>
     );
 };
 
-const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({children}) => {
+const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
+    children,
+    testId,
+}) => {
     const ctx = useCollectionContext();
-    return <Group {...ctx.getStyles('item')}>{children}</Group>;
+    return (
+        <Group data-testid={testId} {...ctx.getStyles('item')}>
+            {children}
+        </Group>
+    );
 };
 
 const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
     id,
     onRemove,
-    data_index,
+    testId,
     removable = true,
     children,
 }) => {
     const ctx = useCollectionContext();
-    const removeButton = removable && onRemove ? <RemoveButton data_index={data_index} onClick={onRemove} /> : null;
+    const removeButton = removable && onRemove ? <RemoveButton onClick={onRemove} /> : null;
     const {attributes, listeners, setNodeRef, transform, transition, isDragging, setActivatorNodeRef} = useSortable({
         id,
     });
 
     return (
         <Group
+            data-testid={testId}
             ref={setNodeRef}
             {...ctx.getStyles('item', {
                 style: transform

--- a/packages/mantine/src/components/collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/collection/CollectionItem.tsx
@@ -8,20 +8,23 @@ import {ActionIcon} from '../action-icon';
 import {useCollectionContext} from './CollectionContext';
 
 interface CollectionItemProps extends CollectionItemSharedProps {
+    data_index: number;
     draggable?: boolean;
     disabled: boolean;
 }
 
 interface CollectionItemSharedProps extends GroupProps {
     id: string;
+    data_index: number;
     onRemove?: React.MouseEventHandler<HTMLButtonElement>;
     removable?: boolean;
 }
 
 const RemoveButton: FunctionComponent<{
+    data_index: number;
     onClick: React.MouseEventHandler<HTMLButtonElement>;
-}> = ({onClick}) => (
-    <ActionIcon.Quaternary style={{alignSelf: 'center'}} onClick={onClick}>
+}> = ({onClick, data_index}) => (
+    <ActionIcon.Quaternary data-testid={`remove-${data_index}`} style={{alignSelf: 'center'}} onClick={onClick}>
         <IconCircleMinus aria-label="Remove" size={20} />
     </ActionIcon.Quaternary>
 );
@@ -30,11 +33,17 @@ const RemoveButtonPlaceholder = () => <div style={{width: 28}} />;
 
 const StaticCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
     onRemove,
+    data_index,
     removable = true,
     children,
 }) => {
     const ctx = useCollectionContext();
-    const removeButton = removable && onRemove ? <RemoveButton onClick={onRemove} /> : <RemoveButtonPlaceholder />;
+    const removeButton =
+        removable && onRemove ? (
+            <RemoveButton data_index={data_index} onClick={onRemove} />
+        ) : (
+            <RemoveButtonPlaceholder />
+        );
 
     return (
         <Group {...ctx.getStyles('item')}>
@@ -52,11 +61,12 @@ const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItem
 const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
     id,
     onRemove,
+    data_index,
     removable = true,
     children,
 }) => {
     const ctx = useCollectionContext();
-    const removeButton = removable && onRemove ? <RemoveButton onClick={onRemove} /> : null;
+    const removeButton = removable && onRemove ? <RemoveButton data_index={data_index} onClick={onRemove} /> : null;
     const {attributes, listeners, setNodeRef, transform, transition, isDragging, setActivatorNodeRef} = useSortable({
         id,
     });

--- a/packages/mantine/src/components/collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/collection/CollectionItem.tsx
@@ -14,7 +14,6 @@ interface CollectionItemProps extends CollectionItemSharedProps {
 
 interface CollectionItemSharedProps extends GroupProps {
     id: string;
-    testId: string;
     onRemove?: React.MouseEventHandler<HTMLButtonElement>;
     removable?: boolean;
 }
@@ -32,27 +31,24 @@ const RemoveButtonPlaceholder = () => <div style={{width: 28}} />;
 const StaticCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
     onRemove,
     removable = true,
-    testId,
+    id,
     children,
 }) => {
     const ctx = useCollectionContext();
     const removeButton = removable && onRemove ? <RemoveButton onClick={onRemove} /> : <RemoveButtonPlaceholder />;
 
     return (
-        <Group data-testid={testId} {...ctx.getStyles('item')}>
+        <Group data-testid={`item-${id}`} {...ctx.getStyles('item')}>
             {children}
             {removeButton}
         </Group>
     );
 };
 
-const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
-    children,
-    testId,
-}) => {
+const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({id, children}) => {
     const ctx = useCollectionContext();
     return (
-        <Group data-testid={testId} {...ctx.getStyles('item')}>
+        <Group data-testid={`item-${id}`} {...ctx.getStyles('item')}>
             {children}
         </Group>
     );
@@ -61,7 +57,6 @@ const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItem
 const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = ({
     id,
     onRemove,
-    testId,
     removable = true,
     children,
 }) => {
@@ -73,7 +68,7 @@ const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionIte
 
     return (
         <Group
-            data-testid={testId}
+            data-testid={`item-${id}`}
             ref={setNodeRef}
             {...ctx.getStyles('item', {
                 style: transform

--- a/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
+++ b/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
@@ -13,7 +13,7 @@ describe('Collection', () => {
             });
             return (
                 <Collection<string> newItem="" {...form.getInputProps('fruits')}>
-                    {(name) => <span data-testid={'item'}>{name}</span>}
+                    {(name) => <span data-testid="item">{name}</span>}
                 </Collection>
             );
         };
@@ -29,7 +29,7 @@ describe('Collection', () => {
     });
 
     it('renders one item for each initial values in the form with custom id', () => {
-        const getItemId = vi.fn((item) => `id-${item}`);
+        const getItemId = (item: any) => `id-${item}`;
 
         const Fixture = () => {
             const form = useForm({
@@ -38,7 +38,7 @@ describe('Collection', () => {
             });
             return (
                 <Collection<string> getItemId={getItemId} newItem="" {...form.getInputProps('fruits')}>
-                    {(name) => <span data-testid={'item'}>{name}</span>}
+                    {(name) => <span data-testid="item">{name}</span>}
                 </Collection>
             );
         };
@@ -63,7 +63,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -85,8 +85,8 @@ describe('Collection', () => {
     });
 
     it('removes the item when clicking on its remove button with custom id', async () => {
-        const user = userEvent.setup({delay: null});
-        const getItemId = vi.fn((item) => `id-${item}`);
+        const user = userEvent.setup();
+        const getItemId = (item: any) => `id-${item}`;
 
         const Fixture = () => {
             const form = useForm({
@@ -96,7 +96,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection getItemId={getItemId} newItem="" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -135,7 +135,7 @@ describe('Collection', () => {
                     {...form.getInputProps('fruits')}
                     onRemoveItem={onRemoveItemSpy}
                 >
-                    {(name) => <span data-testid={'item'}>{name}</span>}
+                    {(name) => <span data-testid="item">{name}</span>}
                 </Collection>
             );
         };
@@ -166,7 +166,7 @@ describe('Collection', () => {
                 <>
                     <button onClick={() => setDisabled(true)}>disable</button>
                     <Collection newItem="" {...form.getInputProps('fruits')} disabled={disabled}>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                 </>
             );
@@ -188,7 +188,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="new" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -210,7 +210,7 @@ describe('Collection', () => {
 
     it('adds a new item when clicking on the add button with custom id', async () => {
         const user = userEvent.setup({delay: null});
-        const getItemId = vi.fn((item) => `id-${item}`);
+        const getItemId = (item: any) => `id-${item}`;
         const Fixture = () => {
             const form = useForm({
                 initialValues: {fruits: ['banana', 'orange']},
@@ -219,7 +219,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection getItemId={getItemId} newItem="new" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -249,7 +249,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="new" {...form.getInputProps('fruits')} allowAdd={allowAdd}>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -274,7 +274,7 @@ describe('Collection', () => {
                 });
                 return (
                     <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                 );
             };
@@ -296,7 +296,7 @@ describe('Collection', () => {
                 });
                 return (
                     <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                 );
             };
@@ -324,7 +324,7 @@ describe('Collection', () => {
                 });
                 return (
                     <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid={'item'}>{name}</span>}
+                        {(name) => <span data-testid="item">{name}</span>}
                     </Collection>
                 );
             };
@@ -361,7 +361,7 @@ describe('Collection', () => {
                 return (
                     <>
                         <Collection newItem="new" {...form.getInputProps('fruits')} draggable>
-                            {(name) => <span data-testid={'item'}>{name}</span>}
+                            {(name) => <span data-testid="item">{name}</span>}
                         </Collection>
                     </>
                 );
@@ -389,7 +389,7 @@ describe('Collection', () => {
                             required
                             draggable
                         >
-                            {(name) => <span data-testid={'item'}>{name}</span>}
+                            {(name) => <span data-testid="item">{name}</span>}
                         </Collection>
                     );
                 };

--- a/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
+++ b/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
@@ -13,17 +13,19 @@ describe('Collection', () => {
             });
             return (
                 <Collection<string> newItem="" {...form.getInputProps('fruits')}>
-                    {(name) => <span data-testid="item">{name}</span>}
+                    {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                 </Collection>
             );
         };
 
         render(<Fixture />);
 
-        const items = screen.getAllByTestId('item');
+        const items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(2);
         expect(items[0]).toHaveTextContent('banana');
         expect(items[1]).toHaveTextContent('orange');
+        expect(screen.getByTestId('remove-0')).toBeInTheDocument();
+        expect(screen.getByTestId('remove-1')).toBeInTheDocument();
     });
 
     it('removes the item when clicking on its remove button', async () => {
@@ -36,7 +38,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -44,16 +46,18 @@ describe('Collection', () => {
         };
 
         render(<Fixture />);
-        let items = screen.getAllByTestId('item');
+        let items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(2);
 
         const removeBanana = await within(items[0].parentElement).findByRole('button', {name: /remove/i});
 
         await user.click(removeBanana);
 
-        items = screen.getAllByTestId('item');
-        expect(screen.getAllByTestId('item')).toHaveLength(1);
-        expect(items[0]).toHaveTextContent('orange');
+        items = screen.getAllByTestId(/item-/);
+        expect(items).toHaveLength(1);
+        expect(screen.queryByTestId('item-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('remove-1')).not.toBeInTheDocument();
+        expect(screen.getByTestId('item-0')).toHaveTextContent('orange');
         expect(screen.getByTestId('form-state')).toHaveTextContent('{"fruits":["orange"]}');
     });
 
@@ -66,22 +70,25 @@ describe('Collection', () => {
                 enhanceGetInputProps: (payload) => ({...enhanceWithCollectionProps(payload, 'fruits')}),
             });
             return (
-                <Collection newItem="" {...form.getInputProps('fruits')} onRemoveItem={onRemoveItemSpy}>
-                    {(name) => <span data-testid="item">{name}</span>}
+                <Collection
+                    data-testid="collection"
+                    newItem=""
+                    {...form.getInputProps('fruits')}
+                    onRemoveItem={onRemoveItemSpy}
+                >
+                    {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                 </Collection>
             );
         };
 
         render(<Fixture />);
-        let items = screen.getAllByTestId('item');
+        const items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(2);
-
         const removeOrange = await within(items[1].parentElement).findByRole('button', {name: /remove/i});
         await user.click(removeOrange);
 
         expect(onRemoveItemSpy).toHaveBeenCalledWith(1);
 
-        items = screen.getAllByTestId('item');
         const removeBanana = await within(items[0].parentElement).findByRole('button', {name: /remove/i});
         await user.click(removeBanana);
 
@@ -100,7 +107,7 @@ describe('Collection', () => {
                 <>
                     <button onClick={() => setDisabled(true)}>disable</button>
                     <Collection newItem="" {...form.getInputProps('fruits')} disabled={disabled}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                     </Collection>
                 </>
             );
@@ -122,7 +129,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="new" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -133,11 +140,12 @@ describe('Collection', () => {
         const addItem = screen.getByRole('button', {name: /add/i});
         await user.click(addItem);
 
-        const items = screen.getAllByTestId('item');
+        const items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(3);
         expect(items[0]).toHaveTextContent('banana');
         expect(items[1]).toHaveTextContent('orange');
         expect(items[2]).toHaveTextContent('new');
+        expect(screen.getByTestId('remove-2')).toBeInTheDocument();
         expect(screen.getByTestId('form-state')).toHaveTextContent('{"fruits":["banana","orange","new"]}');
     });
 
@@ -151,7 +159,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="new" {...form.getInputProps('fruits')} allowAdd={allowAdd}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -176,7 +184,7 @@ describe('Collection', () => {
                 });
                 return (
                     <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                     </Collection>
                 );
             };
@@ -185,7 +193,7 @@ describe('Collection', () => {
 
             expect(screen.queryByRole('button', {name: /remove/i})).not.toBeInTheDocument();
 
-            const items = screen.getAllByTestId('item');
+            const items = screen.getAllByTestId(/item-/);
             expect(items).toHaveLength(1);
             expect(items[0]).toHaveTextContent('banana');
         });
@@ -198,7 +206,7 @@ describe('Collection', () => {
                 });
                 return (
                     <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                     </Collection>
                 );
             };
@@ -209,7 +217,7 @@ describe('Collection', () => {
             const removeButtons = screen.queryAllByRole('button', {name: /remove/i});
             expect(removeButtons).toHaveLength(2);
 
-            const items = screen.getAllByTestId('item');
+            const items = screen.getAllByTestId(/item-/);
             expect(items).toHaveLength(2);
             expect(items[0]).toHaveTextContent('banana');
             expect(items[1]).toHaveTextContent('orange');
@@ -224,7 +232,7 @@ describe('Collection', () => {
                 });
                 return (
                     <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                     </Collection>
                 );
             };
@@ -236,7 +244,7 @@ describe('Collection', () => {
             const removeButtons = screen.queryAllByRole('button', {name: /remove/i});
             expect(removeButtons).toHaveLength(2);
 
-            const items = screen.getAllByTestId('item');
+            const items = screen.getAllByTestId(/item-/);
             expect(items).toHaveLength(2);
             expect(items[0]).toHaveTextContent('banana');
             expect(items[1]).toHaveTextContent('orange');
@@ -257,7 +265,7 @@ describe('Collection', () => {
                 return (
                     <>
                         <Collection newItem="new" {...form.getInputProps('fruits')} draggable>
-                            {(name) => <span data-testid="item">{name}</span>}
+                            {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                         </Collection>
                     </>
                 );
@@ -285,7 +293,7 @@ describe('Collection', () => {
                             required
                             draggable
                         >
-                            {(name) => <span data-testid="item">{name}</span>}
+                            {(name, index) => <span data-testid={`item-${index}`}>{name}</span>}
                         </Collection>
                     );
                 };
@@ -297,7 +305,7 @@ describe('Collection', () => {
                 const removeButtons = screen.queryAllByRole('button', {name: /remove/i});
                 expect(removeButtons).toHaveLength(2);
 
-                const items = screen.getAllByTestId('item');
+                const items = screen.getAllByTestId(/item-/);
                 expect(items).toHaveLength(2);
                 expect(items[0]).toHaveTextContent('banana');
                 expect(items[1]).toHaveTextContent('orange');

--- a/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
+++ b/packages/mantine/src/components/collection/__tests__/Collection.spec.tsx
@@ -13,14 +13,14 @@ describe('Collection', () => {
             });
             return (
                 <Collection<string> newItem="" {...form.getInputProps('fruits')}>
-                    {(name) => <span data-testid="item">{name}</span>}
+                    {(name) => <span>{name}</span>}
                 </Collection>
             );
         };
 
         render(<Fixture />);
 
-        const items = screen.getAllByTestId('item');
+        const items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(2);
         expect(screen.queryByTestId('item-0')).toHaveTextContent('banana');
         expect(screen.queryByTestId('item-1')).toHaveTextContent('orange');
@@ -29,7 +29,7 @@ describe('Collection', () => {
     });
 
     it('renders one item for each initial values in the form with custom id', () => {
-        const getItemId = (item: any) => `id-${item}`;
+        const getItemId = (item: string) => `id-${item}`;
 
         const Fixture = () => {
             const form = useForm({
@@ -38,14 +38,14 @@ describe('Collection', () => {
             });
             return (
                 <Collection<string> getItemId={getItemId} newItem="" {...form.getInputProps('fruits')}>
-                    {(name) => <span data-testid="item">{name}</span>}
+                    {(name) => <span>{name}</span>}
                 </Collection>
             );
         };
 
         render(<Fixture />);
 
-        const items = screen.getAllByTestId('item');
+        const items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(2);
         expect(items[0]).toHaveTextContent('banana');
         expect(items[1]).toHaveTextContent('orange');
@@ -54,7 +54,7 @@ describe('Collection', () => {
     });
 
     it('removes the item when clicking on its remove button', async () => {
-        const user = userEvent.setup({delay: null});
+        const user = userEvent.setup();
         const Fixture = () => {
             const form = useForm({
                 initialValues: {fruits: ['banana', 'orange']},
@@ -63,7 +63,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name) => <span>{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -71,13 +71,13 @@ describe('Collection', () => {
         };
 
         render(<Fixture />);
-        let items = screen.getAllByTestId('item');
+        let items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(2);
 
         const removeBanana = await within(screen.getByTestId('item-0')).findByRole('button', {name: /remove/i});
         await user.click(removeBanana);
 
-        items = screen.getAllByTestId('item');
+        items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(1);
         expect(items[0]).toHaveTextContent('orange');
         expect(screen.queryByTestId('item-1')).not.toBeInTheDocument();
@@ -86,7 +86,7 @@ describe('Collection', () => {
 
     it('removes the item when clicking on its remove button with custom id', async () => {
         const user = userEvent.setup();
-        const getItemId = (item: any) => `id-${item}`;
+        const getItemId = (item: string) => `id-${item}`;
 
         const Fixture = () => {
             const form = useForm({
@@ -96,7 +96,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection getItemId={getItemId} newItem="" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name) => <span>{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -104,7 +104,7 @@ describe('Collection', () => {
         };
 
         render(<Fixture />);
-        let items = screen.getAllByTestId('item');
+        let items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(2);
 
         const removeBanana = await within(screen.queryByTestId('item-id-banana')).findByRole('button', {
@@ -112,7 +112,7 @@ describe('Collection', () => {
         });
         await user.click(removeBanana);
 
-        items = screen.getAllByTestId('item');
+        items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(1);
         expect(items[0]).toHaveTextContent('orange');
         expect(screen.getByTestId('item-id-orange')).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe('Collection', () => {
     });
 
     it('calls the onRemoveItem function when clicking on a remove button', async () => {
-        const user = userEvent.setup({delay: null});
+        const user = userEvent.setup();
         const onRemoveItemSpy = vi.fn();
         const Fixture = () => {
             const form = useForm({
@@ -129,19 +129,14 @@ describe('Collection', () => {
                 enhanceGetInputProps: (payload) => ({...enhanceWithCollectionProps(payload, 'fruits')}),
             });
             return (
-                <Collection
-                    data-testid="collection"
-                    newItem=""
-                    {...form.getInputProps('fruits')}
-                    onRemoveItem={onRemoveItemSpy}
-                >
-                    {(name) => <span data-testid="item">{name}</span>}
+                <Collection newItem="" {...form.getInputProps('fruits')} onRemoveItem={onRemoveItemSpy}>
+                    {(name) => <span>{name}</span>}
                 </Collection>
             );
         };
 
         render(<Fixture />);
-        const items = screen.getAllByTestId('item');
+        const items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(2);
         const removeOrange = await within(screen.queryByTestId('item-1')).findByRole('button', {name: /remove/i});
         await user.click(removeOrange);
@@ -155,7 +150,7 @@ describe('Collection', () => {
     });
 
     it('does not render the remove button when disabled', async () => {
-        const user = userEvent.setup({delay: null});
+        const user = userEvent.setup();
         const Fixture = () => {
             const [disabled, setDisabled] = useState(false);
             const form = useForm({
@@ -166,7 +161,7 @@ describe('Collection', () => {
                 <>
                     <button onClick={() => setDisabled(true)}>disable</button>
                     <Collection newItem="" {...form.getInputProps('fruits')} disabled={disabled}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name) => <span>{name}</span>}
                     </Collection>
                 </>
             );
@@ -179,7 +174,7 @@ describe('Collection', () => {
     });
 
     it('adds a new item when clicking on the add button', async () => {
-        const user = userEvent.setup({delay: null});
+        const user = userEvent.setup();
         const Fixture = () => {
             const form = useForm({
                 initialValues: {fruits: ['banana', 'orange']},
@@ -188,7 +183,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="new" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name) => <span>{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -199,7 +194,7 @@ describe('Collection', () => {
         const addItem = screen.getByRole('button', {name: /add/i});
         await user.click(addItem);
 
-        const items = screen.getAllByTestId('item');
+        const items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(3);
         expect(items[0]).toHaveTextContent('banana');
         expect(items[1]).toHaveTextContent('orange');
@@ -209,8 +204,8 @@ describe('Collection', () => {
     });
 
     it('adds a new item when clicking on the add button with custom id', async () => {
-        const user = userEvent.setup({delay: null});
-        const getItemId = (item: any) => `id-${item}`;
+        const user = userEvent.setup();
+        const getItemId = (item: string) => `id-${item}`;
         const Fixture = () => {
             const form = useForm({
                 initialValues: {fruits: ['banana', 'orange']},
@@ -219,7 +214,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection getItemId={getItemId} newItem="new" {...form.getInputProps('fruits')}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name) => <span>{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -230,7 +225,7 @@ describe('Collection', () => {
         const addItem = screen.getByRole('button', {name: /add/i});
         await user.click(addItem);
 
-        const items = screen.getAllByTestId('item');
+        const items = screen.getAllByTestId(/item-/);
         expect(items).toHaveLength(3);
         expect(items[0]).toHaveTextContent('banana');
         expect(items[1]).toHaveTextContent('orange');
@@ -249,7 +244,7 @@ describe('Collection', () => {
             return (
                 <>
                     <Collection newItem="new" {...form.getInputProps('fruits')} allowAdd={allowAdd}>
-                        {(name) => <span data-testid="item">{name}</span>}
+                        {(name) => <span>{name}</span>}
                     </Collection>
                     <div data-testid="form-state">{JSON.stringify(form.values)}</div>
                 </>
@@ -273,8 +268,8 @@ describe('Collection', () => {
                     enhanceGetInputProps: (payload) => ({...enhanceWithCollectionProps(payload, 'fruits')}),
                 });
                 return (
-                    <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid="item">{name}</span>}
+                    <Collection {...form.getInputProps('fruits')} newItem="new" required>
+                        {(name) => <span>{name}</span>}
                     </Collection>
                 );
             };
@@ -283,7 +278,7 @@ describe('Collection', () => {
 
             expect(screen.queryByRole('button', {name: /remove/i})).not.toBeInTheDocument();
 
-            const items = screen.getAllByTestId('item');
+            const items = screen.getAllByTestId(/item-/);
             expect(items).toHaveLength(1);
             expect(items[0]).toHaveTextContent('banana');
         });
@@ -295,8 +290,8 @@ describe('Collection', () => {
                     enhanceGetInputProps: (payload) => ({...enhanceWithCollectionProps(payload, 'fruits')}),
                 });
                 return (
-                    <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid="item">{name}</span>}
+                    <Collection {...form.getInputProps('fruits')} newItem="new" required>
+                        {(name) => <span>{name}</span>}
                     </Collection>
                 );
             };
@@ -307,7 +302,7 @@ describe('Collection', () => {
             const removeButtons = screen.queryAllByRole('button', {name: /remove/i});
             expect(removeButtons).toHaveLength(2);
 
-            const items = screen.getAllByTestId('item');
+            const items = screen.getAllByTestId(/item-/);
             expect(items).toHaveLength(2);
             expect(items[0]).toHaveTextContent('banana');
             expect(items[1]).toHaveTextContent('orange');
@@ -316,15 +311,15 @@ describe('Collection', () => {
         });
 
         it('not render the remove button after removing an item from a collection containing two items', async () => {
-            const user = userEvent.setup({delay: null});
+            const user = userEvent.setup();
             const Fixture = () => {
                 const form = useForm({
                     initialValues: {fruits: ['banana', 'orange']},
                     enhanceGetInputProps: (payload) => ({...enhanceWithCollectionProps(payload, 'fruits')}),
                 });
                 return (
-                    <Collection data-testid="collection" {...form.getInputProps('fruits')} newItem="new" required>
-                        {(name) => <span data-testid="item">{name}</span>}
+                    <Collection {...form.getInputProps('fruits')} newItem="new" required>
+                        {(name) => <span>{name}</span>}
                     </Collection>
                 );
             };
@@ -336,7 +331,7 @@ describe('Collection', () => {
             const removeButtons = screen.queryAllByRole('button', {name: /remove/i});
             expect(removeButtons).toHaveLength(2);
 
-            const items = screen.getAllByTestId('item');
+            const items = screen.getAllByTestId(/item-/);
             expect(items).toHaveLength(2);
             expect(items[0]).toHaveTextContent('banana');
             expect(items[1]).toHaveTextContent('orange');
@@ -361,7 +356,7 @@ describe('Collection', () => {
                 return (
                     <>
                         <Collection newItem="new" {...form.getInputProps('fruits')} draggable>
-                            {(name) => <span data-testid="item">{name}</span>}
+                            {(name) => <span>{name}</span>}
                         </Collection>
                     </>
                 );
@@ -375,21 +370,15 @@ describe('Collection', () => {
 
         describe('when required is true', () => {
             it('not render the remove button after removing an item from a collection containing two items', async () => {
-                const user = userEvent.setup({delay: null});
+                const user = userEvent.setup();
                 const Fixture = () => {
                     const form = useForm({
                         initialValues: {fruits: ['banana', 'orange']},
                         enhanceGetInputProps: (payload) => ({...enhanceWithCollectionProps(payload, 'fruits')}),
                     });
                     return (
-                        <Collection
-                            data-testid="collection"
-                            {...form.getInputProps('fruits')}
-                            newItem="new"
-                            required
-                            draggable
-                        >
-                            {(name) => <span data-testid="item">{name}</span>}
+                        <Collection {...form.getInputProps('fruits')} newItem="new" required draggable>
+                            {(name) => <span>{name}</span>}
                         </Collection>
                     );
                 };
@@ -401,7 +390,7 @@ describe('Collection', () => {
                 const removeButtons = screen.queryAllByRole('button', {name: /remove/i});
                 expect(removeButtons).toHaveLength(2);
 
-                const items = screen.getAllByTestId('item');
+                const items = screen.getAllByTestId(/item-/);
                 expect(items).toHaveLength(2);
                 expect(items[0]).toHaveTextContent('banana');
                 expect(items[1]).toHaveTextContent('orange');


### PR DESCRIPTION
### Proposed Changes

Added data-testid attribute to remove buttons that has the matching CollectionItem item ids. This way we can differentiate between remove buttons of the same collection.

[Jira Link](https://coveord.atlassian.net/browse/ADUI-10483?atlOrigin=eyJpIjoiMWEzNTUxOTY4ZThkNGYyODgzZDJjMjBiNWNiMTdlZWEiLCJwIjoiaiJ9)

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
