### PR TITLE
fix(mantine,header): header secondary order

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -83,7 +83,6 @@ const defaultProps: Partial<HeaderProps> = {
     variant: 'primary',
     justify: 'space-between',
     wrap: 'nowrap',
-    titleComponent: Title,
 };
 
 const getSpacing = (variant: HeaderVariant) => (variant === 'secondary' ? 'xxs' : 'xs');

--- a/packages/mantine/src/components/header/__tests__/Header.spec.tsx
+++ b/packages/mantine/src/components/header/__tests__/Header.spec.tsx
@@ -11,7 +11,20 @@ describe('Header', () => {
             </Header>,
         );
 
-        const header = screen.getByRole('heading');
+        const header = screen.getByRole('heading', {level: 1});
+        expect(header.tagName).toBe('H1');
+        expect(within(header).getByTestId('child')).toBeVisible();
+    });
+
+    it('renders a heading of level 3 when the variant is secondary', () => {
+        render(
+            <Header variant="secondary">
+                <div data-testid="child" />
+            </Header>,
+        );
+
+        const header = screen.getByRole('heading', {level: 3});
+        expect(header.tagName).toBe('H3');
         expect(within(header).getByTestId('child')).toBeVisible();
     });
 


### PR DESCRIPTION
### Proposed Changes

Making sure the Header with variant secondary remains a `h3`.

|Before|After|
|---|---|
|<img width="346" height="290" alt="image" src="https://github.com/user-attachments/assets/95e5a116-7a1a-439a-be8e-0818032acc1b" />|<img width="344" height="286" alt="image" src="https://github.com/user-attachments/assets/bd7ee955-36ab-48d3-b27d-6d7cff6e231a" />|

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
