### PR TITLE
feat(chip): adjust style of chip, export prop restricted component, c…

### DIFF
--- a/packages/mantine/src/components/chip/Chip.tsx
+++ b/packages/mantine/src/components/chip/Chip.tsx
@@ -1,0 +1,5 @@
+import {ChipFactory, ChipGroup, factory, Chip as MantineChip} from '@mantine/core';
+
+export const Chip = factory<ChipFactory>(({variant: _variant, ...props}, ref) => <MantineChip {...props} ref={ref} />);
+
+Chip.Group = ChipGroup;

--- a/packages/mantine/src/components/chip/index.ts
+++ b/packages/mantine/src/components/chip/index.ts
@@ -1,0 +1,1 @@
+export * from './Chip';

--- a/packages/mantine/src/components/index.ts
+++ b/packages/mantine/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './browser-preview';
 export * from './button';
 export * from './checkbox';
 export * from './child-form';
+export * from './chip';
 export * from './code-editor';
 export * from './collection';
 export * from './copyToClipboard';

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -20,6 +20,7 @@ export {
     ActionIcon,
     BrowserPreview,
     Button,
+    Chip,
     CopyToClipboard,
     Header,
     Menu,

--- a/packages/mantine/src/styles/Chip.module.css
+++ b/packages/mantine/src/styles/Chip.module.css
@@ -1,0 +1,41 @@
+.root {
+    --chip-color: var(--coveo-color-text-primary);
+    --chip-bg: var(--mantine-primary-color-light);
+    --chip-hover: var(--mantine-primary-color-filled-hover);
+    --chip-radius: var(--mantine-radius-lg);
+    --chip-padding: var(--mantine-spacing-sm);
+    --chip-spacing: var(--mantine-spacing-sm);
+
+    > .label {
+        &:not([data-checked]) {
+            border: 1px solid var(--mantine-color-default-border);
+            border-radius: var(--mantine-radius-lg);
+            background-color: var(--mantine-color-white);
+
+            @mixin hover {
+                &[data-disabled] {
+                    border: none;
+                    color: var(--coveo-color-text-disabled);
+                    background-color: var(--coveo-color-bg-disabled);
+                }
+
+                background-color: var(--mantine-color-gray-light);
+                border-color: var(--coveo-color-input-border);
+            }
+        }
+
+        &:not([data-disabled]) {
+            @mixin hover {
+                &[data-checked] {
+                    color: var(--mantine-color-white);
+                }
+            }
+        }
+
+        &[data-disabled] {
+            border: none;
+            color: var(--coveo-color-text-disabled);
+            background-color: var(--coveo-color-bg-disabled);
+        }
+    }
+}

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -16,6 +16,7 @@ import {
     Breadcrumbs,
     Button,
     Checkbox,
+    Chip,
     CloseButton,
     ColorSwatch,
     Combobox,
@@ -54,6 +55,7 @@ import BreadcrumbsClasses from '../styles/Breadcrumbs.module.css';
 import ButtonClasses from '../styles/Button.module.css';
 import CheckboxClasses from '../styles/Checkbox.module.css';
 import CheckboxIndicatorClasses from '../styles/CheckboxIndicator.module.css';
+import ChipClasses from '../styles/Chip.module.css';
 import ComboboxClasses from '../styles/Combobox.module.css';
 import InputClasses from '../styles/Input.module.css';
 import InputWrapperClasses from '../styles/InputWrapper.module.css';
@@ -186,6 +188,12 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 icon: CheckboxIcon,
             },
             classNames: CheckboxIndicatorClasses,
+        }),
+        Chip: Chip.extend({
+            defaultProps: {
+                icon: <IconCheck size={16} />,
+            },
+            classNames: ChipClasses,
         }),
         CloseButton: CloseButton.extend({
             defaultProps: {

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -16,6 +16,7 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             '--coveo-color-bg-disabled': alpha('var(--mantine-color-gray-4)', 0.1),
             '--coveo-color-text-readonly': 'var(--mantine-color-text)',
             '--coveo-color-bg-readonly': theme.colors.gray[1],
+            '--coveo-color-text-primary': 'var(--mantine-primary-color-filled)',
 
             // mantine overrides
             '--mantine-color-default-border': theme.colors.gray[2],


### PR DESCRIPTION
…reate demo in the website

### Proposed Changes
This PR updates the style of the mantine [Chip](https://mantine.dev/core/chip/) component with UX pretine mockups.

I also added an entry in the website to have a demo of the chip, since the mockup seemed to have removed any variant of the chip. the only variant is `light`. I re-exported the component, but without this prop so people cannot use other things (less custom)

[Figma](https://www.figma.com/design/lFjxQoLHYzdLObC0g4HdWd/Opal-Components--Pretine-source-library-?node-id=17201-41100&m=dev)

### Before:
<img width="644" alt="image" src="https://github.com/user-attachments/assets/c641c8d7-8490-4c6e-874d-c0e289b0ce62" />

### After:

https://github.com/user-attachments/assets/8f6c1112-f103-4b83-8763-7097df67b6f4

#### disabled:
<img width="232" alt="image" src="https://github.com/user-attachments/assets/cd176568-da8d-47a0-b84e-d75bc20e4c3b" />



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
