### PR TITLE
feat(mantine,browserpreview): update style

### DIFF
--- a/packages/mantine/src/components/browser-preview/BrowserPreview.module.css
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.module.css
@@ -1,21 +1,12 @@
 .root {
-    box-shadow: var(--mantine-shadow-md);
-    border-radius: var(--mantine-radius-default);
+    border-radius: var(--mantine-radius-lg);
     border: 1px solid;
     border-color: var(--mantine-color-default-border);
     flex: 1;
-}
-
-.header {
-    box-shadow: var(--mantine-shadow-xs);
-    border-radius: var(--mantine-radius-default) var(--mantine-radius-default) 0 0;
+    overflow: hidden;
 }
 
 .content {
     overflow: auto;
     flex-grow: 1;
-}
-
-.infoIcon {
-    color: var(--mantine-color-gray-5);
 }

--- a/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/browser-preview/BrowserPreview.tsx
@@ -1,7 +1,7 @@
-import {InfoSize16Px} from '@coveord/plasma-react-icons';
-import {Box, ColorSwatch, Flex, Group, Stack, StackProps, Text, Title, Tooltip, useMantineTheme} from '@mantine/core';
+import {Flex, Group, Stack, StackProps, Text, Tooltip} from '@mantine/core';
 import cx from 'clsx';
 import {PropsWithChildren} from 'react';
+import {InfoToken} from '../info-token';
 import BrowserPreviewClasses from './BrowserPreview.module.css';
 
 export interface BrowserPreviewProps extends StackProps {
@@ -22,35 +22,27 @@ export const BrowserPreview = ({
     title,
     className,
     ...others
-}: PropsWithChildren<BrowserPreviewProps>) => {
-    const theme = useMantineTheme();
-    return (
-        <Stack className={cx(BrowserPreviewClasses.root, className)} gap={0} maw={544} mih={0} {...others}>
-            <Box>
-                <Group className={BrowserPreviewClasses.header} justify="space-between" px="sm" py="xs" bg="gray.1">
-                    <Group gap="xs">
-                        <Title c="gray.6" order={4}>
-                            Preview
-                        </Title>
-                        {!!headerTooltip && (
-                            <Tooltip label={headerTooltip} position="right" maw={400}>
-                                <InfoSize16Px height={16} className={BrowserPreviewClasses.infoIcon} />
-                            </Tooltip>
-                        )}
-                    </Group>
-                    <Text lineClamp={1} color="gray.6">
-                        {title}
-                    </Text>
-                    <Group gap="xs">
-                        <ColorSwatch color={theme.colors.gray[3]} />
-                        <ColorSwatch color={theme.colors.gray[3]} />
-                        <ColorSwatch color={theme.colors.gray[3]} />
-                    </Group>
-                </Group>
-            </Box>
-            <Flex className={BrowserPreviewClasses.content} p="xl" direction="column">
-                {children}
-            </Flex>
-        </Stack>
-    );
-};
+}: PropsWithChildren<BrowserPreviewProps>) => (
+    <Stack className={cx(BrowserPreviewClasses.root, className)} gap={0} maw={544} mih={0} {...others}>
+        <Group className={BrowserPreviewClasses.header} justify="space-between" p="sm" bg="gray.1" wrap="nowrap">
+            <Group gap="xs" wrap="nowrap">
+                <Text c="dimmed" fz="md" lh="18px">
+                    Preview
+                </Text>
+                {!!headerTooltip && (
+                    <Tooltip label={headerTooltip} position="right" maw={400}>
+                        <InfoToken variant="information" className={BrowserPreviewClasses.infoIcon} />
+                    </Tooltip>
+                )}
+            </Group>
+            {title && (
+                <Text lineClamp={1} c="dimmed" fz="md" lh="18px">
+                    {title}
+                </Text>
+            )}
+        </Group>
+        <Flex className={BrowserPreviewClasses.content} p="lg" direction="column">
+            {children}
+        </Flex>
+    </Stack>
+);

--- a/packages/mantine/src/components/browser-preview/__tests__/BrowserPreview.spec.tsx
+++ b/packages/mantine/src/components/browser-preview/__tests__/BrowserPreview.spec.tsx
@@ -6,16 +6,17 @@ describe('BrowserPreview', () => {
     it('shows no tooltip when none specified', async () => {
         render(<BrowserPreview />);
 
-        expect(screen.queryByRole('img', {name: /info/i})).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: /information/i})).not.toBeInTheDocument();
     });
+
     it('renders the specified text as the header tooltip content', async () => {
         const user = userEvent.setup();
         const headerTooltip = 'This is a custom description.';
 
         render(<BrowserPreview headerTooltip={headerTooltip} />);
 
-        await waitFor(() => screen.findByRole('img', {name: /info/i}));
-        await user.hover(screen.getByRole('img', {name: /info/i}));
+        await waitFor(() => screen.findByRole('img', {name: /information/i}));
+        await user.hover(screen.getByRole('img', {name: /information/i}));
 
         await waitFor(() => expect(screen.getByText(headerTooltip)).toBeVisible());
     });

--- a/packages/mantine/src/components/info-token/InfoToken.tsx
+++ b/packages/mantine/src/components/info-token/InfoToken.tsx
@@ -142,6 +142,7 @@ export const InfoToken: ReturnType<typeof polymorphicFactory<InfoTokenFactory>> 
                 ref={ref}
                 variant={variant}
                 role="img"
+                aria-label={variant}
                 size={size}
                 {...getStyles('root', {
                     className,
@@ -151,7 +152,7 @@ export const InfoToken: ReturnType<typeof polymorphicFactory<InfoTokenFactory>> 
                 })}
                 {...others}
             >
-                <IconComponent size={sizeResolver(size)} aria-label={variant} />
+                <IconComponent size={sizeResolver(size)} />
             </Box>
         );
     },


### PR DESCRIPTION
### Proposed Changes

Update the style of the BrowserPreview component

|Before|After|Mockup|
|---|---|---|
|<img width="591" height="749" alt="image" src="https://github.com/user-attachments/assets/d37727d8-097b-4aef-8304-b32ba3075ebb" />|<img width="593" height="749" alt="image" src="https://github.com/user-attachments/assets/17b8265c-d47a-4623-bf58-3d64855e4591" />|<img width="574" height="685" alt="image" src="https://github.com/user-attachments/assets/0e1de6f8-a1bd-4274-8e02-dc7c1420567d" />|




### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
