### PR TITLE
fix(mantine,navlink): reduce style specificity

### DIFF
--- a/packages/mantine/src/styles/NavLink.module.css
+++ b/packages/mantine/src/styles/NavLink.module.css
@@ -1,17 +1,19 @@
+.root {
+    &:where(:not([data-active]), [data-disabled]) {
+        color: var(--coveo-color-title);
+
+        &:hover {
+            background-color: var(--mantine-color-default-hover);
+        }
+    }
+
+    &:where([data-disabled]) {
+        color: var(--coveo-color-text-disabled);
+    }
+}
+
 .label {
     font-weight: var(--coveo-fw-bold);
-}
-
-.root:not([data-active]):hover {
-    background-color: var(--mantine-color-default-hover);
-}
-
-.root:not([data-active], [data-disabled]) {
-    color: var(--coveo-color-title);
-}
-
-.root[data-disabled] {
-    color: var(--coveo-color-text-disabled);
 }
 
 .children {


### PR DESCRIPTION
### Proposed Changes

Adjusting the NavLink styles so that the rules specificity doesn't increase to a point where it surpasses what we have in the admin-ui.

Before
<img width="382" height="83" alt="image" src="https://github.com/user-attachments/assets/8ba90d83-85be-4584-842b-647be7cec655" />


After
<img width="439" height="80" alt="image" src="https://github.com/user-attachments/assets/ebaf986f-62d6-4782-884f-c69fcbd3b7ea" />

Reasoning:
<img width="1518" height="1844" alt="image" src="https://github.com/user-attachments/assets/3460c065-283a-42db-9f08-bdf4103cd4e2" />


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
