### PR TITLE
feat(mantine): simplify modal usage

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -11,7 +11,7 @@ import {
     useProps,
     useStyles,
 } from '@mantine/core';
-import {Children, ReactElement, ReactNode} from 'react';
+import {Children, ElementType, ReactElement, ReactNode} from 'react';
 import {HeaderProvider} from './Header.context';
 import classes from './Header.module.css';
 import {HeaderRight, HeaderRightStyleNames} from './HeaderRight/HeaderRight';
@@ -54,6 +54,13 @@ export interface HeaderProps
      * The title of the header.
      */
     children: ReactNode;
+    /**
+     * The component used to render the title.
+     *
+     * @default Title
+     * @example 'h2'
+     */
+    titleComponent?: ElementType;
 }
 
 export type HeaderFactory = Factory<{
@@ -76,6 +83,7 @@ const defaultProps: Partial<HeaderProps> = {
     variant: 'primary',
     justify: 'space-between',
     wrap: 'nowrap',
+    titleComponent: Title,
 };
 
 const getSpacing = (variant: HeaderVariant) => (variant === 'secondary' ? 'xxs' : 'xs');
@@ -93,6 +101,7 @@ export const Header = factory<HeaderFactory>((_props, ref) => {
         unstyled,
         vars,
         styles,
+        titleComponent: TitleComponent,
         ...others
     } = props;
     const getStyles = useStyles<HeaderFactory>({
@@ -122,6 +131,7 @@ export const Header = factory<HeaderFactory>((_props, ref) => {
                     {breadcrumbs}
                     <Title
                         variant={variant}
+                        component={TitleComponent}
                         order={variant === 'primary' ? 1 : 3}
                         {...getStyles('title', stylesApiProps)}
                     >

--- a/packages/mantine/src/components/modal/Modal.module.css
+++ b/packages/mantine/src/components/modal/Modal.module.css
@@ -1,9 +1,0 @@
-.footer {
-    border-top: 1px solid var(--mantine-color-default-border);
-}
-
-.modalFooterSticky {
-    padding-bottom: 0;
-    margin: var(--mb-padding) calc(-1 * var(--mb-padding)) calc(var(--mantine-spacing-md) - var(--mb-padding))
-        calc(-1 * var(--mb-padding));
-}

--- a/packages/mantine/src/components/modal/Modal.tsx
+++ b/packages/mantine/src/components/modal/Modal.tsx
@@ -5,17 +5,40 @@ import {
     ModalProps as MantineModalProps,
 } from '@mantine/core';
 import {ModalFooter as PlasmaModalFooter} from './ModalFooter';
+import {Header, HeaderDocAnchorProps} from '../header';
+
+interface PlasmaModalProps extends MantineModalProps {
+    /**
+     * Description of the modal, displayed below the title.
+     */
+    description?: string;
+    /**
+     * Help link for the modal, displayed in the header.
+     * Usually provides a link to external documentation or help resources.
+     */
+    help?: HeaderDocAnchorProps;
+}
 
 // Need to redeclare the factory to override and add footer to the props type
 type PlasmaModalFactory = Omit<MantineModalFactory, 'staticComponents'> & {
+    props: PlasmaModalProps;
     staticComponents: MantineModalFactory['staticComponents'] & {
         Footer: typeof PlasmaModalFooter;
     };
 };
 
-const PlasmaModal = factory<PlasmaModalFactory>((props: MantineModalProps, ref) => (
-    <MantineModal ref={ref} {...props} />
-));
+const PlasmaModal = factory<PlasmaModalFactory>(({title, description, help, ...otherProps}, ref) => {
+    const header =
+        typeof title === 'string' ? (
+            <Header titleComponent="div" variant="secondary" description={description}>
+                {title}
+                {help && <Header.DocAnchor {...help} />}
+            </Header>
+        ) : (
+            title
+        );
+    return <MantineModal ref={ref} title={header} {...otherProps} />;
+});
 
 PlasmaModal.displayName = '@coveord/plasma-mantine/Modal';
 PlasmaModal.Root = MantineModal.Root;

--- a/packages/mantine/src/components/modal/ModalFooter.module.css
+++ b/packages/mantine/src/components/modal/ModalFooter.module.css
@@ -1,0 +1,10 @@
+:global(.mantine-Modal-body) {
+    .root {
+        margin: calc(-1 * var(--mb-padding));
+        margin-top: 0;
+    }
+}
+
+.root {
+    padding: var(--mb-padding, var(--mantine-spacing-lg, 32px));
+}

--- a/packages/mantine/src/components/modal/ModalFooter.tsx
+++ b/packages/mantine/src/components/modal/ModalFooter.tsx
@@ -1,15 +1,9 @@
 import {useRef, useEffect} from 'react';
-import clsx from 'clsx';
 import {Factory, factory} from '@mantine/core';
 import {StickyFooter, StickyFooterProps, StickyFooterStylesNames} from '../sticky-footer';
-import classes from './Modal.module.css';
+import classes from './ModalFooter.module.css';
 
-export interface ModalFooterProps extends Omit<StickyFooterProps, 'variant'> {
-    /**
-     * If the footer is sticky, its margin will be adjusted to counteract the padding of the Modal.Body, ensuring the footer visually sticks to the bottom of the modal.
-     */
-    sticky?: boolean;
-}
+export interface ModalFooterProps extends Omit<StickyFooterProps, 'variant'> {}
 
 export type ModalFooterStylesNames = StickyFooterStylesNames;
 
@@ -24,7 +18,7 @@ const ensuresFooterHasEvenHeight = (footer: HTMLElement) => {
     footer.style.height = `${footer.offsetHeight - remainder + 2}px`;
 };
 
-export const ModalFooter = factory<ModalFooterFactory>(({sticky, ...props}, ref) => {
+export const ModalFooter = factory<ModalFooterFactory>((props, ref) => {
     const _ref = useRef<HTMLDivElement>();
 
     const footerRef = ref || _ref;
@@ -37,11 +31,5 @@ export const ModalFooter = factory<ModalFooterFactory>(({sticky, ...props}, ref)
         // if ref === 'function', this is a callback ref. Haven't found any solution for adjusting the height in this case
     }, [ref, props.h]);
 
-    return (
-        <StickyFooter
-            className={clsx(classes.footer, {[classes.modalFooterSticky]: !!sticky})}
-            ref={footerRef}
-            {...props}
-        />
-    );
+    return <StickyFooter className={classes.root} ref={footerRef} {...props} />;
 });

--- a/packages/mantine/src/components/modal/__tests__/Modal.spec.tsx
+++ b/packages/mantine/src/components/modal/__tests__/Modal.spec.tsx
@@ -7,7 +7,7 @@ describe('Modal', () => {
     it('renders footer', () => {
         render(
             <Modal opened={true} onClose={vi.fn()}>
-                <Modal.Footer sticky>im the footer</Modal.Footer>
+                <Modal.Footer>im the footer</Modal.Footer>
             </Modal>,
         );
 

--- a/packages/mantine/src/components/modal/__tests__/ModalFooter.spec.tsx
+++ b/packages/mantine/src/components/modal/__tests__/ModalFooter.spec.tsx
@@ -12,16 +12,6 @@ describe('ModalFooter', () => {
 
         expect(screen.getByText('im the children')).toBeInTheDocument();
     });
-    it('includes the .modalFooterSticky class styling if set to sticky', () => {
-        render(
-            <Modal.Footer sticky>
-                <div>im the children</div>
-            </Modal.Footer>,
-        );
-
-        const footer = screen.getByText('im the children').parentElement;
-        expect(footer.className).contains('modalFooterSticky');
-    });
     it('has an even height value to ensure the footer sticks completely to the bottom as a workaround to the footer positioning issue when height value is odd', () => {
         render(
             <Modal.Footer h={99}>

--- a/packages/mantine/src/components/prompt/Prompt.module.css
+++ b/packages/mantine/src/components/prompt/Prompt.module.css
@@ -1,10 +1,9 @@
 .root {
     --prompt-icon-size: 68px;
+}
 
-    .body {
-        padding: 0 var(--mantine-spacing-lg) var(--mantine-spacing-lg)
-            calc(var(--prompt-icon-size) + var(--mantine-spacing-md) + var(--mantine-spacing-lg));
-    }
+.body {
+    padding-left: calc(var(--prompt-icon-size) + var(--mantine-spacing-sm) + var(--mb-padding));
 }
 
 .icon {

--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -99,22 +99,6 @@ export const Prompt = factory<PromptFactory>((_props, ref) => {
         (child.type === Modal.Footer ? footers : otherChildren).push(child);
     });
 
-    const titleContent =
-        typeof title === 'string' ? (
-            <Modal.Title
-                component={Header}
-                renderRoot={(p) => (
-                    <Header variant="secondary" {...p}>
-                        {p.children}
-                    </Header>
-                )}
-            >
-                {title}
-            </Modal.Title>
-        ) : (
-            title
-        );
-
     return (
         <PromptContextProvider value={{variant, getStyles}}>
             <Modal.Root ref={ref} variant="prompt" size="sm" {...others} {...getStyles('root')}>
@@ -131,7 +115,11 @@ export const Prompt = factory<PromptFactory>((_props, ref) => {
                                 src={PROMPT_VARIANT_ICONS_SRC[variant]}
                             />
                         )}
-                        {titleContent}
+                        <Modal.Title>
+                            <Header titleComponent="div" variant="secondary">
+                                {title}
+                            </Header>
+                        </Modal.Title>
                         <Modal.CloseButton {...getStyles('close', stylesApiProps)} />
                     </Modal.Header>
                     <Modal.Body {...getStyles('body', stylesApiProps)}>

--- a/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
+++ b/packages/mantine/src/components/sticky-footer/StickyFooter.module.css
@@ -4,13 +4,6 @@
     z-index: 10;
     background-color: var(--mantine-color-body);
     padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
-
-    &[data-variant='modal-footer'] {
-        border-top: 1px solid var(--mantine-color-default-border);
-        padding-bottom: 0;
-        margin: var(--mb-padding) calc(-1 * var(--mb-padding)) calc(var(--mantine-spacing-md) - var(--mb-padding))
-            calc(-1 * var(--mb-padding));
-    }
 }
 
 .border {

--- a/packages/mantine/src/styles/Modal.module.css
+++ b/packages/mantine/src/styles/Modal.module.css
@@ -1,3 +1,11 @@
 .title {
     font-weight: var(--coveo-fw-bold);
 }
+
+.header {
+    gap: var(--mantine-spacing-sm);
+}
+
+.close {
+    align-self: flex-start;
+}

--- a/packages/website/src/examples/layout/Modal/Modal.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/Modal.demo.tsx
@@ -1,4 +1,4 @@
-import {Button, Header, Modal} from '@coveord/plasma-mantine';
+import {Button, Modal} from '@coveord/plasma-mantine';
 import {useState} from 'react';
 
 const Demo = () => {
@@ -9,19 +9,16 @@ const Demo = () => {
             <Modal
                 size="md"
                 opened={opened}
-                title={
-                    <Header variant="secondary" description="Modal description">
-                        Modal Title
-                        <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
-                    </Header>
-                }
+                title="Modal Title"
+                description="Modal description"
+                help={{href: 'https://about:blank', label: 'Tooltip text'}}
                 onClose={() => setOpened(false)}
             >
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut dui sed sapien finibus malesuada id
                 sit amet risus. Praesent finibus sapien vel dolor bibendum, eget euismod metus dignissim. Phasellus
                 lacinia sem nunc, vel dapibus odio suscipit id. Aenean lobortis sollicitudin suscipit. Cras vitae ipsum
                 sit amet nibh efficitur imperdiet. Praesent scelerisque erat est. Cras dictum sodales tellus sed pretium
-                <Modal.Footer sticky>
+                <Modal.Footer>
                     <Button.Tertiary onClick={() => setOpened(false)}>Cancel</Button.Tertiary>
                     <Button.Primary onClick={() => setOpened(false)}>Accept</Button.Primary>
                 </Modal.Footer>

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.demo.tsx
@@ -1,39 +1,32 @@
-import {Button, Header, Modal, Tabs} from '@coveord/plasma-mantine';
+import {Button, Modal, Tabs} from '@coveord/plasma-mantine';
 import {useState} from 'react';
-import classes from './ModalWithTabs.module.css';
 
 const Demo = () => {
     const [opened, setOpened] = useState(false);
     return (
         <>
-            <Modal.Root opened={opened} onClose={() => setOpened(false)}>
-                <Modal.Overlay />
-                <Modal.Content>
-                    <Modal.Header className={classes.headerWithTabs}>
-                        <Header variant="secondary" description="Modal description">
-                            Modal Title
-                            <Header.DocAnchor href="https://about:blank" label="Tooltip text" />
-                        </Header>
-                        <Modal.CloseButton />
-                    </Modal.Header>
-                    <Tabs defaultValue="tab-1">
-                        <Tabs.List pl="lg">
-                            <Tabs.Tab value="tab-1">Tab 1</Tabs.Tab>
-                            <Tabs.Tab value="tab-2">Tab 2</Tabs.Tab>
-                            <Tabs.Tab value="tab-3">Tab 3</Tabs.Tab>
-                        </Tabs.List>
-                        <Modal.Body mih={500}>
-                            <Tabs.Panel value="tab-1">Tab 1 content</Tabs.Panel>
-                            <Tabs.Panel value="tab-2">Tab 2 content</Tabs.Panel>
-                            <Tabs.Panel value="tab-3">Tab 3 content</Tabs.Panel>
-                        </Modal.Body>
-                    </Tabs>
-                    <Modal.Footer>
-                        <Button.Tertiary onClick={() => setOpened(false)}>Cancel</Button.Tertiary>
-                        <Button.Primary>Save</Button.Primary>
-                    </Modal.Footer>
-                </Modal.Content>
-            </Modal.Root>
+            <Modal
+                opened={opened}
+                onClose={() => setOpened(false)}
+                title="Modal Title"
+                description="Modal description"
+                help={{href: 'https://about:blank', label: 'Tooltip text'}}
+            >
+                <Tabs defaultValue="tab-1" mih={500}>
+                    <Tabs.List>
+                        <Tabs.Tab value="tab-1">Tab 1</Tabs.Tab>
+                        <Tabs.Tab value="tab-2">Tab 2</Tabs.Tab>
+                        <Tabs.Tab value="tab-3">Tab 3</Tabs.Tab>
+                    </Tabs.List>
+                    <Tabs.Panel value="tab-1">Tab 1 content</Tabs.Panel>
+                    <Tabs.Panel value="tab-2">Tab 2 content</Tabs.Panel>
+                    <Tabs.Panel value="tab-3">Tab 3 content</Tabs.Panel>
+                </Tabs>
+                <Modal.Footer>
+                    <Button.Tertiary onClick={() => setOpened(false)}>Cancel</Button.Tertiary>
+                    <Button.Primary>Save</Button.Primary>
+                </Modal.Footer>
+            </Modal>
             <Button.Primary onClick={() => setOpened(true)}>Open Modal</Button.Primary>
         </>
     );

--- a/packages/website/src/examples/layout/Modal/ModalWithTabs.module.css
+++ b/packages/website/src/examples/layout/Modal/ModalWithTabs.module.css
@@ -1,3 +1,0 @@
-.headerWithTabs {
-    border-bottom: none;
-}

--- a/packages/website/src/pages/layout/Modal.tsx
+++ b/packages/website/src/pages/layout/Modal.tsx
@@ -1,7 +1,6 @@
 import {ModalMetadata} from '@coveord/plasma-components-props-analyzer';
 import ModalDemo from '@examples/layout/Modal/Modal.demo?demo';
 import ModalWithTabsDemo from '@examples/layout/Modal/ModalWithTabs.demo?demo';
-import ModalWithTabsCSS from '@examples/layout/Modal/ModalWithTabs.module.css?raw';
 import {PageLayout} from '../../building-blocs/PageLayout';
 
 const Page = () => (
@@ -14,19 +13,7 @@ const Page = () => (
         propsMetadata={ModalMetadata}
         demo={<ModalDemo />}
         examples={{
-            withTabs: (
-                <ModalWithTabsDemo
-                    title="Modal with tabs and footer"
-                    additionalFiles={[
-                        {
-                            fileName: 'ModalWithTabs.module.css',
-                            code: ModalWithTabsCSS,
-                            language: 'css',
-                            icon: null,
-                        },
-                    ]}
-                />
-            ),
+            withTabs: <ModalWithTabsDemo title="Modal with tabs and footer" />,
         }}
     />
 );


### PR DESCRIPTION
### Proposed Changes

Changing the Modal component so that it fits the new mockups, but also simplifying its usage. It should be no longer necessary (but still possible) to resort to using the Modal compound components.

|Before|After|
|---|---|
|<img width="931" alt="image" src="https://github.com/user-attachments/assets/01fe7681-b495-41dc-85a6-8e0f049258a7" />|<img width="924" alt="image" src="https://github.com/user-attachments/assets/1205e2e3-ac54-40c4-9988-e35a3aa8ceee" />|
|<img width="934" alt="image" src="https://github.com/user-attachments/assets/ac614d46-b404-486e-93e9-9387f6c06493" />|<img width="928" alt="image" src="https://github.com/user-attachments/assets/df35b291-549c-41e7-8e64-38f62957b79d" />|
|<img width="696" alt="image" src="https://github.com/user-attachments/assets/8264f389-cf3b-4ef5-8645-d68add12d557" />|<img width="694" alt="image" src="https://github.com/user-attachments/assets/04cdbe31-69ab-4216-b7be-2f4070527c25" />|

### Potential Breaking Changes

Modal usage has become a lot simpler, but there might be some adjustments to do (stuff to remove and simplify)

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
