### PR TITLE
fix(Mantine, Prompt): padding between body and footer

### DIFF
--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -50,7 +50,7 @@ export type PromptFactory = Factory<{
     staticComponents: {
         CancelButton: typeof PromptCancelButton;
         ConfirmButton: typeof PromptConfirmButton;
-        Footer: typeof Modal.Footer;
+        Footer: typeof PromptFooter;
     };
 }>;
 
@@ -115,6 +115,8 @@ export const Prompt = factory<PromptFactory>((_props, ref) => {
     );
 });
 
+const PromptFooter = Modal.Footer.withProps({pt: 0});
+
 Prompt.CancelButton = PromptCancelButton;
 Prompt.ConfirmButton = PromptConfirmButton;
-Prompt.Footer = Modal.Footer;
+Prompt.Footer = PromptFooter;


### PR DESCRIPTION
### Proposed Changes

Removed the double padding between the content of the `Prompt` and the footer by removing the padding top on the `Prompt.Footer`.

| Before | After | 
| --- | --- |
| <img width="675" height="287" alt="image" src="https://github.com/user-attachments/assets/a418d917-6c63-42b1-ae5d-01b48fc8491f" /> | <img width="673" height="257" alt="image" src="https://github.com/user-attachments/assets/1bd44f48-ff57-42f4-97c9-7b18ca5d0384" /> |


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
