### PR TITLE
feat(variables): create CSS variables for font-weight

### DIFF
--- a/packages/mantine/src/components/header/Header.module.css
+++ b/packages/mantine/src/components/header/Header.module.css
@@ -6,7 +6,7 @@
 
     & .description {
         color: var(--mantine-color-dimmed);
-        font-weight: 400;
+        font-weight: var(--coveo-fw-normal);
     }
 }
 

--- a/packages/mantine/src/components/table/Table.module.css
+++ b/packages/mantine/src/components/table/Table.module.css
@@ -92,7 +92,7 @@
     text-align: left;
     color: var(--mantine-color-gray-6);
     height: var(--mantine-spacing-xl);
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
     font-size: var(--mantine-font-size-sm);
 
     &:first-of-type {

--- a/packages/mantine/src/styles/Alert.module.css
+++ b/packages/mantine/src/styles/Alert.module.css
@@ -1,5 +1,5 @@
 .title {
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
 }
 
 .icon {

--- a/packages/mantine/src/styles/Badge.module.css
+++ b/packages/mantine/src/styles/Badge.module.css
@@ -1,5 +1,5 @@
 .root {
     --badge-fz-md: 12px;
 
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
 }

--- a/packages/mantine/src/styles/Button.module.css
+++ b/packages/mantine/src/styles/Button.module.css
@@ -1,5 +1,5 @@
 .label {
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
 }
 
 .root {

--- a/packages/mantine/src/styles/InputWrapper.module.css
+++ b/packages/mantine/src/styles/InputWrapper.module.css
@@ -9,9 +9,9 @@
 }
 
 .description {
-    font-weight: 400;
+    font-weight: var(--coveo-fw-normal);
 }
 
 .error {
-    font-weight: 400;
+    font-weight: var(--coveo-fw-normal);
 }

--- a/packages/mantine/src/styles/Modal.module.css
+++ b/packages/mantine/src/styles/Modal.module.css
@@ -1,3 +1,3 @@
 .title {
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
 }

--- a/packages/mantine/src/styles/NavLink.module.css
+++ b/packages/mantine/src/styles/NavLink.module.css
@@ -1,9 +1,9 @@
 .label {
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
 }
 
 .children {
     & .label {
-        font-weight: 400;
+        font-weight: var(--coveo-fw-normal);
     }
 }

--- a/packages/mantine/src/styles/SegmentedControl.module.css
+++ b/packages/mantine/src/styles/SegmentedControl.module.css
@@ -4,7 +4,7 @@
 
 .label {
     @mixin light {
-        font-weight: 400;
+        font-weight: var(--coveo-fw-normal);
         color: var(--mantine-color-dimmed);
 
         @mixin hover {

--- a/packages/mantine/src/styles/Stepper.module.css
+++ b/packages/mantine/src/styles/Stepper.module.css
@@ -6,7 +6,7 @@
 
 .stepIcon {
     background-color: var(--mantine-color-gray-light);
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
 
     &:where([data-completed]) {
         --stepper-icon-color: var(--step-color);

--- a/packages/mantine/src/styles/Table.module.css
+++ b/packages/mantine/src/styles/Table.module.css
@@ -1,3 +1,3 @@
 .th {
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
 }

--- a/packages/mantine/src/styles/Tabs.module.css
+++ b/packages/mantine/src/styles/Tabs.module.css
@@ -28,7 +28,7 @@
 }
 
 .tab {
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
     line-height: 1.5;
     color: var(--mantine-color-dimmed);
 

--- a/packages/mantine/src/styles/Text.module.css
+++ b/packages/mantine/src/styles/Text.module.css
@@ -1,5 +1,5 @@
 .root {
-    font-weight: 400;
+    font-weight: var(--coveo-fw-normal);
 
     &:where([data-inherit]) {
         font-weight: inherit;

--- a/packages/mantine/src/styles/global.css
+++ b/packages/mantine/src/styles/global.css
@@ -1,5 +1,5 @@
 body {
-    font-weight: 400;
+    font-weight: var(--coveo-fw-normal);
     font-size: var(--mantine-font-size-sm);
 
     &::selection {
@@ -10,5 +10,5 @@ body {
 
 b,
 strong {
-    font-weight: 500;
+    font-weight: var(--coveo-fw-bold);
 }

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -2,7 +2,11 @@ import {alpha, ConvertCSSVariablesInput, CSSVariablesResolver} from '@mantine/co
 
 export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
     const result: ConvertCSSVariablesInput = {
-        variables: {},
+        variables: {
+            '--coveo-fw-light': '300',
+            '--coveo-fw-normal': '400',
+            '--coveo-fw-bold': '500',
+        },
         dark: {},
         light: {
             // custom colors

--- a/packages/website/src/styles/main.css
+++ b/packages/website/src/styles/main.css
@@ -1,10 +1,5 @@
 @import './_syntax-highlighting.css';
 
-body {
-    font-size: var(--mantine-font-size-sm);
-    font-weight: 400;
-}
-
 .sentence-case {
     text-transform: lowercase;
 


### PR DESCRIPTION
### Proposed Changes

Adding 3 new CSS variables to streamline font-weights. The Gibson font is picky with weights, it gets way too bold, too quickly.

Here are the new variables:
- `--coveo-fw-bold`
- `--coveo-fw-normal`
- `--coveo-fw-light`  

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 