### PR TITLE
fix(Collection): change remove button ActionIcon size to lg

### DIFF
--- a/packages/mantine/src/components/Collection/layouts/shared/RemoveButton.tsx
+++ b/packages/mantine/src/components/Collection/layouts/shared/RemoveButton.tsx
@@ -17,13 +17,13 @@ export const RemoveButton: FunctionComponent<RemoveButtonProps> = ({removable, o
     const {getStyles} = useCollectionContext();
 
     if (!removable || !onRemove) {
-        return <div style={{width: 28}} />;
+        return <div style={{width: 36}} />;
     }
 
     return (
         <Box {...getStyles('removeButton')}>
-            <ActionIcon.Quaternary onClick={onRemove}>
-                <IconTrash aria-label="Remove" size={16} />
+            <ActionIcon.Quaternary size="lg" onClick={onRemove}>
+                <IconTrash aria-label="Remove" />
             </ActionIcon.Quaternary>
         </Box>
     );


### PR DESCRIPTION
## Summary

[MHUB-2907](https://coveord.atlassian.net/browse/MHUB-2907)

The Collection component's remove button ActionIcon was using the default size (md = 24px). Per DS guidelines, standalone ActionIcons should use `lg` (36px) to align with other UI elements. The smaller sizes (sm, md) are reserved for ActionIcons embedded within other components (e.g., inputs).

## Changes

- `RemoveButton.tsx`: Set `size="lg"` on the `ActionIcon.Quaternary`
- Removed explicit `size={16}` from `IconTrash` — the DS CSS handles icon sizing (20px for `lg`)
- Aligned the spacer div width from 28px to 36px to match the new button size

## How to Test

1. Open Storybook
2. Navigate to Collection component stories
3. Verify the trash icon button is 36x36 and the icon is 20x20

[MHUB-2907]: https://coveord.atlassian.net/browse/MHUB-2907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ