### PR TITLE
feat(mantine,card): create card variant hover and selected state

### DIFF
--- a/packages/mantine/src/styles/Card.module.css
+++ b/packages/mantine/src/styles/Card.module.css
@@ -1,0 +1,22 @@
+.root {
+    transition: box-shadow 150ms ease-in-out;
+
+    &:not([data-with-border]) {
+        border: 1px solid transparent;
+    }
+
+    &[data-selected] {
+        border: 1px solid var(--mantine-primary-color-filled);
+    }
+
+    &[data-variant='hover']:not([data-disabled]) {
+        &:hover {
+            cursor: pointer;
+            box-shadow: var(--mantine-shadow-sm);
+        }
+    }
+
+    &[data-disabled] {
+        pointer-events: none;
+    }
+}

--- a/packages/mantine/src/styles/Paper.module.css
+++ b/packages/mantine/src/styles/Paper.module.css
@@ -1,0 +1,5 @@
+.root {
+    @mixin light {
+        --paper-border-color: var(--mantine-color-default-border);
+    }
+}

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -16,6 +16,7 @@ import {
     Badge,
     Breadcrumbs,
     Button,
+    Card,
     Checkbox,
     Chip,
     CloseButton,
@@ -37,6 +38,7 @@ import {
     Notification,
     NumberInput,
     Pagination,
+    Paper,
     Pill,
     Popover,
     Radio,
@@ -59,6 +61,7 @@ import AlertClasses from '../styles/Alert.module.css';
 import BadgeClasses from '../styles/Badge.module.css';
 import BreadcrumbsClasses from '../styles/Breadcrumbs.module.css';
 import ButtonClasses from '../styles/Button.module.css';
+import CardClasses from '../styles/Card.module.css';
 import CheckboxClasses from '../styles/Checkbox.module.css';
 import CheckboxIndicatorClasses from '../styles/CheckboxIndicator.module.css';
 import ChipClasses from '../styles/Chip.module.css';
@@ -70,6 +73,7 @@ import ModalClasses from '../styles/Modal.module.css';
 import NavLinkClasses from '../styles/NavLink.module.css';
 import NumberInputClasses from '../styles/NumberInput.module.css';
 import PaginationClasses from '../styles/Pagination.module.css';
+import PaperClasses from '../styles/Paper.module.css';
 import PillClasses from '../styles/Pill.module.css';
 import RadioClasses from '../styles/Radio.module.css';
 import RadioCardClasses from '../styles/RadioCard.module.css';
@@ -189,6 +193,15 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 size: 'sm',
             },
             classNames: ButtonClasses,
+        }),
+        Card: Card.extend({
+            defaultProps: {
+                radius: 'lg',
+                shadow: 'xs',
+                padding: 'sm',
+                withBorder: true,
+            },
+            classNames: CardClasses,
         }),
         Checkbox: Checkbox.extend({
             defaultProps: {
@@ -340,6 +353,9 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
                 nextIcon: ArrowHeadRightSize16Px,
                 previousIcon: ArrowHeadLeftSize16Px,
             },
+        }),
+        Paper: Paper.extend({
+            classNames: PaperClasses,
         }),
         Pill: Pill.extend({
             classNames: PillClasses,

--- a/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
+++ b/packages/website/src/examples/layout/Table/TableLayouts.demo.tsx
@@ -1,10 +1,11 @@
 import {
     Box,
+    Card,
     ColumnDef,
     createColumnHelper,
-    Paper,
     renderTableCell,
     SimpleGrid,
+    Stack,
     Table,
     TableLayout,
     TableLayoutProps,
@@ -23,40 +24,36 @@ const TableCards = <TData,>(props: TableLayoutProps<TData>) => {
         .map((header) => (
             <Title order={6}>{renderTableCell(header.column.columnDef.header, header.getContext())}</Title>
         ));
-    const cards = table.getRowModel().rows.map((row) => {
-        const isSelected = !!row.getIsSelected();
-        return (
-            <Paper
-                key={row.id}
-                shadow={isSelected ? 'xs' : 'md'}
-                withBorder={isSelected}
-                p="md"
-                onClick={(event) => {
-                    if (event.detail <= 1) {
-                        row.toggleSelected(true);
-                    } else {
-                        props.onRowDoubleClick?.(row.original, row.index, row);
-                    }
-                }}
-            >
-                <SimpleGrid cols={3} spacing="md">
-                    {row.getVisibleCells().map((cell, index) => (
-                        <Box key={cell.id}>
-                            <Table.Loading visible={props.loading}>
-                                {headers[index]}
-                                {renderTableCell(cell.column.columnDef.cell, cell.getContext())}
-                            </Table.Loading>
-                        </Box>
-                    ))}
-                </SimpleGrid>
-            </Paper>
-        );
-    });
+    const cards = table.getRowModel().rows.map((row) => (
+        <Card
+            key={row.id}
+            mod={{selected: row.getIsSelected()}}
+            variant="hover"
+            onClick={(event) => {
+                if (event.detail <= 1) {
+                    row.toggleSelected(true);
+                } else {
+                    props.onRowDoubleClick?.(row.original, row.index, row);
+                }
+            }}
+        >
+            <Stack gap="sm">
+                {row.getVisibleCells().map((cell, index) => (
+                    <Box key={cell.id}>
+                        <Table.Loading visible={props.loading}>
+                            {headers[index]}
+                            {renderTableCell(cell.column.columnDef.cell, cell.getContext())}
+                        </Table.Loading>
+                    </Box>
+                ))}
+            </Stack>
+        </Card>
+    ));
 
     return (
         <tr>
             <td style={{padding: 0}}>
-                <SimpleGrid cols={2} spacing="lg" px="xl" py="lg">
+                <SimpleGrid cols={4} spacing="lg" px="xl" py="lg">
                     {cards}
                 </SimpleGrid>
             </td>


### PR DESCRIPTION
### Proposed Changes

Added a "hover" variant on [Mantine's Card component](https://mantine.dev/core/card/) and a "selected" state. This way it allows us to cover all required use cases.

Example with the table card layout

https://github.com/user-attachments/assets/325258a0-e943-4119-aee3-a0e3767569e8

Mockups

<img width="1141" height="995" alt="image" src="https://github.com/user-attachments/assets/3ea4f273-065a-4a54-9e0a-b1d9343d3ad2" />


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
