### PR TITLE
Ad UI 10704 apply style changes to radio card

### DIFF
--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -4,7 +4,7 @@
     }
 }
 
-.card:hover([disabled]) {
+.card[disabled] {
     @mixin light {
         cursor: default;
     }

--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -1,0 +1,5 @@
+.card:hover {
+    @mixin light {
+        background-color: var(--mantine-color-default-hover);
+    }
+}

--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -1,4 +1,4 @@
-.card:hover:not([disabled], [readonly]) {
+.card:hover:not([disabled]) {
     @mixin light {
         background-color: var(--mantine-color-default-hover);
     }

--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -4,8 +4,8 @@
     }
 }
 
-.card[disabled] {
-    @mixin light {
-        cursor: default;
+.card {
+    &[disabled] {
+        pointer-events: none;
     }
 }

--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -1,4 +1,4 @@
-.card:hover {
+.card:hover:not([disabled], [readonly]) {
     @mixin light {
         background-color: var(--mantine-color-default-hover);
     }

--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -3,3 +3,9 @@
         background-color: var(--mantine-color-default-hover);
     }
 }
+
+.card:hover([disabled]) {
+    @mixin light {
+        cursor: default;
+    }
+}

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -68,6 +68,7 @@ import NavLinkClasses from '../styles/NavLink.module.css';
 import PaginationClasses from '../styles/Pagination.module.css';
 import PillClasses from '../styles/Pill.module.css';
 import RadioClasses from '../styles/Radio.module.css';
+import RadioCardClasses from '../styles/RadioCard.module.css';
 import ReadOnlyInputClasses from '../styles/ReadOnlyInput.module.css';
 import ReadOnlyStateClasses from '../styles/ReadOnlyState.module.css';
 import ScrollAreaClasses from '../styles/ScrollArea.module.css';
@@ -360,6 +361,9 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 }
                 return {root: {}};
             },
+        }),
+        RadioCard: Radio.Card.extend({
+            classNames: RadioCardClasses,
         }),
         ScrollArea: ScrollArea.extend({
             classNames: ScrollAreaClasses,


### PR DESCRIPTION
### Proposed Changes

[JIRA](https://coveord.atlassian.net/browse/ADUI-10704)

[FIGMA](https://www.figma.com/design/lFjxQoLHYzdLObC0g4HdWd/Opal-Components--Pretine-source-library-?node-id=10029-56434&t=mI7ocwIoeGdyDPDt-0)

<!-- Explain what are your changes. -->
On hover:

Before:
<img width="1069" height="163" alt="image" src="https://github.com/user-attachments/assets/0d71f15e-8b6e-4d9d-b855-84a9f7f659a4" />

After:
<img width="1072" height="175" alt="image" src="https://github.com/user-attachments/assets/f4b27c29-0f3b-4e53-92cf-6faf6b4e267c" />

Mockups:
<img width="736" height="228" alt="image" src="https://github.com/user-attachments/assets/3e20460e-7328-4493-8871-fd497e787a57" />

This change can only be seen by modifing the RadioCard demo in the Radio section of Mantine components. You need to remove the hover color in the Radio.demo.card.module.css file and you should see the new color appear on hover.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
