### PR TITLE
chore: remove node auth token from cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,19 +9,20 @@ concurrency:
 env:
     TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
 
+permissions:
+    pull-requests: write
+    id-token: write
+    actions: read
+    contents: write
+    security-events: write
+    statuses: write
+
 jobs:
     cd:
         name: Continuous Delivery
         if: github.ref_name == 'master' || github.ref_name == 'next'
         runs-on: ubuntu-latest
         environment: production
-        permissions:
-            pull-requests: write
-            id-token: write
-            actions: read
-            contents: write
-            security-events: write
-            statuses: write
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,6 @@ jobs:
               env:
                   DEBUG: '*'
                   DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
             - name: Deploy
               uses: ./.github/actions/deploy
               # Demo for next branch is deployed by the CI workflow


### PR DESCRIPTION
### Proposed Changes

I'm setting up Trusted publisher in the repo, and the last run failed. My guess is that it tried to use the token instead of the OIDC flow.

I've also moved the permissions section to the whole flow instead of having it in the job

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
