### PR TITLE
feat(mantine, tabs): update the style

### DIFF
--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -67,11 +67,14 @@
 /* Table.Header */
 .headerRoot {
     border-bottom: 1px solid var(--mantine-color-default-border);
-    border-top: 1px solid var(--mantine-color-default-border);
     background-color: var(--mantine-color-gray-light);
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-xl);
     position: relative;
     min-height: 69px;
+
+    &:where([data-with-border-top]) {
+        border-top: 1px solid var(--mantine-color-default-border);
+    }
 }
 
 .headerGridInner {

--- a/packages/mantine/src/components/table/table-header/TableHeader.tsx
+++ b/packages/mantine/src/components/table/table-header/TableHeader.tsx
@@ -23,6 +23,12 @@ export interface TableHeaderProps
      * default true
      */
     showActions?: boolean;
+    /**
+     * Whether to show a border on top of the header
+     *
+     * default true
+     */
+    borderTop?: boolean;
 }
 
 export type TableHeaderFactory = Factory<{
@@ -36,6 +42,7 @@ const defaultProps: Partial<TableHeaderProps> = {
     unselectAllLabel: 'Unselect all',
     selectedCountLabel: (count) => `${count} selected`,
     showActions: true,
+    borderTop: true,
 };
 
 export const TableHeader = factory<TableHeaderFactory>((props, ref) => {
@@ -44,6 +51,7 @@ export const TableHeader = factory<TableHeaderFactory>((props, ref) => {
         showActions,
         unselectAllLabel,
         selectedCountLabel,
+        borderTop,
         children,
         classNames,
         className,
@@ -59,7 +67,12 @@ export const TableHeader = factory<TableHeaderFactory>((props, ref) => {
     const gridStyles = getStyles('headerGrid', stylesApiProps);
 
     return (
-        <Box ref={ref} {...getStyles('headerRoot', {className, style, ...stylesApiProps})} {...others}>
+        <Box
+            ref={ref}
+            {...getStyles('headerRoot', {className, style, ...stylesApiProps})}
+            {...others}
+            mod={{'with-border-top': borderTop}}
+        >
             <Grid
                 justify="flex-start"
                 align="center"

--- a/packages/mantine/src/styles/Tabs.module.css
+++ b/packages/mantine/src/styles/Tabs.module.css
@@ -32,8 +32,14 @@
     line-height: 1.5;
     color: var(--mantine-color-dimmed);
 
+    &:not(:disabled, [data-disabled]) {
+        @mixin hover {
+            color: var(--coveo-color-title);
+        }
+    }
+
     &:where(:disabled, [data-disabled]) {
-        opacity: 1; /* Override Mantine's 0.5 */
+        opacity: 1 !important; /* Override Mantine's 0.5 */
         color: var(--coveo-color-text-disabled);
     }
 

--- a/packages/mantine/src/styles/Tabs.module.css
+++ b/packages/mantine/src/styles/Tabs.module.css
@@ -1,18 +1,44 @@
 .root {
+    --tab-active-border-width: calc(3px - var(--tabs-list-border-width));
+    --tab-box-shadow: 0 calc(-1 * var(--tab-active-border-width));
+
+    &[data-inverted] {
+        --tab-box-shadow: 0 var(--tab-active-border-width);
+    }
+
+    &[data-orientation='vertical'] {
+        --tab-box-shadow: calc(-1 * var(--tab-active-border-width)) 0;
+    }
+
+    &[data-placement='right'] {
+        --tab-box-shadow: var(--tab-active-border-width) 0;
+    }
+
     &[data-variant='default'] {
-        &[data-orientation='horizontal'] {
-            .list {
-                margin-bottom: calc(-1 * var(--tabs-list-border-width));
-            }
-        }
+        --tabs-list-border-width: 1px;
     }
 
     @mixin light {
         --tab-border-color: var(--mantine-color-default-border);
+
+        &[data-variant='default'] {
+            --tab-hover-color: var(--mantine-color-default-hover);
+        }
     }
 }
 
 .tab {
     font-weight: 500;
     line-height: 1.5;
+    color: var(--mantine-color-dimmed);
+
+    &:where(:disabled, [data-disabled]) {
+        opacity: 1; /* Override Mantine's 0.5 */
+        color: var(--coveo-color-text-disabled);
+    }
+
+    &:where([data-active]) {
+        color: var(--coveo-color-title);
+        box-shadow: inset var(--tab-box-shadow) var(--tabs-color);
+    }
 }

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -70,7 +70,8 @@ const Demo = () => {
                 },
             ]}
         >
-            <Table.Header />
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false} />
         </Table>
     );
 };

--- a/packages/website/src/examples/layout/Table/TableClientSide.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableClientSide.demo.tsx
@@ -71,7 +71,8 @@ const Demo = () => {
     });
     return (
         <Table<Person> store={table} data={data} columns={columns} options={options} getRowId={({id}) => id}>
-            <Table.Header>
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false}>
                 <Table.Filter placeholder="Search" />
             </Table.Header>
             <Table.Footer>

--- a/packages/website/src/examples/layout/Table/TableColumnsSelector.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableColumnsSelector.demo.tsx
@@ -62,7 +62,8 @@ const Demo = () => {
 
     return (
         <Table store={table} data={data} getRowId={({employeeId}) => employeeId?.toString()} columns={columns}>
-            <Table.Header>
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false}>
                 <Table.ColumnsSelector
                     label="Edit columns"
                     maxSelectableColumns={5}

--- a/packages/website/src/examples/layout/Table/TableConfirmAction.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableConfirmAction.demo.tsx
@@ -62,7 +62,8 @@ const Demo = () => {
                 },
             ]}
         >
-            <Table.Header />
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false} />
         </Table>
     );
 };

--- a/packages/website/src/examples/layout/Table/TableDateRangePicker.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableDateRangePicker.demo.tsx
@@ -70,7 +70,8 @@ const Demo = () => {
             options={options}
             getRowId={({id}) => id.toString()}
         >
-            <Table.Header>
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false}>
                 <Table.DateRangePicker
                     rangeCalendarProps={{maxDate: dayjs().endOf('day').toDate()}}
                     presets={datePickerPresets}

--- a/packages/website/src/examples/layout/Table/TableDisabledRowSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableDisabledRowSelection.demo.tsx
@@ -56,7 +56,8 @@ const Demo = () => {
             columns={columns}
             options={options}
         >
-            <Table.Header>
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false}>
                 <Table.Filter placeholder="Search posts by title" />
             </Table.Header>
             <Table.NoData>

--- a/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
@@ -95,7 +95,8 @@ const Demo = () => {
                 },
             ]}
         >
-            <Table.Header />
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false} />
         </Table>
     );
 };

--- a/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableMultiSelection.demo.tsx
@@ -106,7 +106,8 @@ const Demo = () => {
                       ]
             }
         >
-            <Table.Header>
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false}>
                 <Table.Filter placeholder="Search posts by title" />
             </Table.Header>
             <Table.NoData>

--- a/packages/website/src/examples/layout/Table/TablePredicate.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TablePredicate.demo.tsx
@@ -45,7 +45,8 @@ const Demo = () => {
 
     return (
         <Table<Person> store={table} data={filteredData} columns={columns} getRowId={({id}) => id.toString()}>
-            <Table.Header>
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false}>
                 <Table.Predicate
                     id="age"
                     label="Age group"

--- a/packages/website/src/examples/layout/Table/TableReactQuery.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableReactQuery.demo.tsx
@@ -63,7 +63,8 @@ const Demo = () => {
             loading={query.isLoading || query.isFetching}
             getRowId={({id}) => id.toString()}
         >
-            <Table.Header>
+            {/* Table demo is in a card with a border, remove the one from the header */}
+            <Table.Header borderTop={false}>
                 <Table.Filter placeholder="Search posts by title" />
             </Table.Header>
             <Table.NoData>


### PR DESCRIPTION
### Proposed Changes

Updated the style of the Tab component to match latest UX design

Before 
<img width="387" alt="image" src="https://github.com/user-attachments/assets/870f703d-021b-4396-9686-801307f1ca45" />

After
<img width="388" alt="image" src="https://github.com/user-attachments/assets/d00687fc-249a-4af8-8237-7f01f2c349e2" />

Gallery is hovered, Settings disabled, Account is default and Chat is selected

Figma:
<img width="441" alt="image" src="https://github.com/user-attachments/assets/7c64c331-45b8-4e15-aad3-886735cdd7df" />


I also added a new optional `borderTop` prop on the Table (with a default of true). And updated the demo to remove the double border. We'll be able to do the same thing when one tab first child is a Table with an Header


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
