### PR TITLE
feat(mantine): add CopyToClipboard.Menu

### DIFF
--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -16,8 +16,15 @@ export type {
     CopyToClipboardMenuItemProps,
 } from './CopyToClipboardMenu.js';
 
+export interface CopyToClipboardLegacyProps extends CopyToClipboardButtonProps {
+    /**
+     * @deprecated Use `CopyToClipboard.Input` instead.
+     */
+    withLabel?: boolean;
+}
+
 export type CopyToClipboardFactory = Factory<{
-    props: CopyToClipboardButtonProps;
+    props: CopyToClipboardLegacyProps;
     ref: never;
     staticComponents: {
         Button: typeof CopyToClipboardButton;
@@ -28,7 +35,7 @@ export type CopyToClipboardFactory = Factory<{
     };
 }>;
 
-const defaultProps: Partial<CopyToClipboardButtonProps> = {};
+const defaultProps: Partial<CopyToClipboardLegacyProps> = {};
 
 export const CopyToClipboard = ((_props) => {
     const {withLabel, value, onCopy, color, tooltipLabelCopy, tooltipLabelCopied, ...others} = useProps(

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -1,80 +1,50 @@
-import {IconClipboardCheck, IconClipboardText} from '@coveord/plasma-react-icons';
-import {ActionIconProps, CopyButton, MantineColor, TextInput, Tooltip} from '@mantine/core';
-import {FunctionComponent, MouseEventHandler} from 'react';
-import {ActionIcon} from '../ActionIcon/ActionIcon.js';
+import {FunctionComponent} from 'react';
+import {CopyToClipboardButton, CopyToClipboardButtonProps} from './CopyToClipboardButton.js';
+import {CopyToClipboardInput} from './CopyToClipboardInput.js';
+import {CopyToClipboardMenu, CopyToClipboardMenuTarget, CopyToClipboardMenuItem} from './CopyToClipboardMenu.js';
 
-export interface CopyToClipboardProps extends ActionIconProps {
-    /**
-     * The value to be copied to the clipboard.
-     */
-    value: string;
-    /**
-     * Whether to display the string to be copied alongside the button.
-     *
-     * @default false
-     */
-    withLabel?: boolean;
-    /**
-     * Called each time the value is copied to the clipboard
-     */
-    onCopy?: MouseEventHandler<HTMLButtonElement>;
-    /**
-     * The color of the icon when idle
-     *
-     * @default 'gray'
-     */
-    color?: MantineColor | (string & {});
-    /**
-     * The text displayed when hovering over the button
-     *
-     * @default 'Copy to clipboard'
-     */
-    tooltipLabelCopy?: string;
-    /**
-     * The text displayed when the value is copied to the clipboard
-     *
-     * @default 'Copied'
-     */
-    tooltipLabelCopied?: string;
-}
+/**
+ * @deprecated Use `CopyToClipboardButtonProps` instead.
+ */
+export type CopyToClipboardProps = CopyToClipboardButtonProps;
 
-const CopyToClipboardButton: FunctionComponent<Omit<CopyToClipboardProps, 'withLabel'>> = ({
-    value,
-    onCopy,
-    color,
-    tooltipLabelCopy = 'Copy to clipboard',
-    tooltipLabelCopied = 'Copied',
-    ...others
-}) => (
-    <CopyButton value={value} timeout={2000}>
-        {({copied, copy}) => (
-            <Tooltip label={copied ? tooltipLabelCopied : tooltipLabelCopy}>
-                <ActionIcon.Quaternary
-                    aria-label={tooltipLabelCopy}
-                    color={copied ? 'success' : color}
-                    onClick={(clickEvent) => {
-                        copy();
-                        onCopy?.(clickEvent);
-                    }}
-                    {...others}
-                >
-                    {copied ? <IconClipboardCheck size={16} /> : <IconClipboardText size={16} />}
-                </ActionIcon.Quaternary>
-            </Tooltip>
-        )}
-    </CopyButton>
-);
+export type {CopyToClipboardBaseProps, CopyToClipboardButtonProps} from './CopyToClipboardButton.js';
+export type {CopyToClipboardInputProps} from './CopyToClipboardInput.js';
+export type {
+    CopyToClipboardMenuProps,
+    CopyToClipboardMenuTargetProps,
+    CopyToClipboardMenuItemProps,
+} from './CopyToClipboardMenu.js';
 
-export const CopyToClipboard: FunctionComponent<CopyToClipboardProps> = ({withLabel, ...others}) =>
+export const CopyToClipboard: FunctionComponent<CopyToClipboardButtonProps> & {
+    Button: typeof CopyToClipboardButton;
+    Input: typeof CopyToClipboardInput;
+    Menu: typeof CopyToClipboardMenu;
+    MenuTarget: typeof CopyToClipboardMenuTarget;
+    MenuItem: typeof CopyToClipboardMenuItem;
+} = ({withLabel, value, onCopy, color, tooltipLabelCopy, tooltipLabelCopied, ...others}) =>
     withLabel ? (
-        <TextInput
-            value={others.value}
-            readOnly
-            autoComplete="off"
-            rightSection={<CopyToClipboardButton {...others} />}
+        <CopyToClipboardInput
+            value={value}
+            onCopy={onCopy}
+            color={color}
+            tooltipLabelCopy={tooltipLabelCopy}
+            tooltipLabelCopied={tooltipLabelCopied}
         />
     ) : (
-        <CopyToClipboardButton {...others} />
+        <CopyToClipboardButton
+            value={value}
+            onCopy={onCopy}
+            color={color}
+            tooltipLabelCopy={tooltipLabelCopy}
+            tooltipLabelCopied={tooltipLabelCopied}
+            {...others}
+        />
     );
 
 CopyToClipboard.displayName = 'CopyToClipboard';
+CopyToClipboard.Button = CopyToClipboardButton;
+CopyToClipboard.Input = CopyToClipboardInput;
+CopyToClipboard.Menu = CopyToClipboardMenu;
+CopyToClipboard.MenuTarget = CopyToClipboardMenuTarget;
+CopyToClipboard.MenuItem = CopyToClipboardMenuItem;

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -1,4 +1,4 @@
-import {FunctionComponent} from 'react';
+import {Factory, MantineComponent, useProps} from '@mantine/core';
 import {CopyToClipboardButton, CopyToClipboardButtonProps} from './CopyToClipboardButton.js';
 import {CopyToClipboardInput} from './CopyToClipboardInput.js';
 import {CopyToClipboardMenu, CopyToClipboardMenuTarget, CopyToClipboardMenuItem} from './CopyToClipboardMenu.js';
@@ -16,14 +16,28 @@ export type {
     CopyToClipboardMenuItemProps,
 } from './CopyToClipboardMenu.js';
 
-export const CopyToClipboard: FunctionComponent<CopyToClipboardButtonProps> & {
-    Button: typeof CopyToClipboardButton;
-    Input: typeof CopyToClipboardInput;
-    Menu: typeof CopyToClipboardMenu;
-    MenuTarget: typeof CopyToClipboardMenuTarget;
-    MenuItem: typeof CopyToClipboardMenuItem;
-} = ({withLabel, value, onCopy, color, tooltipLabelCopy, tooltipLabelCopied, ...others}) =>
-    withLabel ? (
+export type CopyToClipboardFactory = Factory<{
+    props: CopyToClipboardButtonProps;
+    ref: never;
+    staticComponents: {
+        Button: typeof CopyToClipboardButton;
+        Input: typeof CopyToClipboardInput;
+        Menu: typeof CopyToClipboardMenu;
+        MenuTarget: typeof CopyToClipboardMenuTarget;
+        MenuItem: typeof CopyToClipboardMenuItem;
+    };
+}>;
+
+const defaultProps: Partial<CopyToClipboardButtonProps> = {};
+
+export const CopyToClipboard = ((_props) => {
+    const {withLabel, value, onCopy, color, tooltipLabelCopy, tooltipLabelCopied, ...others} = useProps(
+        'CopyToClipboard',
+        defaultProps,
+        _props,
+    );
+
+    return withLabel ? (
         <CopyToClipboardInput
             value={value}
             onCopy={onCopy}
@@ -41,6 +55,7 @@ export const CopyToClipboard: FunctionComponent<CopyToClipboardButtonProps> & {
             {...others}
         />
     );
+}) as MantineComponent<CopyToClipboardFactory>;
 
 CopyToClipboard.displayName = 'CopyToClipboard';
 CopyToClipboard.Button = CopyToClipboardButton;

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -38,7 +38,7 @@ export type CopyToClipboardFactory = Factory<{
 const defaultProps: Partial<CopyToClipboardLegacyProps> = {};
 
 export const CopyToClipboard = ((_props) => {
-    const {withLabel, value, onCopy, color, tooltipLabelCopy, tooltipLabelCopied, ...others} = useProps(
+    const {withLabel, value, onCopy, tooltipLabelCopy, tooltipLabelCopied, ...others} = useProps(
         'CopyToClipboard',
         defaultProps,
         _props,
@@ -48,7 +48,6 @@ export const CopyToClipboard = ((_props) => {
         <CopyToClipboardInput
             value={value}
             onCopy={onCopy}
-            color={color}
             tooltipLabelCopy={tooltipLabelCopy}
             tooltipLabelCopied={tooltipLabelCopied}
         />
@@ -56,7 +55,6 @@ export const CopyToClipboard = ((_props) => {
         <CopyToClipboardButton
             value={value}
             onCopy={onCopy}
-            color={color}
             tooltipLabelCopy={tooltipLabelCopy}
             tooltipLabelCopied={tooltipLabelCopied}
             {...others}

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardButton.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardButton.tsx
@@ -1,5 +1,5 @@
 import {IconClipboardCheck, IconClipboardText} from '@coveord/plasma-react-icons';
-import {CopyButton, MantineColor, Tooltip} from '@mantine/core';
+import {CopyButton, Tooltip} from '@mantine/core';
 import {MouseEventHandler, forwardRef} from 'react';
 import {ActionIcon, ActionIconProps} from '../ActionIcon/ActionIcon.js';
 
@@ -12,10 +12,6 @@ export interface CopyToClipboardBaseProps {
      * Called each time the value is copied to the clipboard.
      */
     onCopy?: MouseEventHandler<HTMLButtonElement>;
-    /**
-     * The color of the icon when idle.
-     */
-    color?: MantineColor | (string & {});
     /**
      * The text displayed when hovering over the button.
      *
@@ -32,15 +28,19 @@ export interface CopyToClipboardBaseProps {
 
 interface CopyToClipboardIconButtonProps extends Omit<ActionIconProps, 'children'> {
     copied: boolean;
-    tooltipLabelCopy: string;
-    tooltipLabelCopied: string;
+    tooltipLabelCopy?: string;
+    tooltipLabelCopied?: string;
     onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 export const CopyToClipboardIconButton = forwardRef<HTMLButtonElement, CopyToClipboardIconButtonProps>(
-    ({copied, tooltipLabelCopy, tooltipLabelCopied, color, ...others}, ref) => (
-        <Tooltip label={copied ? tooltipLabelCopied : tooltipLabelCopy}>
-            <ActionIcon.Quaternary ref={ref} color={copied ? 'success' : color} {...others}>
+    ({copied, tooltipLabelCopy = 'Copy to clipboard', tooltipLabelCopied = 'Copied', ...others}, ref) => (
+        <Tooltip
+            key={`${copied ? 'copied' : 'copy'}-tooltip`}
+            label={copied ? tooltipLabelCopied : tooltipLabelCopy}
+            opened={copied || undefined}
+        >
+            <ActionIcon.Quaternary ref={ref} {...others}>
                 {copied ? <IconClipboardCheck size={16} /> : <IconClipboardText size={16} />}
             </ActionIcon.Quaternary>
         </Tooltip>
@@ -52,9 +52,8 @@ export interface CopyToClipboardButtonProps extends ActionIconProps, CopyToClipb
 export const CopyToClipboardButton = ({
     value,
     onCopy,
-    color,
-    tooltipLabelCopy = 'Copy to clipboard',
-    tooltipLabelCopied = 'Copied',
+    tooltipLabelCopy,
+    tooltipLabelCopied,
     ...others
 }: CopyToClipboardButtonProps) => (
     <CopyButton value={value} timeout={2000}>
@@ -62,7 +61,6 @@ export const CopyToClipboardButton = ({
             <CopyToClipboardIconButton
                 aria-label={tooltipLabelCopy}
                 copied={copied}
-                color={color}
                 tooltipLabelCopy={tooltipLabelCopy}
                 tooltipLabelCopied={tooltipLabelCopied}
                 onClick={(clickEvent) => {

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardButton.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardButton.tsx
@@ -40,7 +40,7 @@ export const CopyToClipboardIconButton = forwardRef<HTMLButtonElement, CopyToCli
             label={copied ? tooltipLabelCopied : tooltipLabelCopy}
             opened={copied || undefined}
         >
-            <ActionIcon.Quaternary ref={ref} {...others}>
+            <ActionIcon.Quaternary ref={ref} {...others} aria-label={tooltipLabelCopy}>
                 {copied ? <IconClipboardCheck size={16} /> : <IconClipboardText size={16} />}
             </ActionIcon.Quaternary>
         </Tooltip>
@@ -59,7 +59,6 @@ export const CopyToClipboardButton = ({
     <CopyButton value={value} timeout={2000}>
         {({copied, copy}) => (
             <CopyToClipboardIconButton
-                aria-label={tooltipLabelCopy}
                 copied={copied}
                 tooltipLabelCopy={tooltipLabelCopy}
                 tooltipLabelCopied={tooltipLabelCopied}

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardButton.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardButton.tsx
@@ -1,0 +1,85 @@
+import {IconClipboardCheck, IconClipboardText} from '@coveord/plasma-react-icons';
+import {ActionIconProps, CopyButton, MantineColor, Tooltip} from '@mantine/core';
+import {MouseEventHandler, forwardRef} from 'react';
+import {ActionIcon} from '../ActionIcon/ActionIcon.js';
+
+export interface CopyToClipboardBaseProps {
+    /**
+     * The value to be copied to the clipboard.
+     */
+    value: string;
+    /**
+     * Called each time the value is copied to the clipboard.
+     */
+    onCopy?: MouseEventHandler<HTMLButtonElement>;
+    /**
+     * The color of the icon when idle.
+     *
+     * @default 'teal'
+     */
+    color?: MantineColor | (string & {});
+    /**
+     * The text displayed when hovering over the button.
+     *
+     * @default 'Copy to clipboard'
+     */
+    tooltipLabelCopy?: string;
+    /**
+     * The text displayed when the value is copied to the clipboard.
+     *
+     * @default 'Copied'
+     */
+    tooltipLabelCopied?: string;
+}
+
+interface CopyToClipboardIconButtonProps extends Omit<ActionIconProps, 'children'> {
+    copied: boolean;
+    tooltipLabelCopy: string;
+    tooltipLabelCopied: string;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export const CopyToClipboardIconButton = forwardRef<HTMLButtonElement, CopyToClipboardIconButtonProps>(
+    ({copied, tooltipLabelCopy, tooltipLabelCopied, color, ...others}, ref) => (
+        <Tooltip label={copied ? tooltipLabelCopied : tooltipLabelCopy}>
+            <ActionIcon.Quaternary ref={ref} color={copied ? 'success' : color} {...others}>
+                {copied ? <IconClipboardCheck size={16} /> : <IconClipboardText size={16} />}
+            </ActionIcon.Quaternary>
+        </Tooltip>
+    ),
+);
+
+export interface CopyToClipboardButtonProps extends ActionIconProps, CopyToClipboardBaseProps {
+    /**
+     * @deprecated Use `CopyToClipboard.Input` instead.
+     */
+    withLabel?: boolean;
+}
+
+export const CopyToClipboardButton = ({
+    value,
+    onCopy,
+    color,
+    tooltipLabelCopy = 'Copy to clipboard',
+    tooltipLabelCopied = 'Copied',
+    ...others
+}: CopyToClipboardButtonProps) => (
+    <CopyButton value={value} timeout={2000}>
+        {({copied, copy}) => (
+            <CopyToClipboardIconButton
+                aria-label={tooltipLabelCopy}
+                copied={copied}
+                color={color}
+                tooltipLabelCopy={tooltipLabelCopy}
+                tooltipLabelCopied={tooltipLabelCopied}
+                onClick={(clickEvent) => {
+                    copy();
+                    onCopy?.(clickEvent);
+                }}
+                {...others}
+            />
+        )}
+    </CopyButton>
+);
+
+CopyToClipboardButton.displayName = 'CopyToClipboard.Button';

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardButton.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardButton.tsx
@@ -1,7 +1,7 @@
 import {IconClipboardCheck, IconClipboardText} from '@coveord/plasma-react-icons';
-import {ActionIconProps, CopyButton, MantineColor, Tooltip} from '@mantine/core';
+import {CopyButton, MantineColor, Tooltip} from '@mantine/core';
 import {MouseEventHandler, forwardRef} from 'react';
-import {ActionIcon} from '../ActionIcon/ActionIcon.js';
+import {ActionIcon, ActionIconProps} from '../ActionIcon/ActionIcon.js';
 
 export interface CopyToClipboardBaseProps {
     /**
@@ -14,8 +14,6 @@ export interface CopyToClipboardBaseProps {
     onCopy?: MouseEventHandler<HTMLButtonElement>;
     /**
      * The color of the icon when idle.
-     *
-     * @default 'teal'
      */
     color?: MantineColor | (string & {});
     /**
@@ -49,12 +47,7 @@ export const CopyToClipboardIconButton = forwardRef<HTMLButtonElement, CopyToCli
     ),
 );
 
-export interface CopyToClipboardButtonProps extends ActionIconProps, CopyToClipboardBaseProps {
-    /**
-     * @deprecated Use `CopyToClipboard.Input` instead.
-     */
-    withLabel?: boolean;
-}
+export interface CopyToClipboardButtonProps extends ActionIconProps, CopyToClipboardBaseProps {}
 
 export const CopyToClipboardButton = ({
     value,

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardInput.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardInput.tsx
@@ -1,0 +1,32 @@
+import {TextInput, TextInputProps} from '@mantine/core';
+import {CopyToClipboardBaseProps, CopyToClipboardButton} from './CopyToClipboardButton.js';
+
+export interface CopyToClipboardInputProps
+    extends Omit<TextInputProps, 'value' | 'rightSection' | 'color' | 'onCopy'>, CopyToClipboardBaseProps {}
+
+export const CopyToClipboardInput = ({
+    value,
+    onCopy,
+    color,
+    tooltipLabelCopy,
+    tooltipLabelCopied,
+    ...others
+}: CopyToClipboardInputProps) => (
+    <TextInput
+        value={value}
+        readOnly
+        autoComplete="off"
+        rightSection={
+            <CopyToClipboardButton
+                value={value}
+                onCopy={onCopy}
+                color={color}
+                tooltipLabelCopy={tooltipLabelCopy}
+                tooltipLabelCopied={tooltipLabelCopied}
+            />
+        }
+        {...others}
+    />
+);
+
+CopyToClipboardInput.displayName = 'CopyToClipboard.Input';

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardInput.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardInput.tsx
@@ -2,12 +2,11 @@ import {TextInput, TextInputProps} from '@mantine/core';
 import {CopyToClipboardBaseProps, CopyToClipboardButton} from './CopyToClipboardButton.js';
 
 export interface CopyToClipboardInputProps
-    extends Omit<TextInputProps, 'value' | 'rightSection' | 'color' | 'onCopy'>, CopyToClipboardBaseProps {}
+    extends Omit<TextInputProps, 'value' | 'rightSection' | 'onCopy'>, CopyToClipboardBaseProps {}
 
 export const CopyToClipboardInput = ({
     value,
     onCopy,
-    color,
     tooltipLabelCopy,
     tooltipLabelCopied,
     ...others
@@ -20,7 +19,6 @@ export const CopyToClipboardInput = ({
             <CopyToClipboardButton
                 value={value}
                 onCopy={onCopy}
-                color={color}
                 tooltipLabelCopy={tooltipLabelCopy}
                 tooltipLabelCopied={tooltipLabelCopied}
             />

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
@@ -18,7 +18,7 @@ export interface CopyToClipboardMenuTargetProps extends Omit<ActionIconProps, 'c
 }
 
 export const CopyToClipboardMenuTarget = forwardRef<HTMLButtonElement, CopyToClipboardMenuTargetProps>(
-    ({tooltipLabelCopy = 'Copy to clipboard', tooltipLabelCopied = 'Copied', ...others}, ref) => {
+    ({tooltipLabelCopy, tooltipLabelCopied, ...others}, ref) => {
         const {copied} = useCopyToClipboardMenuContext();
         return (
             <CopyToClipboardIconButton
@@ -52,10 +52,10 @@ export const CopyToClipboardMenuItem = ({value, onCopy, children, ...others}: Co
         <CopyButton value={value} timeout={2000}>
             {({copy}) => (
                 <Menu.Item
-                    onClick={(e) => {
+                    onClick={(event) => {
                         copy();
                         onItemCopy();
-                        onCopy?.(e);
+                        onCopy?.(event);
                     }}
                     {...others}
                 >
@@ -83,8 +83,12 @@ export const CopyToClipboardMenu = ({children, ...others}: CopyToClipboardMenuPr
 
     const targets: ReactElement[] = [];
     const items: ReactNode[] = [];
-    Children.forEach(children, (child) => {
-        if (isValidElement(child) && child.type === CopyToClipboardMenuTarget) {
+    Children.toArray(children).forEach((child) => {
+        if (!isValidElement(child)) {
+            return;
+        }
+
+        if (child.type === CopyToClipboardMenuTarget) {
             targets.push(child);
         } else {
             items.push(child);

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
@@ -81,20 +81,24 @@ export const CopyToClipboardMenu = ({children, ...others}: CopyToClipboardMenuPr
         startResetTimeout();
     };
 
-    let target: ReactElement | undefined;
+    const targets: ReactElement[] = [];
     const items: ReactNode[] = [];
     Children.forEach(children, (child) => {
         if (isValidElement(child) && child.type === CopyToClipboardMenuTarget) {
-            target = child;
+            targets.push(child);
         } else {
             items.push(child);
         }
     });
 
+    if (targets.length !== 1) {
+        throw new Error('CopyToClipboard.Menu component requires exactly one CopyToClipboard.MenuTarget child.');
+    }
+
     return (
         <CopyToClipboardMenuProvider value={{copied, onItemCopy}}>
             <Menu {...others}>
-                <Menu.Target>{target}</Menu.Target>
+                <Menu.Target>{targets[0]}</Menu.Target>
                 <Menu.Dropdown>{items}</Menu.Dropdown>
             </Menu>
         </CopyToClipboardMenuProvider>

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
@@ -10,22 +10,17 @@ export interface CopyToClipboardMenuTargetProps extends Omit<ActionIconProps, 'c
      * @default 'Copy to clipboard'
      */
     tooltipLabelCopy?: string;
-    /**
-     * The text displayed when the value is copied to the clipboard.
-     * @default 'Copied'
-     */
-    tooltipLabelCopied?: string;
 }
 
 export const CopyToClipboardMenuTarget = forwardRef<HTMLButtonElement, CopyToClipboardMenuTargetProps>(
-    ({tooltipLabelCopy, tooltipLabelCopied, ...others}, ref) => {
-        const {copied} = useCopyToClipboardMenuContext();
+    ({tooltipLabelCopy, ...others}, ref) => {
+        const {copied, copiedLabel} = useCopyToClipboardMenuContext();
         return (
             <CopyToClipboardIconButton
                 ref={ref}
                 copied={copied}
                 tooltipLabelCopy={tooltipLabelCopy}
-                tooltipLabelCopied={tooltipLabelCopied}
+                tooltipLabelCopied={copiedLabel}
                 {...others}
             />
         );
@@ -40,12 +35,22 @@ export interface CopyToClipboardMenuItemProps extends Omit<MenuItemProps, 'onCli
      */
     value: string;
     /**
+     * The text displayed in the target button tooltip when this item is copied to the clipboard.
+     */
+    tooltipLabelCopied: string;
+    /**
      * Called each time the value is copied to the clipboard.
      */
     onCopy?: MouseEventHandler<HTMLButtonElement>;
 }
 
-export const CopyToClipboardMenuItem = ({value, onCopy, children, ...others}: CopyToClipboardMenuItemProps) => {
+export const CopyToClipboardMenuItem = ({
+    value,
+    tooltipLabelCopied,
+    onCopy,
+    children,
+    ...others
+}: CopyToClipboardMenuItemProps) => {
     const {onItemCopy} = useCopyToClipboardMenuContext();
     return (
         <CopyButton value={value} timeout={2000}>
@@ -53,7 +58,7 @@ export const CopyToClipboardMenuItem = ({value, onCopy, children, ...others}: Co
                 <Menu.Item
                     onClick={(event) => {
                         copy();
-                        onItemCopy();
+                        onItemCopy(tooltipLabelCopied);
                         onCopy?.(event);
                     }}
                     {...others}
@@ -73,10 +78,15 @@ export interface CopyToClipboardMenuProps extends MenuProps {
 
 export const CopyToClipboardMenu = ({children, ...others}: CopyToClipboardMenuProps) => {
     const [copied, setCopied] = useState(false);
-    const {start: startResetTimeout} = useTimeout(() => setCopied(false), 2000);
+    const [copiedLabel, setCopiedLabel] = useState<string | undefined>(undefined);
+    const {start: startResetTimeout} = useTimeout(() => {
+        setCopied(false);
+        setCopiedLabel(undefined);
+    }, 2000);
 
-    const onItemCopy = () => {
+    const onItemCopy = (label: string) => {
         setCopied(true);
+        setCopiedLabel(label);
         startResetTimeout();
     };
 
@@ -99,7 +109,7 @@ export const CopyToClipboardMenu = ({children, ...others}: CopyToClipboardMenuPr
     }
 
     return (
-        <CopyToClipboardMenuProvider value={{copied, onItemCopy}}>
+        <CopyToClipboardMenuProvider value={{copied, copiedLabel, onItemCopy}}>
             <Menu {...others}>
                 <Menu.Target>{targets[0]}</Menu.Target>
                 <Menu.Dropdown>{items}</Menu.Dropdown>

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
@@ -1,0 +1,104 @@
+import {ActionIconProps, CopyButton, Menu, MenuItemProps, MenuProps} from '@mantine/core';
+import {useTimeout} from '@mantine/hooks';
+import {Children, MouseEventHandler, ReactElement, ReactNode, forwardRef, isValidElement, useState} from 'react';
+import {CopyToClipboardIconButton} from './CopyToClipboardButton.js';
+import {CopyToClipboardMenuProvider, useCopyToClipboardMenuContext} from './CopyToClipboardMenuContext.js';
+
+export interface CopyToClipboardMenuTargetProps extends Omit<ActionIconProps, 'children'> {
+    /**
+     * The text displayed when hovering over the button.
+     * @default 'Copy to clipboard'
+     */
+    tooltipLabelCopy?: string;
+    /**
+     * The text displayed when the value is copied to the clipboard.
+     * @default 'Copied'
+     */
+    tooltipLabelCopied?: string;
+}
+
+export const CopyToClipboardMenuTarget = forwardRef<HTMLButtonElement, CopyToClipboardMenuTargetProps>(
+    ({tooltipLabelCopy = 'Copy to clipboard', tooltipLabelCopied = 'Copied', ...others}, ref) => {
+        const {copied} = useCopyToClipboardMenuContext();
+        return (
+            <CopyToClipboardIconButton
+                ref={ref}
+                aria-label={tooltipLabelCopy}
+                copied={copied}
+                tooltipLabelCopy={tooltipLabelCopy}
+                tooltipLabelCopied={tooltipLabelCopied}
+                {...others}
+            />
+        );
+    },
+);
+
+CopyToClipboardMenuTarget.displayName = 'CopyToClipboard.MenuTarget';
+
+export interface CopyToClipboardMenuItemProps extends Omit<MenuItemProps, 'onClick'> {
+    /**
+     * The value to be copied to the clipboard when this item is clicked.
+     */
+    value: string;
+    /**
+     * Called each time the value is copied to the clipboard.
+     */
+    onCopy?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export const CopyToClipboardMenuItem = ({value, onCopy, children, ...others}: CopyToClipboardMenuItemProps) => {
+    const {onItemCopy} = useCopyToClipboardMenuContext();
+    return (
+        <CopyButton value={value} timeout={2000}>
+            {({copy}) => (
+                <Menu.Item
+                    onClick={(e) => {
+                        copy();
+                        onItemCopy();
+                        onCopy?.(e);
+                    }}
+                    {...others}
+                >
+                    {children}
+                </Menu.Item>
+            )}
+        </CopyButton>
+    );
+};
+
+CopyToClipboardMenuItem.displayName = 'CopyToClipboard.MenuItem';
+
+export interface CopyToClipboardMenuProps extends MenuProps {
+    children: ReactNode;
+}
+
+export const CopyToClipboardMenu = ({children, ...others}: CopyToClipboardMenuProps) => {
+    const [copied, setCopied] = useState(false);
+    const {start: startResetTimeout} = useTimeout(() => setCopied(false), 2000);
+
+    const onItemCopy = () => {
+        setCopied(true);
+        startResetTimeout();
+    };
+
+    let target: ReactElement | undefined;
+    const items: ReactNode[] = [];
+    Children.forEach(children, (child) => {
+        if (isValidElement(child) && child.type === CopyToClipboardMenuTarget) {
+            target = child;
+        } else {
+            items.push(child);
+        }
+    });
+
+    return (
+        <CopyToClipboardMenuProvider value={{copied, onItemCopy}}>
+            <Menu {...others}>
+                <Menu.Target>{target}</Menu.Target>
+                <Menu.Dropdown>{items}</Menu.Dropdown>
+            </Menu>
+        </CopyToClipboardMenuProvider>
+    );
+};
+
+CopyToClipboardMenu.displayName = 'CopyToClipboard.Menu';

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenu.tsx
@@ -23,7 +23,6 @@ export const CopyToClipboardMenuTarget = forwardRef<HTMLButtonElement, CopyToCli
         return (
             <CopyToClipboardIconButton
                 ref={ref}
-                aria-label={tooltipLabelCopy}
                 copied={copied}
                 tooltipLabelCopy={tooltipLabelCopy}
                 tooltipLabelCopied={tooltipLabelCopied}

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenuContext.ts
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenuContext.ts
@@ -2,7 +2,8 @@ import {createSafeContext} from '@mantine/core';
 
 interface CopyToClipboardMenuContextValue {
     copied: boolean;
-    onItemCopy: () => void;
+    onItemCopy: (label: string) => void;
+    copiedLabel: string | undefined;
 }
 
 export const [CopyToClipboardMenuProvider, useCopyToClipboardMenuContext] =

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenuContext.ts
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboardMenuContext.ts
@@ -1,0 +1,9 @@
+import {createSafeContext} from '@mantine/core';
+
+interface CopyToClipboardMenuContextValue {
+    copied: boolean;
+    onItemCopy: () => void;
+}
+
+export const [CopyToClipboardMenuProvider, useCopyToClipboardMenuContext] =
+    createSafeContext<CopyToClipboardMenuContextValue>('CopyToClipboard.Menu component was not found in the tree');

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboard.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboard.component.spec.tsx
@@ -1,5 +1,4 @@
 import {render, screen, userEvent} from '@test-utils';
-
 import {CopyToClipboard} from '../CopyToClipboard.js';
 
 describe('CopyToClipboard', () => {
@@ -13,7 +12,7 @@ describe('CopyToClipboard', () => {
     });
 
     describe('when "isLabel" is true', () => {
-        it('should display an input element', () => {
+        it('displays an input element', () => {
             const testValue = 'text value';
             render(<CopyToClipboard value={testValue} withLabel />);
 

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardButton.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardButton.component.spec.tsx
@@ -1,5 +1,5 @@
 import {render, screen, userEvent} from '@test-utils';
-import {CopyToClipboard} from '../CopyToClipboard';
+import {CopyToClipboard} from '../CopyToClipboard.js';
 
 describe('CopyToClipboard.Button', () => {
     it('displays the button', () => {

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardButton.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardButton.component.spec.tsx
@@ -1,0 +1,21 @@
+import {render, screen, userEvent} from '@test-utils';
+import {CopyToClipboard} from '../CopyToClipboard';
+
+describe('CopyToClipboard.Button', () => {
+    it('displays the button', () => {
+        render(<CopyToClipboard.Button value="copied-value" />);
+
+        expect(screen.getByRole('button', {name: /copy to clipboard/i})).toBeVisible();
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    it('calls onCopy callback when the user copies the value to the clipboard', async () => {
+        const onCopySpy = vi.fn();
+        const user = userEvent.setup();
+        render(<CopyToClipboard.Button value="copied-value" onCopy={onCopySpy} />);
+
+        await user.click(screen.getByRole('button', {name: /copy to clipboard/i}));
+
+        expect(onCopySpy).toHaveBeenCalled();
+    });
+});

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardInput.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardInput.component.spec.tsx
@@ -1,0 +1,28 @@
+import {render, screen, userEvent} from '@test-utils';
+import {CopyToClipboard} from '../CopyToClipboard';
+
+describe('CopyToClipboard.Input', () => {
+    it('displays the input', () => {
+        const copiedValue = 'copied-value';
+        render(<CopyToClipboard.Input value={copiedValue} />);
+
+        expect(screen.getByRole('button', {name: /copy to clipboard/i})).toBeVisible();
+        expect(screen.getByRole('textbox')).toHaveValue(copiedValue);
+    });
+
+    it('displays the label and description', () => {
+        render(<CopyToClipboard.Input value="copied-value" label="my label" description="my description" />);
+
+        expect(screen.getByText('my label')).toBeVisible();
+        expect(screen.getByText('my description')).toBeVisible();
+    });
+
+    it('calls onCopy callback when the user copies the value to the clipboard', async () => {
+        const onCopySpy = vi.fn();
+        const user = userEvent.setup();
+
+        render(<CopyToClipboard.Input value="copied-value" onCopy={onCopySpy} />);
+        await user.click(screen.getByRole('button', {name: /copy/i}));
+        expect(onCopySpy).toHaveBeenCalled();
+    });
+});

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardInput.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardInput.component.spec.tsx
@@ -1,5 +1,5 @@
 import {render, screen, userEvent} from '@test-utils';
-import {CopyToClipboard} from '../CopyToClipboard';
+import {CopyToClipboard} from '../CopyToClipboard.js';
 
 describe('CopyToClipboard.Input', () => {
     it('displays the input', () => {

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardMenu.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardMenu.component.spec.tsx
@@ -1,5 +1,5 @@
 import {render, screen, userEvent, waitFor} from '@test-utils';
-import {CopyToClipboard} from '../CopyToClipboard';
+import {CopyToClipboard} from '../CopyToClipboard.js';
 
 describe('CopyToClipboard.Menu', () => {
     it('displays the menu', () => {

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardMenu.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardMenu.component.spec.tsx
@@ -6,8 +6,12 @@ describe('CopyToClipboard.Menu', () => {
         render(
             <CopyToClipboard.Menu>
                 <CopyToClipboard.MenuTarget />
-                <CopyToClipboard.MenuItem value="copy-name">Copy name to clipboard</CopyToClipboard.MenuItem>
-                <CopyToClipboard.MenuItem value="copy-id">Copy ID to clipboard</CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-name" tooltipLabelCopied="Name copied">
+                    Copy name to clipboard
+                </CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-id" tooltipLabelCopied="ID copied">
+                    Copy ID to clipboard
+                </CopyToClipboard.MenuItem>
             </CopyToClipboard.Menu>,
         );
 
@@ -19,8 +23,12 @@ describe('CopyToClipboard.Menu', () => {
         render(
             <CopyToClipboard.Menu>
                 <CopyToClipboard.MenuTarget />
-                <CopyToClipboard.MenuItem value="copy-name">Copy name to clipboard</CopyToClipboard.MenuItem>
-                <CopyToClipboard.MenuItem value="copy-id">Copy ID to clipboard</CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-name" tooltipLabelCopied="Name copied">
+                    Copy name to clipboard
+                </CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-id" tooltipLabelCopied="ID copied">
+                    Copy ID to clipboard
+                </CopyToClipboard.MenuItem>
             </CopyToClipboard.Menu>,
         );
 
@@ -36,10 +44,12 @@ describe('CopyToClipboard.Menu', () => {
         render(
             <CopyToClipboard.Menu>
                 <CopyToClipboard.MenuTarget />
-                <CopyToClipboard.MenuItem value="copy-name" onCopy={onCopySpy}>
+                <CopyToClipboard.MenuItem value="copy-name" tooltipLabelCopied="Name copied" onCopy={onCopySpy}>
                     Copy name to clipboard
                 </CopyToClipboard.MenuItem>
-                <CopyToClipboard.MenuItem value="copy-id">Copy ID to clipboard</CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-id" tooltipLabelCopied="ID copied">
+                    Copy ID to clipboard
+                </CopyToClipboard.MenuItem>
             </CopyToClipboard.Menu>,
         );
 
@@ -47,5 +57,25 @@ describe('CopyToClipboard.Menu', () => {
         await waitFor(() => user.click(screen.getByText('Copy name to clipboard')));
 
         expect(onCopySpy).toHaveBeenCalled();
+    });
+
+    it('displays the correct tooltip label when a menu item is copied', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <CopyToClipboard.Menu>
+                <CopyToClipboard.MenuTarget />
+                <CopyToClipboard.MenuItem value="copy-name" tooltipLabelCopied="Name copied">
+                    Copy name to clipboard
+                </CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-id" tooltipLabelCopied="ID copied">
+                    Copy ID to clipboard
+                </CopyToClipboard.MenuItem>
+            </CopyToClipboard.Menu>,
+        );
+
+        await user.click(screen.getByRole('button', {name: /copy to clipboard/i}));
+        await waitFor(() => user.click(screen.getByText('Copy name to clipboard')));
+        expect(screen.getByRole('tooltip', {name: /name copied/i})).toBeVisible();
     });
 });

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardMenu.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardMenu.component.spec.tsx
@@ -26,6 +26,7 @@ describe('CopyToClipboard.Menu', () => {
 
         await user.click(screen.getByRole('button', {name: /copy to clipboard/i}));
         await waitFor(() => expect(screen.getByText('Copy name to clipboard')).toBeVisible());
+        expect(screen.getByText('Copy ID to clipboard')).toBeVisible();
     });
 
     it('calls onCopy callback when the user copies the value to the clipboard', async () => {

--- a/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardMenu.component.spec.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/__tests__/CopyToClipboardMenu.component.spec.tsx
@@ -1,0 +1,50 @@
+import {render, screen, userEvent, waitFor} from '@test-utils';
+import {CopyToClipboard} from '../CopyToClipboard';
+
+describe('CopyToClipboard.Menu', () => {
+    it('displays the menu', () => {
+        render(
+            <CopyToClipboard.Menu>
+                <CopyToClipboard.MenuTarget />
+                <CopyToClipboard.MenuItem value="copy-name">Copy name to clipboard</CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-id">Copy ID to clipboard</CopyToClipboard.MenuItem>
+            </CopyToClipboard.Menu>,
+        );
+
+        expect(screen.getByRole('button', {name: /copy to clipboard/i})).toBeVisible();
+    });
+
+    it('opens the dropdown and shows menu items when the button is clicked', async () => {
+        const user = userEvent.setup();
+        render(
+            <CopyToClipboard.Menu>
+                <CopyToClipboard.MenuTarget />
+                <CopyToClipboard.MenuItem value="copy-name">Copy name to clipboard</CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-id">Copy ID to clipboard</CopyToClipboard.MenuItem>
+            </CopyToClipboard.Menu>,
+        );
+
+        await user.click(screen.getByRole('button', {name: /copy to clipboard/i}));
+        await waitFor(() => expect(screen.getByText('Copy name to clipboard')).toBeVisible());
+    });
+
+    it('calls onCopy callback when the user copies the value to the clipboard', async () => {
+        const onCopySpy = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <CopyToClipboard.Menu>
+                <CopyToClipboard.MenuTarget />
+                <CopyToClipboard.MenuItem value="copy-name" onCopy={onCopySpy}>
+                    Copy name to clipboard
+                </CopyToClipboard.MenuItem>
+                <CopyToClipboard.MenuItem value="copy-id">Copy ID to clipboard</CopyToClipboard.MenuItem>
+            </CopyToClipboard.Menu>,
+        );
+
+        await user.click(screen.getByRole('button', {name: /copy to clipboard/i}));
+        await waitFor(() => user.click(screen.getByText('Copy name to clipboard')));
+
+        expect(onCopySpy).toHaveBeenCalled();
+    });
+});

--- a/packages/storybook/src/call-to-action/CopyToClipboard.stories.tsx
+++ b/packages/storybook/src/call-to-action/CopyToClipboard.stories.tsx
@@ -1,7 +1,18 @@
 import {CopyToClipboard} from '@coveord/plasma-mantine/components/CopyToClipboard';
 import type {Meta, StoryObj} from '@storybook/react-vite';
 
-const meta: Meta<typeof CopyToClipboard> = {
+type Variant = 'Button' | 'Input' | 'Menu';
+
+interface StoryArgs {
+    variant: Variant;
+    value: string;
+    label: string;
+    description: string;
+    menuItem1Value: string;
+    menuItem2Value: string;
+}
+
+const meta: Meta<StoryArgs> = {
     title: '@components/call-to-action/CopyToClipboard',
     id: 'CopyToClipboard',
     component: CopyToClipboard,
@@ -9,25 +20,68 @@ const meta: Meta<typeof CopyToClipboard> = {
         layout: 'centered',
     },
     argTypes: {
+        variant: {
+            control: 'select',
+            options: ['Button', 'Input', 'Menu'] satisfies Variant[],
+            description: 'Which CopyToClipboard variant to display',
+            table: {
+                defaultValue: {summary: 'Button'},
+            },
+        },
         value: {
             control: 'text',
             description: 'The value to be copied to clipboard',
-            table: {type: {summary: 'string'}},
+            if: {arg: 'variant', neq: 'Menu'},
         },
-        withLabel: {
-            control: 'boolean',
-            description: 'Whether to show the "Copy to clipboard" label',
-            table: {defaultValue: {summary: 'false'}, type: {summary: 'boolean'}},
+        label: {
+            control: 'text',
+            description: 'Label for the Input field',
+            if: {arg: 'variant', eq: 'Input'},
+        },
+        description: {
+            control: 'text',
+            description: 'Description for the Input field',
+            if: {arg: 'variant', eq: 'Input'},
+        },
+        menuItem1Value: {
+            control: 'text',
+            description: 'The value to be copied to clipboard for the first MenuItem',
+            if: {arg: 'variant', eq: 'Menu'},
+        },
+        menuItem2Value: {
+            control: 'text',
+            description: 'The value to be copied to clipboard for the second MenuItem',
+            if: {arg: 'variant', eq: 'Menu'},
         },
     },
     args: {
+        variant: 'Button',
         value: 'Copy me!',
-        withLabel: false,
+        label: 'My Label',
+        description: 'My Description',
+        menuItem1Value: 'name-123',
+        menuItem2Value: 'source-id-123',
     },
 };
 export default meta;
-type Story = StoryObj<typeof CopyToClipboard>;
+type Story = StoryObj<StoryArgs>;
 
 export const Demo: Story = {
-    render: ({value, withLabel}) => <CopyToClipboard value={value} withLabel={withLabel} />,
+    render: ({variant, value, label, description, menuItem1Value, menuItem2Value}) => {
+        if (variant === 'Input') {
+            return <CopyToClipboard.Input label={label} description={description} value={value} />;
+        }
+        if (variant === 'Menu') {
+            return (
+                <CopyToClipboard.Menu>
+                    <CopyToClipboard.MenuTarget />
+                    <CopyToClipboard.MenuItem value={menuItem1Value}>Copy name to clipboard</CopyToClipboard.MenuItem>
+                    <CopyToClipboard.MenuItem value={menuItem2Value}>
+                        Copy source ID to clipboard
+                    </CopyToClipboard.MenuItem>
+                </CopyToClipboard.Menu>
+            );
+        }
+        return <CopyToClipboard.Button value={value} />;
+    },
 };

--- a/packages/storybook/src/call-to-action/CopyToClipboard.stories.tsx
+++ b/packages/storybook/src/call-to-action/CopyToClipboard.stories.tsx
@@ -9,7 +9,9 @@ interface StoryArgs {
     label: string;
     description: string;
     menuItem1Value: string;
+    menuItem1TooltipLabelCopied: string;
     menuItem2Value: string;
+    menuItem2TooltipLabelCopied: string;
 }
 
 const meta: Meta<StoryArgs> = {
@@ -48,9 +50,19 @@ const meta: Meta<StoryArgs> = {
             description: 'The value to be copied to clipboard for the first MenuItem',
             if: {arg: 'variant', eq: 'Menu'},
         },
+        menuItem1TooltipLabelCopied: {
+            control: 'text',
+            description: 'The tooltip label displayed when the first MenuItem value is copied',
+            if: {arg: 'variant', eq: 'Menu'},
+        },
         menuItem2Value: {
             control: 'text',
             description: 'The value to be copied to clipboard for the second MenuItem',
+            if: {arg: 'variant', eq: 'Menu'},
+        },
+        menuItem2TooltipLabelCopied: {
+            control: 'text',
+            description: 'The tooltip label displayed when the second MenuItem value is copied',
             if: {arg: 'variant', eq: 'Menu'},
         },
     },
@@ -60,14 +72,25 @@ const meta: Meta<StoryArgs> = {
         label: 'My Label',
         description: 'My Description',
         menuItem1Value: 'name-123',
+        menuItem1TooltipLabelCopied: 'Name copied',
         menuItem2Value: 'source-id-123',
+        menuItem2TooltipLabelCopied: 'Source ID copied',
     },
 };
 export default meta;
 type Story = StoryObj<StoryArgs>;
 
 export const Demo: Story = {
-    render: ({variant, value, label, description, menuItem1Value, menuItem2Value}) => {
+    render: ({
+        variant,
+        value,
+        label,
+        description,
+        menuItem1Value,
+        menuItem1TooltipLabelCopied,
+        menuItem2Value,
+        menuItem2TooltipLabelCopied,
+    }) => {
         if (variant === 'Input') {
             return <CopyToClipboard.Input label={label} description={description} value={value} />;
         }
@@ -75,8 +98,10 @@ export const Demo: Story = {
             return (
                 <CopyToClipboard.Menu>
                     <CopyToClipboard.MenuTarget />
-                    <CopyToClipboard.MenuItem value={menuItem1Value}>Copy name to clipboard</CopyToClipboard.MenuItem>
-                    <CopyToClipboard.MenuItem value={menuItem2Value}>
+                    <CopyToClipboard.MenuItem value={menuItem1Value} tooltipLabelCopied={menuItem1TooltipLabelCopied}>
+                        Copy name to clipboard
+                    </CopyToClipboard.MenuItem>
+                    <CopyToClipboard.MenuItem value={menuItem2Value} tooltipLabelCopied={menuItem2TooltipLabelCopied}>
                         Copy source ID to clipboard
                     </CopyToClipboard.MenuItem>
                 </CopyToClipboard.Menu>


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->
[PSE-559](https://coveord.atlassian.net/browse/PSE-559)

Reworked the `CopyToClipboard` component to be a compound component and added a new `Menu` variant that lets users copy a value from a dropdown menu : 

Legacy usage (still works for now but is marked as deprecated)
```
// Standalone button
<CopyToClipboard value="value to copy" />

// Input (read-only input with copy button)
<CopyToClipboard withLabel value="value to copy" />
```

New usage : 
```
// Standalone button
<CopyToClipboard.Button value="value to copy" />

// Input with label and description (read-only input with copy button)
<CopyToClipboard.Input label="My Label" description="My Description" value="value to copy" />

// Menu with multiple copyable values
<CopyToClipboard.Menu>
    <CopyToClipboard.MenuTarget />
    <CopyToClipboard.MenuItem value="name-value" tooltipLabelCopied="Name copied">Copy name to clipboard</CopyToClipboard.MenuItem>
    <CopyToClipboard.MenuItem value="source-id-123" tooltipLabelCopied="Source ID copied">Copy source ID to clipboard</CopyToClipboard.MenuItem>
</CopyToClipboard.Menu>
```

https://github.com/user-attachments/assets/4f76c4c6-420b-45fd-abe2-71387e00dafd


Storybook link : https://plasma.coveo.com/feature/PSE-559-add-copy-to-clipboard-menu-variant/?path=/story/copytoclipboard--demo&args=variant:Menu





### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[PSE-559]: https://coveord.atlassian.net/browse/PSE-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ