### PR TITLE
feat(mantine): changed newly added variables with hardcoded ones

### DIFF
--- a/packages/mantine/src/styles/Checkbox.module.css
+++ b/packages/mantine/src/styles/Checkbox.module.css
@@ -23,11 +23,11 @@ So we are allowing ourselves some custom style to achieve the desired effect
         /* mantine hardcodes disabled styles so we need to write custom styles */
         &:disabled {
             border-color: var(--mantine-color-default-border);
-            background-color: var(--coveo-color-bg-disabled);
-            color: var(--coveo-color-text-disabled);
+            background-color: var(--mantine-color-disabled);
+            color: var(--mantine-color-disabled-color);
 
             & + .icon {
-                color: var(--coveo-color-text-disabled);
+                color: var(--mantine-color-disabled-color);
             }
         }
     }
@@ -38,7 +38,7 @@ So we are allowing ourselves some custom style to achieve the desired effect
         &[data-disabled] {
             .label,
             .description {
-                color: var(--coveo-color-text-disabled);
+                color: var(--mantine-color-disabled-color);
             }
         }
     }

--- a/packages/mantine/src/styles/Input.module.css
+++ b/packages/mantine/src/styles/Input.module.css
@@ -2,7 +2,7 @@
     --input-section-color: var(--mantine-color-placeholder);
 
     @mixin light {
-        --input-disabled-color: var(--coveo-color-text-disabled);
+        --input-disabled-color: var(--mantine-color-disabled-color);
 
         &[data-variant='default'] {
             --input-bd: var(--coveo-color-input-border);

--- a/packages/mantine/src/styles/Radio.module.css
+++ b/packages/mantine/src/styles/Radio.module.css
@@ -8,7 +8,7 @@
         &[data-disabled] {
             .label,
             .description {
-                color: var(--coveo-color-text-disabled);
+                color: var(--mantine-color-disabled-color);
             }
         }
     }
@@ -21,7 +21,7 @@
         }
 
         &:disabled {
-            background-color: var(--coveo-color-bg-disabled);
+            background-color: var(--mantine-color-disabled);
         }
 
         /* mantine hardcodes disabled styles so we need to write custom styles */

--- a/packages/mantine/src/styles/SegmentedControl.module.css
+++ b/packages/mantine/src/styles/SegmentedControl.module.css
@@ -16,7 +16,7 @@
         }
 
         &[data-disabled] {
-            color: var(--coveo-color-text-disabled);
+            color: var(--mantine-color-disabled-color);
         }
     }
 }

--- a/packages/mantine/src/styles/Select.module.css
+++ b/packages/mantine/src/styles/Select.module.css
@@ -11,7 +11,7 @@
 
         &[data-combobox-disabled] {
             opacity: 1;
-            color: var(--coveo-color-text-disabled);
+            color: var(--mantine-color-disabled-color);
         }
 
         &[data-combobox-active='true'] {
@@ -39,7 +39,7 @@
 .input {
     @mixin light {
         &[data-disabled] {
-            --input-disabled-bg: var(--coveo-color-bg-disabled);
+            --input-disabled-bg: var(--mantine-color-disabled);
             --input-bd: var(--mantine-color-default-border);
         }
     }

--- a/packages/mantine/src/styles/Tabs.module.css
+++ b/packages/mantine/src/styles/Tabs.module.css
@@ -40,7 +40,7 @@
 
     &:where(:disabled, [data-disabled]) {
         opacity: 1 !important; /* Override Mantine's 0.5 */
-        color: var(--coveo-color-text-disabled);
+        color: var(--mantine-color-disabled-color);
     }
 
     &:where([data-active]) {

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -12,8 +12,6 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             // custom colors
             '--coveo-color-input-border': theme.colors.gray[3],
             '--coveo-color-title': theme.colors.gray[8],
-            '--coveo-color-text-disabled': theme.colors.gray[3],
-            '--coveo-color-bg-disabled': alpha('var(--mantine-color-gray-4)', 0.1),
             '--coveo-color-text-readonly': 'var(--mantine-color-text)',
             '--coveo-color-bg-readonly': theme.colors.gray[1],
 
@@ -28,12 +26,8 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             '--mantine-color-warning-filled': theme.colors.yellow[4],
             '--mantine-color-placeholder': theme.colors.gray[4],
             '--mantine-color-default-hover': theme.colors.gray[1],
-            /**
-             * ADUI-10725 https://coveord.atlassian.net/browse/ADUI-10725
-             * '--mantine-color-disabled'
-             * '--mantine-color-disabled-color'
-             * '--mantine-color-disabled-border'
-             */
+            '--mantine-color-disabled': alpha('var(--mantine-color-gray-4)', 0.1),
+            '--mantine-color-disabled-color': theme.colors.gray[3],
         },
     };
 


### PR DESCRIPTION
### Proposed Changes

[JIRA](https://coveord.atlassian.net/browse/ADUI-10725)

We made some custom variables because mantine did not provide specific css variables to play with. @GermainBergeron made some improvements on mantine's repository and :sneaky: added these variables so that we could leverage them instead of creating custom ones.

the `--mantine-color-disabled-border` variable does not seem to be used by UX anymore (probably a change they made that now uses the same border, disabled or not)
 
### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
