### PR TITLE
fix(mantine): disable CodeEditor stickyScroll

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -229,6 +229,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                     formatOnPaste: true,
                     fontSize: px(theme.fontSizes.xs) as number,
                     readOnly: disabled,
+                    stickyScroll: {enabled: false},
                     tabSize,
                 }}
                 value={_value}


### PR DESCRIPTION
### Proposed Changes

Disabling monaco-editor's `stickyScroll` feature to prevent the big empty space issue:

https://github.com/user-attachments/assets/91861356-3cd7-4ec4-9423-c5bfe52d06fd

To test this in the demo, you can go in the CodeEditor demo page and paste a big json object with a lot of nested properties in the JSON code editor example. You will see that the "stickyScroll" behaviour is no longer there.


### Potential Breaking Changes



<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
