### PR TITLE
feat(actionicon): change default size to 36px

### DIFF
--- a/packages/mantine/src/styles/ActionIcon.module.css
+++ b/packages/mantine/src/styles/ActionIcon.module.css
@@ -1,4 +1,6 @@
 .root {
+    --ai-size: 36px;
+
     &[data-variant='subtle'] {
         &:where(:disabled:not([data-loading]), [data-disabled]:not([data-loading])) {
             background: transparent;

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -169,9 +169,6 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             classNames: AccordionClasses,
         }),
         ActionIcon: ActionIcon.extend({
-            defaultProps: {
-                size: 'lg',
-            },
             classNames: ActionIconClasses,
         }),
         AppShell: AppShell.extend({


### PR DESCRIPTION
### Proposed Changes

Changed the default ActionIcon size to 36px

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
