### PR TITLE
feat(infotoken): apply style changes

### DIFF
--- a/packages/mantine/src/components/info-token/InfoToken.tsx
+++ b/packages/mantine/src/components/info-token/InfoToken.tsx
@@ -3,6 +3,7 @@ import {
     IconAlertTriangleFilled,
     IconBulbFilled,
     IconHelpCircle,
+    IconInfoCircle,
     IconInfoCircleFilled,
     TablerIcon,
 } from '@coveord/plasma-react-icons';
@@ -26,9 +27,17 @@ export type InfoTokenFactory = Factory<{
     stylesNames: InfoTokenComponentStylesNames;
     vars: InfoTokenCssVariables;
     variant: InfoTokenVariant;
+    staticComponents: {
+        Information: typeof TokenInformation;
+        InformationOutline: typeof TokenInformationOutline;
+        Advice: typeof TokenAdvice;
+        Warning: typeof TokenWarning;
+        Error: typeof TokenError;
+        Question: typeof TokenQuestion;
+    };
 }>;
 export type InfoTokenComponentStylesNames = 'root';
-export type InfoTokenVariant = 'information' | 'advice' | 'warning' | 'error' | 'question';
+export type InfoTokenVariant = 'information' | 'information-outline' | 'advice' | 'warning' | 'error' | 'question';
 export type InfoTokenCssVariables = {
     root: '--info-token-color';
 };
@@ -59,7 +68,7 @@ const colorResolver = (variant: InfoTokenVariant): string => {
         case 'question':
             return 'var(--mantine-primary-color-filled)';
         case 'warning':
-            return 'var(--mantine-color-yellow-filled)';
+            return 'var(--mantine-color-yellow-4)';
         case 'information':
         default:
             return 'var(--mantine-color-gray-3)';
@@ -91,6 +100,8 @@ const iconResolver = (variant: InfoTokenVariant): TablerIcon => {
             return IconAlertSquareFilled;
         case 'information':
             return IconInfoCircleFilled;
+        case 'information-outline':
+            return IconInfoCircle;
         case 'question':
             return IconHelpCircle;
         case 'warning':
@@ -145,3 +156,21 @@ export const InfoToken: ReturnType<typeof polymorphicFactory<InfoTokenFactory>> 
         );
     },
 );
+
+const TokenInformation = InfoToken.withProps({
+    variant: 'information',
+});
+const TokenInformationOutline = InfoToken.withProps({
+    variant: 'information-outline',
+});
+const TokenAdvice = InfoToken.withProps({variant: 'advice'});
+const TokenWarning = InfoToken.withProps({variant: 'warning'});
+const TokenError = InfoToken.withProps({variant: 'error'});
+const TokenQuestion = InfoToken.withProps({variant: 'question'});
+
+InfoToken.Information = TokenInformation;
+InfoToken.InformationOutline = TokenInformationOutline;
+InfoToken.Advice = TokenAdvice;
+InfoToken.Warning = TokenWarning;
+InfoToken.Error = TokenError;
+InfoToken.Question = TokenQuestion;

--- a/packages/website/src/examples/feedback/info-token/InfoToken.demo.tsx
+++ b/packages/website/src/examples/feedback/info-token/InfoToken.demo.tsx
@@ -1,12 +1,15 @@
-import {InfoToken, Stack} from '@coveord/plasma-mantine';
+import {Group, InfoToken, Stack} from '@coveord/plasma-mantine';
 
 const Demo = () => (
     <Stack gap="sm">
-        <InfoToken variant="information" />
-        <InfoToken variant="advice" />
-        <InfoToken variant="warning" />
-        <InfoToken variant="error" />
-        <InfoToken variant="question" />
+        <Group>
+            <InfoToken.Information />
+            <InfoToken.InformationOutline />
+        </Group>
+        <InfoToken.Advice />
+        <InfoToken.Warning />
+        <InfoToken.Error />
+        <InfoToken.Question />
     </Stack>
 );
 export default Demo;


### PR DESCRIPTION
### Proposed Changes

Apply changes to InfoToken component. I have also added a semantic nomenclature for the component (as we do with Button)

[JIRA](https://coveord.atlassian.net/browse/ADUI-10879)
[Figma](https://www.figma.com/design/lFjxQoLHYzdLObC0g4HdWd/Opal-Components--Pretine-source-library-?node-id=10477-74560&focus-id=10477-74560&m=dev)

- InfoToken.Information
- InfoToken.InformationOutline (new variation designed for inputs)
- InfoToken.Advice
- InfoToken.Warning
- InfoToken.Error
- InfoToken.Question

I changed the warning color since it was not the right shade.

This would not break the actual implementation in our product since people can still use the InfoToken component, but it could be great to enforce it as we want to do with button

### Before

<img width="897" height="281" alt="image" src="https://github.com/user-attachments/assets/81fb1cd5-eb6b-4325-89fa-9e2382d6cc86" />


### After

<img width="1072" height="342" alt="image" src="https://github.com/user-attachments/assets/01f56570-0ed8-4da7-917f-c45f260fea38" />


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
