### PR TITLE
ci: enable turbo remote caching

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,9 @@ concurrency:
     group: ${{ github.ref_name }}
     cancel-in-progress: true
 
+env:
+    TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
+
 jobs:
     cd:
         name: Continuous Delivery

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         types: [opened, reopened, synchronize]
 
+env:
+    TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
+
 jobs:
     lint:
         name: Lint Changed Files

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
         "commit-cli": "cz",
         "preinstall": "npx only-allow pnpm",
         "lintfix": "pnpm --recursive --parallel lintfix",
+        "pnpm:devPreinstall": "pnpm turbo:login",
         "precommit": "lint-staged",
         "prepare": "husky",
         "reconstruct": "pnpm dlx rimraf packages/*/node_modules packages/*/.turbo node_modules && npm run setup && echo done",
         "setup": "pnpm install",
         "start": "turbo run build --filter=!@coveord/plasma-website && pnpm --recursive --parallel start",
-        "test": "turbo run test --concurrency=1"
+        "test": "turbo run test --concurrency=1",
+        "turbo:login": "node scripts/turboLogin.mjs"
     },
     "commitlint": {
         "extends": [

--- a/scripts/turboLogin.mjs
+++ b/scripts/turboLogin.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import {exec} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// The SSM parameter name where the TURBO_TOKEN is stored
+const SSM_PARAMETER_NAME = '/turborepo/token';
+
+const runCommandAndReturnText = async (command) =>
+    new Promise((resolve, reject) => {
+        exec(command, (error, stdout) => {
+            if (!error) {
+                resolve(stdout.trim());
+            } else {
+                reject(error);
+            }
+        });
+    });
+
+const validateAwsLogin = async () =>
+    await runCommandAndReturnText('aws sts get-caller-identity')
+        .then(() => true)
+        .catch(() => false);
+
+const getTurboToken = async () =>
+    await runCommandAndReturnText(
+        `aws ssm get-parameter --name "${SSM_PARAMETER_NAME}" --with-decryption --query Parameter.Value --output text`,
+    );
+
+const configureTurbo = (token) => {
+    const turboDir = './.turbo';
+    const configFile = path.join(turboDir, 'config.json');
+
+    // Create directory if it doesn't exist
+    if (!fs.existsSync(turboDir)) {
+        fs.mkdirSync(turboDir, {recursive: true});
+    }
+
+    const config = {
+        token,
+    };
+
+    fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
+};
+
+try {
+    // Set AWS profile for local development
+    process.env.AWS_PROFILE = 'dev';
+
+    // Check if user is logged into AWS
+    if (!(await validateAwsLogin())) {
+        console.log('⚠️  Not logged in to AWS - skipping Turbo login');
+        console.log('   Run "aws sso login" and "pnpm install" again to enable Turborepo remote caching');
+        process.exit(0); // Don't fail, just skip
+    }
+
+    const token = await getTurboToken();
+
+    if (!token) {
+        console.log('⚠️  Could not retrieve TURBO_TOKEN - remote caching will be disabled');
+        process.exit(0); // Don't fail, just skip
+    }
+
+    configureTurbo(token);
+    console.log('✅ Successfully logged into Turborepo - remote caching enabled!');
+} catch (error) {
+    console.log('⚠️  Error setting up Turborepo:', error.message);
+    console.log('   Remote caching will be disabled');
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://turborepo.org/schema.json",
+    "remoteCache": {
+        "teamSlug": "plasma",
+        "apiUrl": "https://djcopdhbb4ijlio2hgabt64kjy0lxwet.lambda-url.us-east-1.on.aws"
+    },
     "tasks": {
         "build": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
### Proposed Changes

This pull request introduces improvements to Turborepo remote caching and streamlines the setup for local development and CI/CD workflows. The main changes include adding a script for Turborepo authentication using AWS SSM, updating workflow files to use the `TURBO_TOKEN` secret, and configuring remote caching in Turborepo. These updates help ensure that remote caching is enabled for faster builds and that authentication is handled securely and automatically.

<details>
<summary>More details</summary>

**Turborepo Remote Caching Setup:**

* Added a new script `scripts/turboLogin.mjs` that automates fetching the Turborepo token from AWS SSM and configures it locally, improving developer experience and security.
* Updated `turbo.json` to enable remote caching with the correct team slug and API URL, allowing Turborepo to use shared build caches.

**Workflow and Environment Improvements:**

* Updated `.github/workflows/ci.yml` and `.github/workflows/cd.yml` to inject the `TURBO_TOKEN` secret into the environment, ensuring that CI/CD jobs can use Turborepo remote caching. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR7-R9) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R9-R11)

**Package Management Enhancements:**

* Added a new `pnpm:devPreinstall` script in `package.json` to run the Turborepo login script automatically during setup, and defined the `turbo:login` command for manual execution.
</details>


Before
<img width="868" height="460" alt="image" src="https://github.com/user-attachments/assets/10d2865b-dca9-4d16-a5c7-ed2e197bdba2" />

After
<img width="827" height="463" alt="Screenshot 2025-09-24 at 8 57 55 PM" src="https://github.com/user-attachments/assets/bcec091c-f5cc-491e-ac5b-abd2b39679cd" />


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
