### PR TITLE
Ad UI 10888 style changes number text time input

### DIFF
--- a/packages/mantine/src/styles/Input.module.css
+++ b/packages/mantine/src/styles/Input.module.css
@@ -1,6 +1,5 @@
 .wrapper {
     --input-section-color: var(--mantine-color-placeholder);
-    --input-height: 38px;
 
     @mixin light {
         --input-disabled-color: var(--mantine-color-disabled-color);

--- a/packages/mantine/src/styles/Input.module.css
+++ b/packages/mantine/src/styles/Input.module.css
@@ -1,5 +1,6 @@
 .wrapper {
     --input-section-color: var(--mantine-color-placeholder);
+    --input-height: 38px;
 
     @mixin light {
         --input-disabled-color: var(--mantine-color-disabled-color);
@@ -13,6 +14,14 @@
         > .section {
             > svg {
                 color: var(--input-disabled-color);
+            }
+        }
+    }
+
+    &[data-error] {
+        > .section {
+            > svg {
+                color: var(--mantine-color-error);
             }
         }
     }

--- a/packages/mantine/src/styles/InputWrapper.module.css
+++ b/packages/mantine/src/styles/InputWrapper.module.css
@@ -1,7 +1,7 @@
 .root {
     display: flex;
     flex-direction: column;
-    gap: var(--mantine-spacing-xxs);
+    gap: var(--mantine-spacing-xs);
 }
 
 .label {

--- a/packages/mantine/src/styles/NumberInput.module.css
+++ b/packages/mantine/src/styles/NumberInput.module.css
@@ -1,0 +1,7 @@
+.control {
+    @mixin light {
+        @mixin hover {
+            background-color: var(--mantine-color-default-hover);
+        }
+    }
+}

--- a/packages/mantine/src/styles/ReadOnlyInput.module.css
+++ b/packages/mantine/src/styles/ReadOnlyInput.module.css
@@ -4,13 +4,13 @@
     --input-bd: var(--mantine-color-default-border);
     --input-bg: var(--mantine-color-gray-1);
     --input-color: var(--mantine-color-text);
-    --input-placeholder-color: var(--mantine-color-placeholder);
+    --input-placeholder-color: var(--mantine-color-text);
 }
 
 .section {
     --input-section-color: var(--mantine-color-text);
 
     > svg {
-        color: var(--mantine-color-gray-3);
+        color: var(--input-section-color);
     }
 }

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -34,6 +34,7 @@ import {
     MultiSelect,
     NavLink,
     Notification,
+    NumberInput,
     Pagination,
     Pill,
     Popover,
@@ -65,6 +66,7 @@ import InputWrapperClasses from '../styles/InputWrapper.module.css';
 import ListClasses from '../styles/List.module.css';
 import ModalClasses from '../styles/Modal.module.css';
 import NavLinkClasses from '../styles/NavLink.module.css';
+import NumberInputClasses from '../styles/NumberInput.module.css';
 import PaginationClasses from '../styles/Pagination.module.css';
 import PillClasses from '../styles/Pill.module.css';
 import RadioClasses from '../styles/Radio.module.css';
@@ -325,6 +327,9 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             defaultProps: {
                 icon: <InfoSize24Px height={24} />,
             },
+        }),
+        NumberInput: NumberInput.extend({
+            classNames: NumberInputClasses,
         }),
         Pagination: Pagination.extend({
             classNames: PaginationClasses,

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -4,6 +4,7 @@ import {
     CrossSize16Px,
     FilterSize16Px,
     IconCheck,
+    IconClock,
     IconSlash,
     InfoSize24Px,
 } from '@coveord/plasma-react-icons';
@@ -51,6 +52,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
+import {TimeInput} from '@mantine/dates';
 import {CheckboxIcon, CircleLoader, InfoToken} from '../components';
 import ActionIconClasses from '../styles/ActionIcon.module.css';
 import AlertClasses from '../styles/Alert.module.css';
@@ -434,6 +436,11 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 size: 'sm',
             },
             classNames: TextClasses,
+        }),
+        TimeInput: TimeInput.extend({
+            defaultProps: {
+                rightSection: <IconClock size={16} />,
+            },
         }),
         Tooltip: Tooltip.extend({
             defaultProps: {

--- a/packages/website/src/examples/form/form/Form.demo.tsx
+++ b/packages/website/src/examples/form/form/Form.demo.tsx
@@ -16,6 +16,7 @@ import {
     Title,
     useForm,
 } from '@coveord/plasma-mantine';
+import {TimeInput} from '@mantine/dates';
 
 const Demo = () => {
     const form = useForm({
@@ -29,6 +30,7 @@ const Demo = () => {
             radio: '1',
             switch: false,
             file: '',
+            time: '',
             select: '',
             multiSelect: [],
             codeEditor: '{"key": "value"}',
@@ -53,6 +55,8 @@ const Demo = () => {
                         readOnly={form.values.readOnly}
                         disabled={form.values.disabled}
                         placeholder="Text input placeholder"
+                        // leftSection={<IconSearch size={16} />}
+                        // error="This is an error"
                     />
                 </Stack>
                 <Stack gap="xs">
@@ -107,6 +111,17 @@ const Demo = () => {
                     <Title order={4}>FileInput</Title>
                     <FileInput
                         {...form.getInputProps('file')}
+                        label={form.values.label}
+                        description={form.values.description}
+                        withAsterisk={form.values.withAsterisk}
+                        readOnly={form.values.readOnly}
+                        disabled={form.values.disabled}
+                    />
+                </Stack>
+                <Stack gap="xs">
+                    <Title order={4}>TimeInput</Title>
+                    <TimeInput
+                        {...form.getInputProps('time')}
                         label={form.values.label}
                         description={form.values.description}
                         withAsterisk={form.values.withAsterisk}


### PR DESCRIPTION
### Proposed Changes

This PR adds few changes made on Input (Text, Number and Time).

|  | Before | After |
|----------|----------|----------|
| spacing   | <img width="415" height="137" alt="image" src="https://github.com/user-attachments/assets/45682034-1740-4a3b-8e8a-ffca58b3180a" />     | <img width="407" height="143" alt="image" src="https://github.com/user-attachments/assets/b9ee3293-1898-49c8-b2df-5c5ca16f250e" />    |
| control :hover   | <img width="413" height="146" alt="image" src="https://github.com/user-attachments/assets/c6b53b14-5b7d-47c8-bfc7-1e24bcbfd5f5" />     | <img width="413" height="138" alt="image" src="https://github.com/user-attachments/assets/9be887c4-6ea8-4bcf-933a-cf5e0efdbe5a" />    |
| rightSection icon    | <img width="407" height="124" alt="image" src="https://github.com/user-attachments/assets/6517c77b-160e-467a-8a7a-559e06503813" />     | <img width="407" height="138" alt="image" src="https://github.com/user-attachments/assets/5dda4444-f398-4c91-b7a0-b4c5c3d1ec27" />    |

The TimeInput screenshot for _before_ was taken from mantine directly (and was added to the Form.demo.tsx), but as you can see, the default behavior does not use an icon for the rightSection

I also fixed the leftSection icon being red if the input is in error state (custom component broke the default behavior handled by mantine by default... Which is something that is bound to happen a lot with customization of css element not provided by mantine

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
