### PR TITLE
fix(mantine): gray-light and gray-light-hover transparency

### DIFF
--- a/packages/mantine/src/components/info-token/InfoToken.tsx
+++ b/packages/mantine/src/components/info-token/InfoToken.tsx
@@ -62,7 +62,7 @@ const colorResolver = (variant: InfoTokenVariant): string => {
             return 'var(--mantine-color-yellow-filled)';
         case 'information':
         default:
-            return 'var(--mantine-color-gray-filled)';
+            return 'var(--mantine-color-gray-3)';
     }
 };
 

--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -67,7 +67,7 @@
 /* Table.Header */
 .headerRoot {
     border-bottom: 1px solid var(--mantine-color-default-border);
-    background-color: var(--mantine-color-gray-light);
+    background-color: var(--mantine-color-gray-0);
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-xl);
     position: relative;
     min-height: 69px;
@@ -103,11 +103,11 @@
         padding-right: var(--mantine-spacing-xl);
     }
 
-    background-color: var(--mantine-color-gray-light);
+    background-color: var(--mantine-color-gray-0);
 
     &[data-control='true'] {
         @mixin hover {
-            background-color: var(--mantine-color-gray-light-hover);
+            background-color: var(--mantine-color-gray-1);
         }
     }
 }

--- a/packages/mantine/src/theme/__tests__/plasmaCSSVariablesResolver.spec.ts
+++ b/packages/mantine/src/theme/__tests__/plasmaCSSVariablesResolver.spec.ts
@@ -11,8 +11,12 @@ describe('plasmaCSSVariablesResolver', () => {
         expect(variables.light['--mantine-color-text']).toBe('#3b3e46');
         expect(variables.light['--mantine-color-dimmed']).toBe('#676d7a');
         expect(variables.light['--mantine-color-gray-filled']).toBe('#959cab');
-        expect(variables.light['--mantine-color-gray-light']).toBe('#f9f9fa');
-        expect(variables.light['--mantine-color-gray-light-hover']).toBe('#f1f2f4');
+        expect(variables.light['--mantine-color-gray-light']).toBe(
+            'color-mix(in srgb, var(--mantine-color-gray-filled), transparent 90%)',
+        );
+        expect(variables.light['--mantine-color-gray-light-hover']).toBe(
+            'color-mix(in srgb, var(--mantine-color-gray-filled), transparent 84%)',
+        );
         expect(variables.light['--mantine-color-warning-filled']).toBe('#c89300');
     });
 });

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -9,7 +9,7 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             '--coveo-color-input-border': theme.colors.gray[3],
             '--coveo-color-title': theme.colors.gray[8],
             '--coveo-color-text-disabled': theme.colors.gray[3],
-            '--coveo-color-bg-disabled': alpha(theme.colors.gray[4], 0.1),
+            '--coveo-color-bg-disabled': alpha('var(--mantine-color-gray-4)', 0.1),
             '--coveo-color-text-readonly': 'var(--mantine-color-text)',
             '--coveo-color-bg-readonly': theme.colors.gray[1],
 
@@ -19,8 +19,8 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             '--mantine-color-text': theme.colors.gray[6],
             '--mantine-color-dimmed': theme.colors.gray[5],
             '--mantine-color-gray-filled': theme.colors.gray[4],
-            '--mantine-color-gray-light': theme.colors.gray[0],
-            '--mantine-color-gray-light-hover': theme.colors.gray[1],
+            '--mantine-color-gray-light': alpha('var(--mantine-color-gray-filled)', 0.1),
+            '--mantine-color-gray-light-hover': alpha('var(--mantine-color-gray-filled)', 0.16),
             '--mantine-color-warning-filled': theme.colors.yellow[4],
             '--mantine-color-placeholder': theme.colors.gray[4],
             '--mantine-color-default-hover': theme.colors.gray[1],
@@ -32,5 +32,6 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
              */
         },
     };
+
     return result;
 };


### PR DESCRIPTION
### Proposed Changes

Updated the `--mantine-color-gray-light` and `--mantine-color-gray-light-hover` colors to fit Figma (and keep transparency like Mantine)
Updated usage of this color where the transparency didn't make sense
Updated the color of the Status info token

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
