### PR TITLE
fix: remaining imports without explicit file extension

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -12,7 +12,7 @@ import {
     useStyles,
 } from '@mantine/core';
 import {Children, ElementType, ReactElement, ReactNode} from 'react';
-import {HeaderProvider} from './Header.context';
+import {HeaderProvider} from './Header.context.js';
 import classes from './Header.module.css';
 import {
     HeaderBreadcrumbAnchor,

--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mantine/core';
 import {Children, ComponentType, ReactElement, ReactNode} from 'react';
 import {Modal} from '../modal/index.js';
-import {PromptContextProvider} from './Prompt.context';
+import {PromptContextProvider} from './Prompt.context.js';
 import classes from './Prompt.module.css';
 import {PromptCancelButton, PromptCancelButtonStylesNamesVariant} from './PromptCancelButton.js';
 import {PromptConfirmButton, PromptConfirmButtonStylesNamesVariant} from './PromptConfirmButton.js';

--- a/packages/mantine/src/components/prompt/PromptCancelButton.tsx
+++ b/packages/mantine/src/components/prompt/PromptCancelButton.tsx
@@ -1,6 +1,6 @@
 import {CompoundStylesApiProps, factory, Factory, useProps} from '@mantine/core';
 import {Button, ButtonProps} from '../button/Button.js';
-import {usePromptContext} from './Prompt.context';
+import {usePromptContext} from './Prompt.context.js';
 
 export type PromptCancelButtonStylesNamesVariant = 'cancel';
 

--- a/packages/mantine/src/components/prompt/PromptConfirmButton.tsx
+++ b/packages/mantine/src/components/prompt/PromptConfirmButton.tsx
@@ -2,7 +2,7 @@ import {CompoundStylesApiProps, factory, Factory, PolymorphicComponentProps, use
 import {JSXElementConstructor, ReactElement} from 'react';
 import {Button, ButtonProps} from '../button/Button.js';
 import {PromptVariant} from './Prompt.js';
-import {usePromptContext} from './Prompt.context';
+import {usePromptContext} from './Prompt.context.js';
 
 export type PromptConfirmButtonStylesNamesVariant = 'confirm';
 

--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -12,7 +12,7 @@ import isEqual from 'fast-deep-equal';
 import {Children, ForwardedRef, ReactElement, useEffect, useRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../utils/index.js';
 import classes from './Table.module.css';
-import {TableLayout, TableProps} from './Table.types';
+import {TableLayout, TableProps} from './Table.types.js';
 import {TableProvider} from './TableContext.js';
 import {TableLayouts} from './layouts/TableLayouts.js';
 import {TableActionItem, TableActionItemStylesNames, TableHeaderActionsStylesNames} from './table-actions/index.js';

--- a/packages/mantine/src/components/table/TableContext.tsx
+++ b/packages/mantine/src/components/table/TableContext.tsx
@@ -2,7 +2,7 @@ import {createSafeContext, GetStylesApi} from '@mantine/core';
 import {Table} from '@tanstack/table-core';
 import {MutableRefObject, ReactElement} from 'react';
 import {type PlasmaTableFactory} from './Table.js';
-import {TableAction, TableLayout} from './Table.types';
+import {TableAction, TableLayout} from './Table.types.js';
 import {TableStore} from './use-table.js';
 
 export interface TableContextValue<TData = unknown> {

--- a/packages/mantine/src/components/table/index.ts
+++ b/packages/mantine/src/components/table/index.ts
@@ -1,7 +1,7 @@
 export {flexRender as renderTableCell} from '@tanstack/react-table';
 export * from './Table.js';
 export {type TablePredicateProps} from './table-predicate/TablePredicate.js';
-export {type TableAction, type TableLayout, type TableLayoutProps, type TableProps} from './Table.types';
+export {type TableAction, type TableLayout, type TableLayoutProps, type TableProps} from './Table.types.js';
 export {useTableContext} from './TableContext.js';
 export {useTable, type TableState, type TableStore, type UseTableOptions} from './use-table.js';
 export {useUrlSyncedState, type UseUrlSyncedStateOptions, type SearchParamEntry} from './use-url-synced-state.js';

--- a/packages/mantine/src/components/table/table-pagination/TablePagination.tsx
+++ b/packages/mantine/src/components/table/table-pagination/TablePagination.tsx
@@ -2,7 +2,7 @@ import {Pagination} from '@mantine/core';
 import {useDidUpdate} from '@mantine/hooks';
 import {FunctionComponent} from 'react';
 
-import {TablePaginationProps} from './TablePagination.types';
+import {TablePaginationProps} from './TablePagination.types.js';
 import {useTableContext} from '../TableContext.js';
 
 export const TablePagination: FunctionComponent<TablePaginationProps> = ({onPageChange}) => {

--- a/packages/mantine/src/components/table/table-per-page/TablePerPage.tsx
+++ b/packages/mantine/src/components/table/table-per-page/TablePerPage.tsx
@@ -2,7 +2,7 @@ import {Group, SegmentedControl, Text} from '@mantine/core';
 import {FunctionComponent, useMemo} from 'react';
 
 import {useTableContext} from '../TableContext.js';
-import {TablePerPageProps} from './TablePerPage.types';
+import {TablePerPageProps} from './TablePerPage.types.js';
 
 export const TablePerPage: FunctionComponent<TablePerPageProps> & {DEFAULT_SIZE: number} = ({
     label = 'Results per page',

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,1 +1,1 @@
-export * from './Colors';
+export * from './Colors.js';


### PR DESCRIPTION
### Proposed Changes

This pull request updates import statements to consistently use explicit `.js` file extensions that were forgotten in the last PR (#4145). No changes to logic or functionality were made—only import paths were updated for compatibility.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
