### PR TITLE
Ad UI 10883 select style changes

### DIFF
--- a/packages/mantine/src/styles/Select.module.css
+++ b/packages/mantine/src/styles/Select.module.css
@@ -1,7 +1,6 @@
 .option {
     @mixin light {
         color: var(--coveo-color-title);
-        border-radius: var(--mantine-radius-sm);
 
         @mixin hover {
             &:not([data-combobox-disabled], [data-checked], [data-combobox-selected]) {

--- a/packages/mantine/src/styles/Select.module.css
+++ b/packages/mantine/src/styles/Select.module.css
@@ -1,4 +1,6 @@
 .option {
+    padding: var(--mantine-spacing-xs);
+
     @mixin light {
         color: var(--coveo-color-title);
 

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -330,8 +330,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         }),
         Popover: Popover.extend({
             defaultProps: {
-                shadow: 'md',
-                withArrow: true,
+                shadow: 'xs',
                 middlewares: {inline: true},
             },
         }),


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

This PR does not change much from the previous [PR](https://github.com/coveo/plasma/pull/4062) that applied style to Select component appart 
- removing the arrow from the popover
- popover shadow
- modifying option padding
- option border-radius


[JIRA](https://coveord.atlassian.net/browse/ADUI-10883)

[Figma](https://www.figma.com/design/lFjxQoLHYzdLObC0g4HdWd/Opal-Components--Pretine-source-library-?node-id=8613-333163&p=f&m=dev)

### Before

<img width="612" height="221" alt="image" src="https://github.com/user-attachments/assets/4d65840e-a751-496c-92fa-e413456b2063" />

### After

<img width="609" height="235" alt="image" src="https://github.com/user-attachments/assets/8999588d-13c9-47cb-ac71-9b378180d4a9" />


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
