### PR TITLE
feat(multiselect): change pill text color, revert gap inputwrapper

### DIFF
--- a/packages/mantine/src/styles/InputWrapper.module.css
+++ b/packages/mantine/src/styles/InputWrapper.module.css
@@ -1,7 +1,7 @@
 .root {
     display: flex;
     flex-direction: column;
-    gap: var(--mantine-spacing-xs);
+    gap: var(--mantine-spacing-xxs);
 }
 
 .label {

--- a/packages/mantine/src/styles/Pill.module.css
+++ b/packages/mantine/src/styles/Pill.module.css
@@ -1,3 +1,4 @@
 .root {
+    color: var(--mantine-color-text);
     background-color: var(--mantine-color-gray-light);
 }


### PR DESCRIPTION
### Proposed Changes

Most of the MultiSelect visual changes were already made from a previous PR. 

[FIGMA](https://www.figma.com/design/lFjxQoLHYzdLObC0g4HdWd/Opal-Components--Pretine-source-library-?node-id=10364-11750&m=dev)
[JIRA](https://coveord.atlassian.net/browse/ADUI-10892)

I have changed to the correct text color for the `Pill` component and I put back the 4px gap between label and description of the inputWrapper

| | Before | After |
|----------|----------|----------|
| Pill    | <img width="71" height="42" alt="image" src="https://github.com/user-attachments/assets/e0ab4b01-f88e-4348-aa35-f97f01f199a6" />     | <img width="58" height="42" alt="image" src="https://github.com/user-attachments/assets/aa9235e5-806c-4831-8ff9-435657cc2a28" />     |
| InputWrapper | <img width="401" height="138" alt="image" src="https://github.com/user-attachments/assets/69318431-f9d7-4290-bc3b-122754c412df" />     | <img width="399" height="125" alt="image" src="https://github.com/user-attachments/assets/0ea21692-ce04-42cc-b19f-7b1d1edacf4c" />     |

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
