### PR TITLE
fix(react-icons): missing element in cache prevent package publish

### DIFF
--- a/packages/react-icons/turbo.json
+++ b/packages/react-icons/turbo.json
@@ -1,0 +1,8 @@
+{
+    "extends": ["//"],
+    "tasks": {
+        "build": {
+            "outputs": ["dist/**", "mock/index.js"]
+        }
+    }
+}


### PR DESCRIPTION
### Proposed Changes

Added an override for turbo cache in react-icons, since it produce the mock/index.js artefact

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
