### PR TITLE
docs(llms): UX guidance for I–P components

### DIFF
--- a/packages/llms/src/components/Image.md
+++ b/packages/llms/src/components/Image.md
@@ -48,12 +48,6 @@ description: Displays a responsive image with configurable object-fit behaviour 
 - Rendering `Image` without a sized container or explicit `w`/`h` — the image will have no defined dimensions and may cause layout shift.
 - Using `Image` for a page-section background — use `BackgroundImage` for that pattern.
 
-## What an AI agent should understand
-
-- `Image` is a direct re-export of `@mantine/core` `Image` with a `displayName` set. All Mantine `Image` props are available.
-- Plasma adds no additional props or behaviour beyond the Mantine base component.
-- The `fit` prop maps directly to the CSS `object-fit` property of the inner `<img>` element.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Image.md
+++ b/packages/llms/src/components/Image.md
@@ -1,0 +1,95 @@
+---
+name: Image
+description: Displays a responsive image with configurable object-fit behaviour inside a sized container.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Image` renders an image element inside a constrained container, letting you control how the image scales and crops relative to that container without writing custom CSS.
+
+## When to use it
+
+- Displaying product thumbnails or illustrative images in a card or panel where a fixed container size is defined.
+- When you need to control how the image fills its container (cover, contain, fill, etc.) via a single prop.
+
+## When not to use it
+
+- When you need a full-bleed section background.
+- When you only need a user avatar at a fixed circular size.
+- When the image is purely decorative and should convey no meaning — consider whether an `aria-hidden` background image approach is better.
+
+## Decision-making guidance
+
+- Choose `fit="cover"` (the default) when you want the image to fill the container and can accept cropping.
+- Choose `fit="contain"` when the full image must be visible without cropping, even if it leaves empty space.
+- Always supply explicit `w` and `h` props (or size via CSS) so the container has a defined aspect ratio before the image loads, preventing layout shift.
+- Provide `fallbackSrc` to show a placeholder image if the source fails to load.
+
+## Variants
+
+**`fit`** controls the CSS `object-fit` property:
+
+- `'cover'` (default) — crops the image to fill the container.
+- `'contain'` — scales down to show the full image inside the container.
+- `'fill'` — stretches to fill regardless of aspect ratio.
+- `'none'` — renders at intrinsic size.
+- `'scale-down'` — behaves like `contain` or `none`, whichever is smaller.
+
+## Accessibility expectations
+
+- `Image` renders an `<img>` element. You MUST supply a meaningful `alt` prop describing the image content for screen readers.
+- For purely decorative images that add no information, set `alt=""` so screen readers skip them.
+
+## Common anti-patterns
+
+- Omitting `alt` — this fails basic accessibility requirements.
+- Rendering `Image` without a sized container or explicit `w`/`h` — the image will have no defined dimensions and may cause layout shift.
+- Using `Image` for a page-section background — use `BackgroundImage` for that pattern.
+
+## What an AI agent should understand
+
+- `Image` is a direct re-export of `@mantine/core` `Image` with a `displayName` set. All Mantine `Image` props are available.
+- Plasma adds no additional props or behaviour beyond the Mantine base component.
+- The `fit` prop maps directly to the CSS `object-fit` property of the inner `<img>` element.
+
+# API reference
+
+## Props
+
+> Extends: `ImageProps` from `@mantine/core`.
+
+_No additional props beyond the Mantine base component._
+
+Key props relevant to Plasma usage patterns:
+
+**`src`** `string` · optional — Image source URL.
+
+**`fit`** `'fill' | 'contain' | 'cover' | 'none' | 'scale-down'` · optional · default: `'cover'` — How the image fits within its container; maps to CSS `object-fit`.
+
+**`alt`** `string` · optional — Alt text for the image. MUST be provided for meaningful images.
+
+**`w`** `number | string` · optional — Width of the container.
+
+**`h`** `number | string` · optional — Height of the container.
+
+## Usage
+
+```tsx
+import {Image} from '@coveord/plasma-mantine';
+
+// Cover (default) — fills container, may crop
+function CoverExample() {
+    return <Image src="https://example.com/photo.jpg" alt="Mountain landscape" w={400} h={300} />;
+}
+
+// Contain — full image visible, may letterbox
+function ContainExample() {
+    return <Image src="https://example.com/logo.png" alt="Company logo" w={200} h={200} fit="contain" />;
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/InfoToken.md
+++ b/packages/llms/src/components/InfoToken.md
@@ -3,6 +3,61 @@ name: InfoToken
 description: Inline token for displaying semantic metadata with a predefined icon.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `InfoToken` gives users a compact semantic icon that can reinforce the tone or type of nearby information without adding a full message.
+
+## When to use it
+
+Use `InfoToken` when:
+
+- a small semantic marker helps users recognize information type
+- the surrounding text already explains the meaning
+- the interface needs a compact icon for information, advice, warning, error, question, or success
+- the token is decorative support rather than the only message
+
+## When not to use it
+
+Do not use `InfoToken` when:
+
+- users need a full status label; use `Badge`
+- the state needs to be represented as a standalone status indicator; use `StatusToken`
+- the message needs explanatory text or actions; use `Alert`
+- the icon would be the only way to understand the meaning
+
+## Decision-making guidance
+
+- Use `InfoToken` as an inline semantic cue next to text.
+- Use `StatusToken` for object state or lifecycle status.
+- Use `Alert` when users need to read a persistent message.
+
+## Variants
+
+- Use semantic sub-components to choose the token type.
+- Use `outline` for the default compact token treatment.
+- Use `light` when the token needs a filled background treatment.
+
+## Accessibility expectations
+
+- Do not rely on color or icon shape alone to communicate critical meaning.
+- Pair the token with nearby text that names the state or message.
+
+## Common anti-patterns
+
+- Using an `InfoToken` as the only label for an error or warning.
+- Mixing token semantics inconsistently in the same interface.
+- Using decorative tokens where no semantic cue is needed.
+
+## What an AI agent should understand
+
+- `InfoToken` is a compact supporting semantic icon.
+- Use semantic sub-components because the public props do not expose `type`.
+- Use `Alert`, `Badge`, or `StatusToken` when users need more than a supporting cue.
+
+# API reference
+
 ## Props
 
 > Extends: `BoxProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/InfoToken.md
+++ b/packages/llms/src/components/InfoToken.md
@@ -50,12 +50,6 @@ Do not use `InfoToken` when:
 - Mixing token semantics inconsistently in the same interface.
 - Using decorative tokens where no semantic cue is needed.
 
-## What an AI agent should understand
-
-- `InfoToken` is a compact supporting semantic icon.
-- Use semantic sub-components because the public props do not expose `type`.
-- Use `Alert`, `Badge`, or `StatusToken` when users need more than a supporting cue.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Input.md
+++ b/packages/llms/src/components/Input.md
@@ -3,6 +3,65 @@ name: Input
 description: Base input wrapper extended with a LabelInfo tooltip sub-component for contextual help.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `Input` family provides shared form-field structure and small contextual help patterns for labels, descriptions, placeholders, and errors.
+
+`Input.LabelInfo` helps users understand a field without adding long explanatory text to the form surface.
+
+## When to use it
+
+Use `Input` sub-components when:
+
+- composing custom form fields that should follow Plasma input structure
+- a label needs short optional clarification through `Input.LabelInfo`
+- descriptions, errors, or placeholders need to align with Mantine input patterns
+- a custom field should remain consistent with Plasma form styling
+
+## When not to use it
+
+Do not use `Input.LabelInfo` when:
+
+- the information is required to complete the field; use visible description text
+- the message is a warning or validation issue; use error text or an alert
+- the explanation is too long for a tooltip
+- the field already has enough visible context
+
+## Decision-making guidance
+
+- Use field descriptions for guidance users should read before entering a value.
+- Use `Input.LabelInfo` for optional clarifying context.
+- Use `Alert` for broader form-level guidance or warnings.
+- Use component-specific inputs such as `TextInput`, `Select`, or `PasswordInput` when they already provide the needed structure.
+
+## Accessibility expectations
+
+- Labels MUST clearly identify the field.
+- Required guidance SHOULD remain visible instead of hidden in a tooltip.
+- Error text SHOULD be associated with the field through the input component.
+
+## Content guidance
+
+- Label info text SHOULD be concise and supplementary.
+- Descriptions SHOULD explain expected input, constraints, or consequences.
+- Error text SHOULD explain what is wrong and how to fix it.
+
+## Common anti-patterns
+
+- Hiding required instructions inside `Input.LabelInfo`.
+- Using label info for long documentation.
+- Composing custom fields when a dedicated input component exists.
+
+## What an AI agent should understand
+
+- `Input` is mostly a composition layer for consistent form-field structure.
+- `Input.LabelInfo` is for optional field clarification, not required instructions.
+- Prefer dedicated input components when possible.
+
+# API reference
+
 ## Props
 
 _No additional props beyond the Mantine base component._

--- a/packages/llms/src/components/Input.md
+++ b/packages/llms/src/components/Input.md
@@ -32,7 +32,7 @@ Do not use `Input.LabelInfo` when:
 ## Decision-making guidance
 
 - Use field descriptions for guidance users should read before entering a value.
-- Use `Input.LabelInfo` for optional clarifying context.
+- Use `Input.LabelInfo` for optional clarifying context — always inside the `label` prop of a form field, never on its own.
 - Use `Alert` for broader form-level guidance or warnings.
 - Use component-specific inputs such as `TextInput`, `Select`, or `PasswordInput` when they already provide the needed structure.
 

--- a/packages/llms/src/components/Input.md
+++ b/packages/llms/src/components/Input.md
@@ -54,12 +54,6 @@ Do not use `Input.LabelInfo` when:
 - Using label info for long documentation.
 - Composing custom fields when a dedicated input component exists.
 
-## What an AI agent should understand
-
-- `Input` is mostly a composition layer for consistent form-field structure.
-- `Input.LabelInfo` is for optional field clarification, not required instructions.
-- Prefer dedicated input components when possible.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Kbd.md
+++ b/packages/llms/src/components/Kbd.md
@@ -1,0 +1,95 @@
+---
+name: Kbd
+description: Renders keyboard key names or shortcuts in a styled monospace badge that visually resembles a physical key.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Kbd` provides a semantic and visually distinct way to represent keyboard keys or shortcuts inline within text or UI, making instructions clearer and scannable.
+
+## When to use it
+
+- Documenting keyboard shortcuts in help text (e.g. "Press ⌘ K to open search").
+- Labelling hotkeys in menus or command palettes next to their associated actions.
+- Any inline reference to a specific key the user should press.
+
+## When not to use it
+
+- For code or command strings that are not keyboard keys — use `Code` or `CodeEditor` instead.
+- Inside purely decorative contexts where the key-press semantic adds no meaning.
+
+## Decision-making guidance
+
+- Combine multiple `Kbd` elements with a `+` separator (plain text) to represent key combinations: `<Kbd>⌘</Kbd> + <Kbd>K</Kbd>`.
+- Use symbolic characters (⌘, ⇧, ⌥, ⌃) for modifier keys on macOS, or spelled-out labels (Ctrl, Shift, Alt) for cross-platform or Windows-first contexts.
+
+## Accessibility expectations
+
+- `Kbd` renders a `<kbd>` HTML element, which has implicit semantic meaning for screen readers as a keyboard input.
+- No additional ARIA attributes are typically needed.
+- When used inside a sentence, ensure surrounding text provides enough context so the key reference is meaningful out of visual context.
+
+## Content guidance
+
+- Keep content short — single key names or symbols only.
+- Prefer platform-native symbols (⌘, ⇧) when writing macOS-specific documentation; prefer spelled-out labels (Ctrl, Shift) when targeting multiple platforms.
+- Avoid combining an entire shortcut string inside a single `Kbd` (e.g. `<Kbd>Ctrl+K</Kbd>`) — render each key separately so each key gets its own visual treatment.
+
+## Common anti-patterns
+
+- Putting a full shortcut string like "Ctrl+Shift+P" in one `Kbd` element instead of composing separate `Kbd` per key.
+- Using `Kbd` for non-keyboard text like file paths or code snippets — use `Code` for those.
+
+## What an AI agent should understand
+
+- `Kbd` is a direct re-export of `@mantine/core` `Kbd` with a `displayName` set. All Mantine `Kbd` props are available.
+- Plasma adds no additional props or behaviour beyond the Mantine base component.
+- The rendered HTML element is `<kbd>`, which carries semantic meaning for assistive technologies.
+
+# API reference
+
+## Props
+
+> Extends: `KbdProps` from `@mantine/core`.
+
+_No additional props beyond the Mantine base component._
+
+Key props relevant to Plasma usage patterns:
+
+**`children`** `ReactNode` · required — The key name or symbol to display (e.g. `'⌘'`, `'Ctrl'`, `'Enter'`).
+
+## Usage
+
+```tsx
+import {Kbd} from '@coveord/plasma-mantine';
+import {Text} from '@mantine/core';
+
+// Single key
+function SingleKeyExample() {
+    return <Kbd>⌘</Kbd>;
+}
+
+// Key combination inline in text
+function KeyCombinationExample() {
+    return (
+        <Text>
+            Press <Kbd>⌘</Kbd> + <Kbd>K</Kbd> to open the command palette.
+        </Text>
+    );
+}
+
+// Cross-platform shortcut
+function CrossPlatformExample() {
+    return (
+        <Text>
+            <Kbd>Ctrl</Kbd> + <Kbd>Shift</Kbd> + <Kbd>P</Kbd>
+        </Text>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Kbd.md
+++ b/packages/llms/src/components/Kbd.md
@@ -57,8 +57,7 @@ Key props relevant to Plasma usage patterns:
 ## Usage
 
 ```tsx
-import {Kbd} from '@coveord/plasma-mantine';
-import {Text} from '@mantine/core';
+import {Kbd, Text} from '@coveord/plasma-mantine';
 
 // Single key
 function SingleKeyExample() {

--- a/packages/llms/src/components/Kbd.md
+++ b/packages/llms/src/components/Kbd.md
@@ -42,12 +42,6 @@ description: Renders keyboard key names or shortcuts in a styled monospace badge
 - Putting a full shortcut string like "Ctrl+Shift+P" in one `Kbd` element instead of composing separate `Kbd` per key.
 - Using `Kbd` for non-keyboard text like file paths or code snippets — use `Code` for those.
 
-## What an AI agent should understand
-
-- `Kbd` is a direct re-export of `@mantine/core` `Kbd` with a `displayName` set. All Mantine `Kbd` props are available.
-- Plasma adds no additional props or behaviour beyond the Mantine base component.
-- The rendered HTML element is `<kbd>`, which carries semantic meaning for assistive technologies.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/LastUpdated.md
+++ b/packages/llms/src/components/LastUpdated.md
@@ -3,6 +3,57 @@ name: LastUpdated
 description: Component that displays a human-readable last-updated timestamp with default or custom formatting.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `LastUpdated` component tells users how fresh the displayed information is.
+
+It is useful in dashboards, tables, monitoring views, and async data surfaces where recency affects trust.
+
+## When to use it
+
+Use `LastUpdated` when:
+
+- users need to know when data was last refreshed
+- the view depends on background polling or asynchronous updates
+- stale data could change user interpretation
+- the timestamp should be shown consistently across views
+
+## When not to use it
+
+Do not use `LastUpdated` when:
+
+- the timestamp refers to a business event, not UI data freshness
+- the data is static or recency does not affect decisions
+- the timestamp needs a richer audit trail
+- the value belongs in a table column or metadata field instead
+
+## Decision-making guidance
+
+- Use this component specifically to show when data was last refreshed or synced — for example, in a live dashboard or a view that updates in the background.
+- For timestamps that describe a business event — like when a record was created or who last edited it — use regular text or a table column instead. Those are content timestamps, not freshness indicators.
+- The default label and date format work for most cases. Only change them if they don't fit the specific context.
+
+## Content guidance
+
+- Labels SHOULD clarify what was updated.
+- Timestamp format SHOULD match the precision users need.
+
+## Common anti-patterns
+
+- Showing last updated timestamps that do not actually reflect the visible data.
+- Using overly precise timestamps when relative freshness is enough.
+- Confusing data freshness with object modification history.
+
+## What an AI agent should understand
+
+- `LastUpdated` is for communicating data freshness.
+- Use it when recency affects user trust in the current view.
+- Use other metadata patterns for business event timestamps.
+
+# API reference
+
 ## Props
 
 > Extends: `BoxProps`, `Pick<GroupProps, 'justify'>`, `StylesApiProps<LastUpdatedFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/LastUpdated.md
+++ b/packages/llms/src/components/LastUpdated.md
@@ -46,12 +46,6 @@ Do not use `LastUpdated` when:
 - Using overly precise timestamps when relative freshness is enough.
 - Confusing data freshness with object modification history.
 
-## What an AI agent should understand
-
-- `LastUpdated` is for communicating data freshness.
-- Use it when recency affects user trust in the current view.
-- Use other metadata patterns for business event timestamps.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Loader.md
+++ b/packages/llms/src/components/Loader.md
@@ -23,7 +23,7 @@ description: Animated spinner that communicates an ongoing asynchronous operatio
 
 ## Decision-making guidance
 
-- Use `size="sm"` for inline loaders inside compact UI (buttons, table cells, small panels).
+- Use `size="sm"` for inline loaders inside compact UI such as table cells or small panels. For button loading states, use the `Button` `loading` prop rather than placing a `Loader` inside a button.
 - Use `size="md"` (the default) for section-level loading states.
 - Use `size="lg"` for full-page or prominent loading states.
 - Centre the `Loader` within its container using flexbox or Mantine's layout utilities so it does not appear misaligned.
@@ -71,15 +71,6 @@ function SectionLoader() {
         <div style={{display: 'flex', justifyContent: 'center', padding: 32}}>
             <Loader />
         </div>
-    );
-}
-
-// Small inline loader inside a button
-function SaveButton({saving}: {saving: boolean}) {
-    return (
-        <button disabled={saving} aria-label={saving ? 'Saving…' : 'Save'}>
-            {saving ? <Loader size="sm" /> : 'Save'}
-        </button>
     );
 }
 ```

--- a/packages/llms/src/components/Loader.md
+++ b/packages/llms/src/components/Loader.md
@@ -44,13 +44,6 @@ description: Animated spinner that communicates an ongoing asynchronous operatio
 - Using a large `Loader` inline inside dense text or a small button — it creates layout disruption; use `size="sm"` for compact contexts.
 - Leaving a `Loader` visible indefinitely on error — always replace it with an error state or message when the operation fails.
 
-## What an AI agent should understand
-
-- `Loader` is a direct re-export of `@mantine/core` `Loader` with a `displayName` set. All Mantine `Loader` props are available.
-- Plasma adds no additional props or behaviour beyond the Mantine base component.
-- The default `size` is `md`.
-- For a circular progress indicator that also shows a label or percentage, look for a `CircleLoader` component in Plasma which provides a more opinionated variant.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Loader.md
+++ b/packages/llms/src/components/Loader.md
@@ -1,0 +1,96 @@
+---
+name: Loader
+description: Animated spinner that communicates an ongoing asynchronous operation to the user.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Loader` provides visual feedback that the application is working, preventing users from perceiving the UI as frozen or unresponsive during data fetching or background processing.
+
+## When to use it
+
+- While content is being fetched and the layout placeholder is unknown (e.g. first load of a data table).
+- As an inline indicator inside a button or form field to signal a pending action.
+- As a full-page or section-level overlay when the entire view is loading.
+
+## When not to use it
+
+- When a progress percentage is known — use a `Progress` bar instead so users have a concrete sense of how long remains.
+- When loading is near-instantaneous (under ~300 ms) — showing a loader that flashes briefly can feel jittery; consider a debounce or minimum display duration.
+- For skeleton screen patterns where the approximate content shape is known — skeletons provide better perceived performance than a generic spinner.
+
+## Decision-making guidance
+
+- Use `size="sm"` for inline loaders inside compact UI (buttons, table cells, small panels).
+- Use `size="md"` (the default) for section-level loading states.
+- Use `size="lg"` for full-page or prominent loading states.
+- Centre the `Loader` within its container using flexbox or Mantine's layout utilities so it does not appear misaligned.
+
+## States
+
+`Loader` is itself a state indicator — it has no internal states. Show or hide it conditionally based on your loading flag.
+
+## Accessibility expectations
+
+- `Loader` is a visual-only spinner with no accessible announcement by default; screen readers do not announce it automatically.
+- You SHOULD accompany a visible `Loader` with a visually hidden `aria-live` region or `aria-busy="true"` on the loading container so screen reader users receive feedback that content is loading.
+- When used inside a button, the button SHOULD also be `disabled` and have an `aria-label` that communicates the pending state (e.g. `"Saving…"`).
+
+## Common anti-patterns
+
+- Rendering a `Loader` without any accessible announcement — sighted users see the spinner but screen reader users receive no feedback.
+- Using a large `Loader` inline inside dense text or a small button — it creates layout disruption; use `size="sm"` for compact contexts.
+- Leaving a `Loader` visible indefinitely on error — always replace it with an error state or message when the operation fails.
+
+## What an AI agent should understand
+
+- `Loader` is a direct re-export of `@mantine/core` `Loader` with a `displayName` set. All Mantine `Loader` props are available.
+- Plasma adds no additional props or behaviour beyond the Mantine base component.
+- The default `size` is `md`.
+- For a circular progress indicator that also shows a label or percentage, look for a `CircleLoader` component in Plasma which provides a more opinionated variant.
+
+# API reference
+
+## Props
+
+> Extends: `LoaderProps` from `@mantine/core`.
+
+_No additional props beyond the Mantine base component._
+
+Key props relevant to Plasma usage patterns:
+
+**`size`** `'sm' | 'md' | 'lg' | number` · optional · default: `'md'` — Controls the diameter of the spinner.
+
+**`color`** `string` · optional — Mantine color key or CSS color value; defaults to the theme's primary color.
+
+**`type`** `'oval' | 'bars' | 'dots'` · optional · default: `'oval'` — Visual style of the spinner.
+
+## Usage
+
+```tsx
+import {Loader} from '@coveord/plasma-mantine';
+
+// Section-level loader
+function SectionLoader() {
+    return (
+        <div style={{display: 'flex', justifyContent: 'center', padding: 32}}>
+            <Loader />
+        </div>
+    );
+}
+
+// Small inline loader inside a button
+function SaveButton({saving}: {saving: boolean}) {
+    return (
+        <button disabled={saving} aria-label={saving ? 'Saving…' : 'Save'}>
+            {saving ? <Loader size="sm" /> : 'Save'}
+        </button>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Menu.md
+++ b/packages/llms/src/components/Menu.md
@@ -3,6 +3,59 @@ name: Menu
 description: Dropdown menu with transparent support for disabled-state tooltips on `Menu.Item`.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `Menu` presents a compact list of contextual commands without permanently taking space in the layout.
+
+It is useful for secondary actions, overflow actions, row actions, and command groups that should stay close to their trigger.
+
+## When to use it
+
+Use `Menu` when:
+
+- actions are contextual to a nearby trigger or selected item
+- actions are secondary or overflow commands
+- a compact command list is easier to scan than several visible buttons
+- disabled menu items need tooltip explanations
+
+## When not to use it
+
+Do not use `Menu` when:
+
+- the action is primary and should always be visible
+- the user needs to compare complex options or fill out inputs
+- the content is navigation between major sections
+- hiding the available actions would make the workflow hard to discover
+
+## Decision-making guidance
+
+- Use `Button` or `ActionIcon` for visible high-frequency actions.
+- Use `Menu` for grouped contextual commands such as bulk actions or row actions.
+- Use labels and dividers to separate distinct action groups.
+- Use disabled tooltips only when they help users understand a requirement or permission boundary.
+
+## Accessibility expectations
+
+- Menu triggers MUST have clear labels or accessible names.
+- Menu item labels SHOULD be action-oriented and specific.
+- Disabled menu items SHOULD explain the missing condition when the reason is not obvious.
+
+## Common anti-patterns
+
+- Hiding the only path to an important action inside a menu.
+- Mixing unrelated commands in one menu without grouping.
+- Using a menu as a replacement for form controls or navigation structure.
+
+## What an AI agent should understand
+
+- `Menu` is for compact contextual command lists.
+- `Menu.Item` supports Plasma disabled tooltips.
+- Use visible buttons for primary actions and menus for secondary or overflow actions.
+
+# API reference
+
 ## Props
 
 _No additional props beyond the Mantine base component._

--- a/packages/llms/src/components/Menu.md
+++ b/packages/llms/src/components/Menu.md
@@ -48,12 +48,6 @@ Do not use `Menu` when:
 - Mixing unrelated commands in one menu without grouping.
 - Using a menu as a replacement for form controls or navigation structure.
 
-## What an AI agent should understand
-
-- `Menu` is for compact contextual command lists.
-- `Menu.Item` supports Plasma disabled tooltips.
-- Use visible buttons for primary actions and menus for secondary or overflow actions.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Modal.md
+++ b/packages/llms/src/components/Modal.md
@@ -3,6 +3,59 @@ name: Modal
 description: Overlay dialog that focuses user attention and can render a description, help link, and footer actions.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `Modal` focuses users on a contained task or information surface without navigating away from the current page.
+
+It is useful when users need to complete, review, or inspect something in a temporary overlay.
+
+## When to use it
+
+Use `Modal` when:
+
+- a contained task should interrupt the current page without replacing it
+- users need focused context, actions, and a clear way to close
+- the content is related to the current page but needs temporary prominence
+- a footer should group modal-specific actions
+
+## When not to use it
+
+Do not use `Modal` when:
+
+- the task is large enough to deserve its own page or step
+- users need to compare modal content with the underlying page
+- the overlay is only a simple confirmation; use `Prompt`
+- the content is contextual and lightweight enough for inline disclosure or a menu
+
+## Decision-making guidance
+
+- Use `Modal` for focused temporary tasks.
+- Use `Prompt` for confirmation decisions with semantic intent.
+- Use page navigation for complex flows with several steps or deep editing.
+- Use `Modal.Footer` for modal actions.
+
+## Accessibility expectations
+
+- Modals SHOULD have clear titles.
+- Descriptions SHOULD explain impact when the task is risky or complex.
+- Closing behavior SHOULD preserve or intentionally discard user input according to the workflow.
+
+## Common anti-patterns
+
+- Putting multi-page workflows inside a modal.
+- Opening a modal for information that could be inline.
+- Using modal footers outside modal contexts.
+
+## What an AI agent should understand
+
+- `Modal` is for focused temporary overlay tasks.
+- Use `Prompt` for confirmation flows.
+- Use `Modal.Footer` for modal action groups.
+
+# API reference
+
 ## Props
 
 > Extends: `MantineModalProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/Modal.md
+++ b/packages/llms/src/components/Modal.md
@@ -48,12 +48,6 @@ Do not use `Modal` when:
 - Opening a modal for information that could be inline.
 - Using modal footers outside modal contexts.
 
-## What an AI agent should understand
-
-- `Modal` is for focused temporary overlay tasks.
-- Use `Prompt` for confirmation flows.
-- Use `Modal.Footer` for modal action groups.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Modal.md
+++ b/packages/llms/src/components/Modal.md
@@ -18,13 +18,12 @@ Use `Modal` when:
 - a contained task should interrupt the current page without replacing it
 - users need focused context, actions, and a clear way to close
 - the content is related to the current page but needs temporary prominence
-- a footer should group modal-specific actions
 
 ## When not to use it
 
 Do not use `Modal` when:
 
-- the task is large enough to deserve its own page or step
+- the task is complex enough to warrant its own page or step — multi-step flows, many form inputs, or content that would need its own tabs
 - users need to compare modal content with the underlying page
 - the overlay is only a simple confirmation; use `Prompt`
 - the content is contextual and lightweight enough for inline disclosure or a menu
@@ -46,7 +45,7 @@ Do not use `Modal` when:
 
 - Putting multi-page workflows inside a modal.
 - Opening a modal for information that could be inline.
-- Using modal footers outside modal contexts.
+- Stacking multiple modals on top of each other — resolve one before opening the next.
 
 # API reference
 

--- a/packages/llms/src/components/MonthPickerInput.md
+++ b/packages/llms/src/components/MonthPickerInput.md
@@ -60,13 +60,6 @@ description: Form input that opens a calendar popover for selecting a single mon
 - Omitting `clearable` on optional fields, forcing users to reload or use workarounds to unset a value.
 - Using `type="multiple"` without a clear rationale — multi-select month patterns are rare and often better served by checkboxes or a `MultiSelect` with month options.
 
-## What an AI agent should understand
-
-- `MonthPickerInput` is a direct re-export of `@mantine/dates` `MonthPickerInput` with a `displayName` set. All Mantine props are available.
-- Plasma adds no additional props or behaviour beyond the Mantine base component.
-- The component shares the same `type`, `clearable`, and `placeholder` patterns used by `DatePickerInput` — the key difference is that the calendar only shows month-level granularity.
-- Pass tooltip content into `Input.LabelInfo` in forms where the field label needs supplementary guidance.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/MonthPickerInput.md
+++ b/packages/llms/src/components/MonthPickerInput.md
@@ -1,0 +1,116 @@
+---
+name: MonthPickerInput
+description: Form input that opens a calendar popover for selecting a single month, multiple months, or a month range.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`MonthPickerInput` lets users select a month (or range of months) without typing, eliminating format ambiguity and invalid-date errors in contexts where day-level precision is unnecessary.
+
+## When to use it
+
+- Collecting a single month (e.g. "Report month", "Billing period").
+- Collecting multiple individual months that are not necessarily consecutive.
+- Collecting a month range (e.g. a subscription period, a fiscal window).
+- Any scenario where a user needs to select at the month level rather than a specific date — this is less granular and less cognitively demanding than `DatePickerInput`.
+
+## When not to use it
+
+- When day-level precision is required — use `DatePickerInput` instead.
+- When only a year is needed and not a month — use `YearPickerInput` instead.
+
+## Decision-making guidance
+
+- Use `type="default"` (single month) for point-in-time selections such as a report month.
+- Use `type="range"` for interval selections such as a date range filter over months; this covers the most common multi-month use case.
+- Use `type="multiple"` when users need to pick specific, non-contiguous months (unusual — validate this is truly needed before using it).
+- Enable `clearable` whenever the field is optional, so users can remove a previously set value without workarounds.
+
+## Variants
+
+**`type`** controls selection behaviour:
+
+- `'default'` — single month selection.
+- `'multiple'` — multiple individual months.
+- `'range'` — continuous month range with start and end.
+
+## Interaction notes
+
+- The popover opens when the user focuses or clicks the input.
+- In `type="range"` mode, the first click sets the start month and the second click sets the end month.
+- When `clearable` is enabled, a clear button appears inside the input when a value is set.
+
+## Accessibility expectations
+
+- The input MUST have a visible label; use the `label` prop or connect an external label with `aria-labelledby`.
+- `description` and `error` props SHOULD be used to provide supplementary guidance and validation feedback — these are rendered in accessible positions.
+- The popover calendar is keyboard-navigable: arrow keys move between months, Enter confirms selection, Escape closes the popover.
+
+## Content guidance
+
+- Use a `placeholder` that signals what kind of value is expected (e.g. `"Pick a month"`).
+- Labels SHOULD be noun phrases: "Report month" rather than "Select a report month".
+- Error messages SHOULD be specific: "End month must be after start month" rather than "Invalid selection".
+
+## Common anti-patterns
+
+- Using `MonthPickerInput` when day-level precision is needed — use `DatePickerInput` in that case.
+- Omitting `clearable` on optional fields, forcing users to reload or use workarounds to unset a value.
+- Using `type="multiple"` without a clear rationale — multi-select month patterns are rare and often better served by checkboxes or a `MultiSelect` with month options.
+
+## What an AI agent should understand
+
+- `MonthPickerInput` is a direct re-export of `@mantine/dates` `MonthPickerInput` with a `displayName` set. All Mantine props are available.
+- Plasma adds no additional props or behaviour beyond the Mantine base component.
+- The component shares the same `type`, `clearable`, and `placeholder` patterns used by `DatePickerInput` — the key difference is that the calendar only shows month-level granularity.
+- Pass tooltip content into `Input.LabelInfo` in forms where the field label needs supplementary guidance.
+
+# API reference
+
+## Props
+
+> Extends: `MonthPickerInputProps` from `@mantine/dates`.
+
+_No additional props beyond the Mantine base component._
+
+Key props relevant to Plasma usage patterns:
+
+**`type`** `'default' | 'multiple' | 'range'` · optional · default: `'default'` — Controls selection mode.
+
+**`clearable`** `boolean` · optional · default: `false` — Shows a clear button inside the input when a value is present.
+
+**`placeholder`** `string` · optional — Placeholder text shown when no month is selected.
+
+**`label`** `string` · optional — Visible label for the input.
+
+**`description`** `string` · optional — Helper text displayed below the label.
+
+**`error`** `string` · optional — Validation error message displayed below the input.
+
+**`required`** `boolean` · optional · default: `false` — Marks the field as required and shows a required indicator.
+
+**`disabled`** `boolean` · optional · default: `false` — Disables the input.
+
+**`readOnly`** `boolean` · optional · default: `false` — Makes the input read-only.
+
+## Usage
+
+```tsx
+import {MonthPickerInput} from '@coveord/plasma-mantine';
+
+// Single month selection
+function ReportMonthPicker() {
+    return <MonthPickerInput label="Report month" placeholder="Pick a month" clearable />;
+}
+
+// Month range selection
+function BillingPeriodPicker() {
+    return <MonthPickerInput type="range" label="Billing period" placeholder="Pick a month range" clearable required />;
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/MultiSelect.md
+++ b/packages/llms/src/components/MultiSelect.md
@@ -1,0 +1,134 @@
+---
+name: MultiSelect
+description: Dropdown input that allows users to select multiple values from a predefined list, with optional search and clear capabilities.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`MultiSelect` lets users pick any number of values from a fixed list in a single compact form field, displaying selections as removable pills inside the input — without requiring a visible list of checkboxes that would consume vertical space.
+
+## When to use it
+
+- Form fields where users need to select multiple values from a known list (e.g. assigning labels, selecting product categories, choosing permissions).
+- When the option list is long enough that a flat checkbox list would be unwieldy (more than ~6 options).
+- When users may want to search through options — enable `searchable` for large lists.
+
+## When not to use it
+
+- When only a single value can be selected — use `Select` instead.
+- When the list of options is very small (2–4 items) and all options benefit from being visible simultaneously — use `Checkbox.Group` or `Chip.Group` for better scannability.
+- When the user needs to enter free-form values that are not constrained to a predefined list — use `Collection` instead, which lets users manage an array of similar grouped inputs.
+
+## Decision-making guidance
+
+- Enable `searchable` whenever the option list exceeds ~8 items, so users can filter by typing rather than scrolling.
+- Enable `clearable` whenever the field is optional, providing a single-action way to reset all selections.
+- Keep `data` items as short, scan-friendly labels. If items need descriptions or icons, consider a custom `renderOption` or a different pattern entirely.
+- Use `w` (width) to constrain the component to a sensible size — the default width expands to its container, which can be too wide in some layouts.
+
+## Interaction notes
+
+- Selected values appear as dismissible pills inside the input field.
+- Clicking the input opens the dropdown; typing filters the list when `searchable` is enabled.
+- Each pill has an individual remove button. The clear button (when `clearable` is enabled) removes all selections at once.
+- The dropdown closes when the user clicks outside or presses Escape.
+
+## Accessibility expectations
+
+- The input MUST have a visible label via the `label` prop or an external label connected with `aria-labelledby`.
+- `description` and `error` props SHOULD be used to provide guidance and validation feedback — these are rendered in accessible positions.
+- The component is keyboard navigable: Tab focuses the input, arrow keys navigate options, Enter/Space toggles selection, Escape closes the dropdown, Backspace removes the last selected pill.
+
+## Content guidance
+
+- Use a `placeholder` that describes the expected action, such as `"Pick values"` or `"Select categories"`.
+- Labels SHOULD be noun phrases: "Assigned labels" rather than "Select labels to assign".
+- Error messages SHOULD be specific: "Select at least one category" rather than "Invalid selection".
+- Keep individual option labels concise — truncation inside the pill is visually jarring.
+
+## Common anti-patterns
+
+- Using `MultiSelect` for a small fixed set of 2–3 options where checkboxes or chips would be more scannable.
+- Omitting `searchable` on a long list, forcing users to scroll through many options.
+- Omitting `clearable` on an optional field, leaving users with no bulk-reset affordance.
+- Providing very long option labels that truncate awkwardly when rendered as pills.
+
+## What an AI agent should understand
+
+- `MultiSelect` is a direct re-export of `@mantine/core` `MultiSelect` with a `displayName` set. All Mantine props are available.
+- Plasma adds no additional props or behaviour beyond the Mantine base component.
+- `data` accepts `string[]`, `{value: string; label: string}[]`, or grouped options `{group: string; items: ...}[]`.
+- Use `Input.LabelInfo` to attach supplementary tooltip guidance alongside the field label.
+- The distinction from `TagsInput`: `MultiSelect` constrains selections to predefined `data`; `TagsInput` allows arbitrary user-entered values.
+
+# API reference
+
+## Props
+
+> Extends: `MultiSelectProps` from `@mantine/core`.
+
+_No additional props beyond the Mantine base component._
+
+Key props relevant to Plasma usage patterns:
+
+**`data`** `string[] | {value: string; label: string}[] | {group: string; items: ...}[]` · required — The list of options users can choose from.
+
+**`searchable`** `boolean` · optional · default: `false` — Allows users to filter options by typing in the input.
+
+**`clearable`** `boolean` · optional · default: `false` — Shows a clear button to remove all selected values at once.
+
+**`placeholder`** `string` · optional — Placeholder text shown when no values are selected.
+
+**`label`** `string` · optional — Visible label for the input.
+
+**`description`** `string` · optional — Helper text displayed below the label.
+
+**`error`** `string` · optional — Validation error message displayed below the input.
+
+**`required`** `boolean` · optional · default: `false` — Marks the field as required and shows a required indicator.
+
+**`disabled`** `boolean` · optional · default: `false` — Disables the input.
+
+**`readOnly`** `boolean` · optional · default: `false` — Makes the input read-only (selections cannot be changed).
+
+## Usage
+
+```tsx
+import {MultiSelect} from '@coveord/plasma-mantine';
+
+// Basic multi-select with search
+function LabelAssignment() {
+    return (
+        <MultiSelect
+            label="Assigned labels"
+            placeholder="Pick values"
+            data={['Bug', 'Feature', 'Enhancement', 'Documentation', 'Testing', 'Security', 'Performance']}
+            searchable
+            clearable
+            w={300}
+        />
+    );
+}
+
+// Grouped options
+function CategoryFilter() {
+    return (
+        <MultiSelect
+            label="Categories"
+            placeholder="Select categories"
+            data={[
+                {group: 'Fruits', items: ['Apple', 'Orange', 'Banana']},
+                {group: 'Vegetables', items: ['Carrot', 'Broccoli']},
+            ]}
+            searchable
+            clearable
+        />
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/MultiSelect.md
+++ b/packages/llms/src/components/MultiSelect.md
@@ -55,14 +55,6 @@ description: Dropdown input that allows users to select multiple values from a p
 - Omitting `clearable` on an optional field, leaving users with no bulk-reset affordance.
 - Providing very long option labels that truncate awkwardly when rendered as pills.
 
-## What an AI agent should understand
-
-- `MultiSelect` is a direct re-export of `@mantine/core` `MultiSelect` with a `displayName` set. All Mantine props are available.
-- Plasma adds no additional props or behaviour beyond the Mantine base component.
-- `data` accepts `string[]`, `{value: string; label: string}[]`, or grouped options `{group: string; items: ...}[]`.
-- Use `Input.LabelInfo` to attach supplementary tooltip guidance alongside the field label.
-- The distinction from `TagsInput`: `MultiSelect` constrains selections to predefined `data`; `TagsInput` allows arbitrary user-entered values.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/MultiSelect.md
+++ b/packages/llms/src/components/MultiSelect.md
@@ -7,7 +7,7 @@ description: Dropdown input that allows users to select multiple values from a p
 
 ## What problem does it solve?
 
-`MultiSelect` lets users pick any number of values from a fixed list in a single compact form field, displaying selections as removable pills inside the input — without requiring a visible list of checkboxes that would consume vertical space.
+`MultiSelect` lets users pick any number of values from a fixed list in a single compact form field, displaying selections as removable pills inside the input.
 
 ## When to use it
 

--- a/packages/llms/src/components/NavLink.md
+++ b/packages/llms/src/components/NavLink.md
@@ -1,0 +1,112 @@
+---
+name: NavLink
+description: Navigation link component for sidebars and menus that supports active state, icons, badges, and nested child links.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`NavLink` renders a styled navigation item that communicates the current location within an application. It supports left icons, right sections (such as badges), active highlighting, disabled state, and nesting — all in a consistent interactive target.
+
+## When to use it
+
+Use `NavLink` when:
+
+- building a sidebar or vertical navigation menu
+- you need to indicate which section of the application the user is currently viewing
+- a navigation item has child items that expand beneath it
+- you want to decorate a navigation entry with a status badge or icon
+
+## When not to use it
+
+Do not use `NavLink` when:
+
+- the link is inline within prose; use `Anchor` instead
+- the action triggers a command rather than navigation; use `Button`
+- a flat, horizontal navigation structure is needed; use tabs or a custom nav bar
+
+## Decision-making guidance
+
+- Use `active` only on the item that exactly matches the current route; do not apply it to parent items when a child is active.
+- Use `leftSection` for route-identifying icons so users can scan the menu quickly.
+- Use `rightSection` for contextual badges (e.g. unread count, "New") — do not overload both sections simultaneously without a clear purpose.
+- For nested menus, keep the nesting depth to one level. Deeper hierarchies become hard to navigate.
+
+## Variants
+
+Mantine's `NavLink` supports `variant` values (`filled`, `light`, `subtle`). Plasma does not restrict the available variants; use the design token–compatible variant that fits the application shell.
+
+## States
+
+- **Default** — unvisited, not active
+- **Active** — current page; apply `active` prop
+- **Hover** — automatic via CSS
+- **Disabled** — prevents interaction and dims the link
+- **With children (collapsed/expanded)** — chevron indicates toggleable children; defaults to collapsed
+
+## Interaction notes
+
+Clicking a NavLink with children toggles its expanded state rather than navigating. Navigation only occurs when `href` resolves to a real destination. If using a client-side router, pass the router's `Link` component via the `component` prop.
+
+## Accessibility expectations
+
+- `NavLink` renders as an anchor (`<a>`) by default. Ensure `href` is always set when used for navigation.
+- The `active` state SHOULD correspond to the current page so screen-reader users receive correct `aria-current` semantics (Mantine sets this automatically).
+- Disabled nav links MUST NOT be the only way to reach a destination; remove them from the tree if the route is genuinely unavailable.
+
+## Common anti-patterns
+
+- Marking multiple items `active` at the same time.
+- Using `NavLink` for form submission or destructive actions.
+- Nesting more than one level deep in a sidebar.
+- Omitting `href` when the link is expected to be keyboard- or right-click-navigable.
+
+## What an AI agent should understand
+
+- `NavLink` is a thin Plasma re-export of Mantine's `NavLink` with no additional props.
+- Nest `NavLink` components as children to create collapsible sub-menus.
+- Use `Badge.Primary` (or other `Badge` sub-components) in `rightSection` for status annotations.
+- Pass a router's `Link` component to `component` for client-side navigation.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `NavLinkProps` from `@mantine/core`. Refer to [Mantine NavLink documentation](https://mantine.dev/core/nav-link/) for the full prop list.
+
+## Sub-components
+
+Mantine exposes `NavLink` only as a single component; sub-items are created by rendering `NavLink` as children.
+
+## Usage
+
+```tsx
+import {Badge} from '@coveord/plasma-mantine';
+import {NavLink} from '@coveord/plasma-mantine/components/NavLink';
+import {IconHome2} from '@coveord/plasma-react-icons';
+
+function SidebarNav() {
+    return (
+        <>
+            <NavLink
+                label="Home"
+                href="/home"
+                active
+                leftSection={<IconHome2 size={16} />}
+                rightSection={<Badge.Primary>New</Badge.Primary>}
+            />
+            <NavLink label="Reports" href="#">
+                <NavLink label="Overview" href="#" />
+                <NavLink label="Details" href="#" />
+            </NavLink>
+        </>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/NavLink.md
+++ b/packages/llms/src/components/NavLink.md
@@ -62,13 +62,6 @@ Clicking a NavLink with children toggles its expanded state rather than navigati
 - Nesting more than one level deep in a sidebar.
 - Omitting `href` when the link is expected to be keyboard- or right-click-navigable.
 
-## What an AI agent should understand
-
-- `NavLink` is a thin Plasma re-export of Mantine's `NavLink` with no additional props.
-- Nest `NavLink` components as children to create collapsible sub-menus.
-- Use `Badge.Primary` (or other `Badge` sub-components) in `rightSection` for status annotations.
-- Pass a router's `Link` component to `component` for client-side navigation.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/NavLink.md
+++ b/packages/llms/src/components/NavLink.md
@@ -77,8 +77,7 @@ Mantine exposes `NavLink` only as a single component; sub-items are created by r
 ## Usage
 
 ```tsx
-import {Badge} from '@coveord/plasma-mantine';
-import {NavLink} from '@coveord/plasma-mantine/components/NavLink';
+import {Badge, NavLink} from '@coveord/plasma-mantine';
 import {IconHome2} from '@coveord/plasma-react-icons';
 
 function SidebarNav() {

--- a/packages/llms/src/components/Notification.md
+++ b/packages/llms/src/components/Notification.md
@@ -70,12 +70,6 @@ description: Toast notification that communicates the outcome of an action with 
 - Stacking many toasts at once for bulk operations — batch them into a single notification.
 - Using `Notification` in place of form validation errors — use inline field validation instead.
 
-## What an AI agent should understand
-
-- `Notification` is a thin Plasma re-export of Mantine's `Notification` with no additional props.
-- For programmatic toasts, import `notifications` from `@coveord/plasma-mantine/notifications` and call `notifications.show()`.
-- Icons are not automatic — always pass the correct icon element to the `icon` prop to match the intended `variant`.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Notification.md
+++ b/packages/llms/src/components/Notification.md
@@ -1,0 +1,114 @@
+---
+name: Notification
+description: Toast notification that communicates the outcome of an action with info, success, warning, or error severity.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Notification` gives users timely feedback about the outcome of an action — without interrupting their flow. It appears briefly as a toast in the corner of the screen, then disappears on its own. Because it's transient, it's best for low-priority feedback the user should see but doesn't need to act on immediately.
+
+## When to use it
+
+- Confirming that an action completed successfully (e.g. "Changes saved").
+- Letting the user know a background task finished or failed.
+- Surfacing a non-blocking warning the user should be aware of.
+- Showing a loading state while an async operation is in progress.
+
+## When not to use it
+
+- When the message is critical and the user must act on it — use a `Prompt` or `Alert` instead. Toasts auto-dismiss and can be missed.
+- When the error blocks the user from continuing — a toast is not enough for blocking errors.
+- When the feedback belongs to a specific form field — use inline field validation instead.
+- When the message needs to stay visible until the user dismisses it — use a persistent `Alert` in the page content.
+- When many notifications would stack at once for bulk operations — batch them into a single notification.
+
+## Decision-making guidance
+
+- Prefer the `notifications` system API for transient toasts so they are managed consistently — queued, auto-dismissed, and accessible.
+- When the message must persist in the document flow until the user acts on it, use `Alert` instead.
+- Convey severity through the `color` prop and a matching `icon` (there is no semantic `variant` prop):
+    - `info` — neutral information, no action required
+    - `success` — positive confirmation
+    - `warning` — something may go wrong; user should review
+    - `error` — something went wrong; user may need to act
+- Always pair the colour with a matching icon so the meaning is communicated by both colour and shape, not colour alone.
+
+## Severity levels
+
+- Use `info` for general information or updates.
+- Use `success` to confirm an operation completed successfully.
+- Use `warning` for a potential issue that is non-blocking.
+- Use `error` when an operation failed and the user may need to act.
+
+## States
+
+- **Default** — shows icon, optional title, and message body
+- **Loading** — set `loading` to `true` to replace the icon with a spinner; use while awaiting an async result
+
+## Interaction notes
+
+- Toasts shown via `notifications.show()` auto-dismiss after a configurable timeout. Do not rely on the user seeing them for critical error recovery.
+
+## Accessibility expectations
+
+- MUST include a descriptive `title` and a `children` message body so both sighted and screen-reader users understand the context.
+- Icon SHOULD complement, not replace, the text message — do not rely solely on colour.
+- `loading` notifications SHOULD not disappear abruptly; transition to a resolved state (success or error) after the operation settles.
+
+## Content guidance
+
+- Titles SHOULD be short (3–6 words) and outcome-focused — say what happened, not what to do.
+- Body text SHOULD be kept to 2 lines maximum — toasts are glanceable, not detailed.
+- For errors and warnings, always include what the user can do next — avoid vague messages like "Something went wrong" with no recovery path.
+
+## Common anti-patterns
+
+- Using `error` variant for informational messages just to draw attention.
+- Showing a notification without an icon, leaving the severity ambiguous.
+- Stacking many toasts at once for bulk operations — batch them into a single notification.
+- Using `Notification` in place of form validation errors — use inline field validation instead.
+
+## What an AI agent should understand
+
+- `Notification` is a thin Plasma re-export of Mantine's `Notification` with no additional props.
+- For programmatic toasts, import `notifications` from `@coveord/plasma-mantine/notifications` and call `notifications.show()`.
+- Icons are not automatic — always pass the correct icon element to the `icon` prop to match the intended `variant`.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `NotificationProps` from `@mantine/core`. Refer to [Mantine Notification documentation](https://mantine.dev/core/notification/) for the full prop list.
+
+Key props in practice:
+
+- **`title`** `ReactNode` — Notification heading
+- **`children`** `ReactNode` — Notification message body
+- **`icon`** `ReactNode` — Icon displayed on the left; SHOULD match the intended severity
+- **`loading`** `boolean` — Replaces the icon with a spinner
+- **`withCloseButton`** `boolean` — Shows or hides the dismiss button (default `true`)
+
+## Usage
+
+```tsx
+import {Notification} from '@coveord/plasma-mantine/components/Notification';
+import {notifications} from '@coveord/plasma-mantine/notifications';
+import {IconCircleCheckFilled, IconAlertSquareFilled} from '@coveord/plasma-react-icons';
+
+// Toast via notifications system
+function showError() {
+    notifications.show({
+        title: 'Export failed',
+        message: 'The file could not be generated. Try again or contact support.',
+        icon: <IconAlertSquareFilled size={20} color="var(--mantine-color-red-4)" />,
+    });
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Notification.md
+++ b/packages/llms/src/components/Notification.md
@@ -35,13 +35,6 @@ description: Toast notification that communicates the outcome of an action with 
     - `error` — something went wrong; user may need to act
 - Always pair the colour with a matching icon so the meaning is communicated by both colour and shape, not colour alone.
 
-## Severity levels
-
-- Use `info` for general information or updates.
-- Use `success` to confirm an operation completed successfully.
-- Use `warning` for a potential issue that is non-blocking.
-- Use `error` when an operation failed and the user may need to act.
-
 ## States
 
 - **Default** — shows icon, optional title, and message body
@@ -65,7 +58,7 @@ description: Toast notification that communicates the outcome of an action with 
 
 ## Common anti-patterns
 
-- Using `error` variant for informational messages just to draw attention.
+- Using the `error` colour/icon for informational messages just to draw attention.
 - Showing a notification without an icon, leaving the severity ambiguous.
 - Stacking many toasts at once for bulk operations — batch them into a single notification.
 - Using `Notification` in place of form validation errors — use inline field validation instead.
@@ -89,9 +82,8 @@ Key props in practice:
 ## Usage
 
 ```tsx
-import {Notification} from '@coveord/plasma-mantine/components/Notification';
 import {notifications} from '@coveord/plasma-mantine/notifications';
-import {IconCircleCheckFilled, IconAlertSquareFilled} from '@coveord/plasma-react-icons';
+import {IconAlertSquareFilled} from '@coveord/plasma-react-icons';
 
 // Toast via notifications system
 function showError() {

--- a/packages/llms/src/components/NumberInput.md
+++ b/packages/llms/src/components/NumberInput.md
@@ -1,0 +1,115 @@
+---
+name: NumberInput
+description: Numeric text field with increment/decrement controls, configurable formatting, and optional prefix, suffix, and range constraints.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`NumberInput` provides a purpose-built field for numeric values. Unlike a plain text input, it enforces numeric-only entry, exposes stepper controls, and handles locale-aware formatting (thousand separators, decimal separators, prefix/suffix) so products do not need to implement custom number parsing.
+
+## When to use it
+
+Use `NumberInput` when:
+
+- the user must enter a number (quantity, threshold, percentage, page count, etc.)
+- the value has a defined minimum and/or maximum that should be enforced at the input level
+- the user may need to increment or decrement the value in small steps
+- the value requires display formatting such as currency, units, or large-number separators
+
+## When not to use it
+
+Do not use `NumberInput` when:
+
+- the "number" is not arithmetic — use a plain `TextInput` with appropriate `inputMode`
+- the range of valid values is small and discrete — use a `Select` or `Slider` instead
+- free-form text alongside a number is expected in the same field
+
+## Decision-making guidance
+
+- Set minimum and maximum values when the field has hard limits — this prevents users from entering something invalid before they submit.
+- If the value can't be negative (like a quantity or a count), restrict the field to positive numbers only.
+- If only whole numbers make sense, prevent decimal entry.
+- Use a prefix or suffix to show the unit directly inside the field (e.g. `$` before a price, `%` after a percentage) — don't place it as separate text next to the field.
+- For large numbers like financial amounts, use a thousands separator to make them easier to read at a glance.
+
+## States
+
+- **Default** — editable with stepper buttons
+- **Disabled** — field and steppers non-interactive
+- **Error** — validation message shown below the field via `error` prop
+- **Read-only** — set `readOnly` to display the value without allowing edits
+- **Loading** — not built-in; represent via form-level state if needed
+
+## Interaction notes
+
+Users can type directly into the field or use the `+`/`−` stepper buttons. The field clamps the value to `min`/`max` on blur. Pressing the up/down arrow keys also increments/decrements by `step`.
+
+## Accessibility expectations
+
+- MUST include a visible `label` — use `InputWrapper` label or the `label` prop.
+- `description` SHOULD explain units or constraints when they are not self-evident from context.
+- `error` MUST describe what is wrong and what the valid range is when the constraint is violated.
+
+## Common anti-patterns
+
+- Using `NumberInput` for non-arithmetic identifiers (phone numbers, ZIP codes).
+- Omitting `min={0}` for fields that cannot logically be negative (quantity, duration, price).
+- Relying on `placeholder` to communicate constraints instead of `description`.
+- Using a plain `TextInput` with manual number validation when `NumberInput` handles it natively.
+
+## What an AI agent should understand
+
+- `NumberInput` is a thin Plasma re-export of Mantine's `NumberInput` with no additional props.
+- Formatting props (`prefix`, `suffix`, `thousandSeparator`, `decimalSeparator`) affect display only, not the underlying numeric value passed to `onChange`.
+- `defaultValue` sets an uncontrolled starting value; use `value` + `onChange` for controlled usage.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `NumberInputProps` from `@mantine/core`. Refer to [Mantine NumberInput documentation](https://mantine.dev/core/number-input/) for the full prop list.
+
+Key props in practice:
+
+- **`min`** `number` · optional — Minimum allowed value
+- **`max`** `number` · optional — Maximum allowed value
+- **`step`** `number` · optional · default: `1` — Step size for stepper controls and arrow keys
+- **`allowNegative`** `boolean` · optional · default: `true` — When `false`, negative values are rejected
+- **`allowDecimal`** `boolean` · optional · default: `true` — When `false`, decimal entry is blocked
+- **`prefix`** `string` · optional — Text displayed before the value (e.g. `"$"`)
+- **`suffix`** `string` · optional — Text displayed after the value (e.g. `" %"`)
+- **`thousandSeparator`** `string` · optional · default: `","` — Character used to group thousands
+- **`decimalSeparator`** `string` · optional · default: `"."` — Character used for the decimal point
+- **`leftSection`** `ReactNode` · optional — Icon or element placed inside the left side of the field
+
+## Usage
+
+```tsx
+import {NumberInput} from '@coveord/plasma-mantine/components/NumberInput';
+import {IconCoins} from '@coveord/plasma-react-icons';
+
+function BudgetField() {
+    return (
+        <NumberInput
+            label="Monthly budget"
+            description="Enter the maximum spend in USD"
+            prefix="$"
+            thousandSeparator=","
+            allowNegative={false}
+            allowDecimal={false}
+            min={0}
+            max={1000000}
+            leftSection={<IconCoins size={16} />}
+            defaultValue={0}
+        />
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/NumberInput.md
+++ b/packages/llms/src/components/NumberInput.md
@@ -59,12 +59,6 @@ Users can type directly into the field or use the `+`/`−` stepper buttons. The
 - Relying on `placeholder` to communicate constraints instead of `description`.
 - Using a plain `TextInput` with manual number validation when `NumberInput` handles it natively.
 
-## What an AI agent should understand
-
-- `NumberInput` is a thin Plasma re-export of Mantine's `NumberInput` with no additional props.
-- Formatting props (`prefix`, `suffix`, `thousandSeparator`, `decimalSeparator`) affect display only, not the underlying numeric value passed to `onChange`.
-- `defaultValue` sets an uncontrolled starting value; use `value` + `onChange` for controlled usage.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/NumberInput.md
+++ b/packages/llms/src/components/NumberInput.md
@@ -83,7 +83,7 @@ Key props in practice:
 ## Usage
 
 ```tsx
-import {NumberInput} from '@coveord/plasma-mantine/components/NumberInput';
+import {NumberInput} from '@coveord/plasma-mantine';
 import {IconCoins} from '@coveord/plasma-react-icons';
 
 function BudgetField() {

--- a/packages/llms/src/components/Pagination.md
+++ b/packages/llms/src/components/Pagination.md
@@ -1,0 +1,105 @@
+---
+name: Pagination
+description: Page navigation control that lets users move through a multi-page dataset with numbered pages, ellipsis, and optional first/last shortcuts.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Pagination` gives users explicit control over which page of a large dataset they are viewing. It renders a row of numbered page buttons with smart ellipsis truncation so the control stays compact even for datasets with hundreds of pages.
+
+## When to use it
+
+Use `Pagination` when:
+
+- a list, table, or grid is split across multiple pages and the user needs to navigate between them
+- the total number of pages is known at render time
+- the user benefits from being able to jump to an arbitrary page number (not just previous/next)
+
+## When not to use it
+
+Do not use `Pagination` when:
+
+- infinite scroll or "load more" is the intended pattern — pagination implies discrete pages
+- there is only one page of results
+- the dataset is small enough to display in full without scrolling
+
+## Decision-making guidance
+
+- Pagination always needs to know what page the user is on — manage that in your component's state and update it when the user clicks a page.
+- If users often need to jump several pages at once, show more page numbers around the current page.
+- If users commonly need to jump to the very first or last page, show first/last buttons at the edges.
+- Disable the pagination controls while data is loading to prevent the user from triggering conflicting requests.
+
+## States
+
+- **Default** — shows numbered pages with previous/next arrows
+- **Disabled** — all controls non-interactive; apply while data is loading
+- **With edges** — adds first-page and last-page jump buttons
+
+## Interaction notes
+
+Clicking a page number updates the active page and SHOULD trigger a new data fetch. The current page button is visually distinguished from neighbours. Ellipsis (`…`) appears when there are more pages than can fit within `siblings` and `boundaries`.
+
+## Accessibility expectations
+
+- `Pagination` renders `<button>` elements with appropriate labels. Do not wrap the component in another `<nav>` without removing Mantine's built-in landmark to avoid nesting.
+- When the page changes, focus SHOULD move to the top of the newly loaded content so keyboard and screen-reader users know the page has updated.
+- MUST NOT disable `Pagination` permanently — if no results exist, hide it instead.
+
+## Common anti-patterns
+
+- Using `Pagination` with an uncontrolled pattern (no `value`/`onChange`) and losing sync with server state.
+- Rendering `Pagination` when `total` is `0` or `1`.
+- Keeping `Pagination` enabled while new data is loading, causing duplicate or race-condition requests.
+- Setting `siblings` or `boundaries` so high that the control spans the full width on small screens.
+
+## What an AI agent should understand
+
+- `Pagination` is a thin Plasma re-export of Mantine's `Pagination` with no additional props.
+- `total` is the number of pages, not the number of records — derive it from `Math.ceil(recordCount / pageSize)`.
+- Use controlled `value` + `onChange` to stay in sync with data-fetching logic.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `PaginationProps` from `@mantine/core`. Refer to [Mantine Pagination documentation](https://mantine.dev/core/pagination/) for the full prop list.
+
+Key props in practice:
+
+- **`total`** `number` · required — Total number of pages
+- **`value`** `number` · optional — Controlled current page (1-based)
+- **`onChange`** `(page: number) => void` · optional — Called when the user selects a page
+- **`siblings`** `number` · optional · default: `1` — Pages shown on each side of the active page
+- **`boundaries`** `number` · optional · default: `1` — Pages always shown at the start and end of the range
+- **`withEdges`** `boolean` · optional · default: `false` — Shows first/last page jump buttons
+- **`disabled`** `boolean` · optional · default: `false` — Disables all interactive controls
+
+## Usage
+
+```tsx
+import {Pagination} from '@coveord/plasma-mantine/components/Pagination';
+import {useState} from 'react';
+
+function PaginatedTable() {
+    const [page, setPage] = useState(1);
+    const pageSize = 20;
+    const totalRecords = 348;
+    const totalPages = Math.ceil(totalRecords / pageSize);
+
+    return (
+        <>
+            {/* table content */}
+            <Pagination value={page} onChange={setPage} total={totalPages} withEdges siblings={2} />
+        </>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Pagination.md
+++ b/packages/llms/src/components/Pagination.md
@@ -55,12 +55,6 @@ Clicking a page number updates the active page and SHOULD trigger a new data fet
 - Keeping `Pagination` enabled while new data is loading, causing duplicate or race-condition requests.
 - Setting `siblings` or `boundaries` so high that the control spans the full width on small screens.
 
-## What an AI agent should understand
-
-- `Pagination` is a thin Plasma re-export of Mantine's `Pagination` with no additional props.
-- `total` is the number of pages, not the number of records — derive it from `Math.ceil(recordCount / pageSize)`.
-- Use controlled `value` + `onChange` to stay in sync with data-fetching logic.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Pagination.md
+++ b/packages/llms/src/components/Pagination.md
@@ -24,6 +24,7 @@ Do not use `Pagination` when:
 - infinite scroll or "load more" is the intended pattern — pagination implies discrete pages
 - there is only one page of results
 - the dataset is small enough to display in full without scrolling
+- the list lives inside a dropdown or menu — paginating there forces extra clicks; show a scrollable list or a "load more" pattern instead
 
 ## Decision-making guidance
 
@@ -76,7 +77,7 @@ Key props in practice:
 ## Usage
 
 ```tsx
-import {Pagination} from '@coveord/plasma-mantine/components/Pagination';
+import {Pagination} from '@coveord/plasma-mantine';
 import {useState} from 'react';
 
 function PaginatedTable() {

--- a/packages/llms/src/components/PasswordInput.md
+++ b/packages/llms/src/components/PasswordInput.md
@@ -3,6 +3,59 @@ name: PasswordInput
 description: Password input with support for a read-only visual state.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `PasswordInput` lets users enter or review secret values while hiding the characters by default.
+
+It is useful for credentials, tokens, and other sensitive values that should not be displayed as plain text during entry.
+
+## When to use it
+
+Use `PasswordInput` when:
+
+- users enter a password, secret, token, or credential-like value
+- the value should be masked by default
+- users may need to reveal the value temporarily to verify it
+- a read-only secret field should keep field styling while preventing edits
+
+## When not to use it
+
+Do not use `PasswordInput` when:
+
+- the value is not sensitive
+- users need to scan or compare the full value frequently
+- the value should be copied rather than edited; pair a read-only input with `CopyToClipboard`
+- masking would make the task harder without protecting anything meaningful
+
+## Decision-making guidance
+
+- Use `PasswordInput` for secret entry.
+- Use `TextInput` for non-secret values.
+- Use read-only styling when the value is shown for reference and should not be edited.
+- Consider `CopyToClipboard` for read-only generated secrets users need elsewhere.
+
+## Accessibility expectations
+
+- Labels MUST identify what secret value is expected.
+- Helper text SHOULD state format or rotation requirements when relevant.
+- Do not rely on placeholder text as the only instruction.
+
+## Common anti-patterns
+
+- Masking non-sensitive values.
+- Showing generated secrets without a copy affordance.
+- Using disabled state for a value that should be readable but not editable.
+
+## What an AI agent should understand
+
+- `PasswordInput` is for masked secret values.
+- Use `readOnly` for non-editable values that still need field readability.
+- Pair with copy behavior when users need to transfer generated secrets.
+
+# API reference
+
 ## Props
 
 _No additional props beyond the Mantine base component._

--- a/packages/llms/src/components/PasswordInput.md
+++ b/packages/llms/src/components/PasswordInput.md
@@ -48,12 +48,6 @@ Do not use `PasswordInput` when:
 - Showing generated secrets without a copy affordance.
 - Using disabled state for a value that should be readable but not editable.
 
-## What an AI agent should understand
-
-- `PasswordInput` is for masked secret values.
-- Use `readOnly` for non-editable values that still need field readability.
-- Pair with copy behavior when users need to transfer generated secrets.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Pill.md
+++ b/packages/llms/src/components/Pill.md
@@ -1,0 +1,102 @@
+---
+name: Pill
+description: Compact tag-style element used to display a selected value or token, optionally with a remove button for multi-value inputs.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Pill` represents a discrete selected value within a multi-value input or a tag list. It provides a contained, visually distinct token that can optionally be removed by the user, making it the correct building block for tag inputs, multiselect fields, and filter chips within an input field.
+
+## When to use it
+
+Use `Pill` when:
+
+- rendering selected values inside a `PillsInput` or multiselect field
+- displaying removable tags or tokens where each item represents a discrete selection
+- building a custom multi-value input that requires individual item removal
+
+## When not to use it
+
+Do not use `Pill` when:
+
+- the value is a read-only label or category indicator not associated with an input; use `Badge` instead
+- the user is choosing between options (not removing them); use `Chip` or `Select`
+- a single selected value is sufficient; a plain `Select` or `TextInput` is simpler
+
+## Decision-making guidance
+
+- Use `withRemoveButton` only when the user can remove the value. Do not show the remove button on read-only or display-only contexts.
+- Prefer `size="sm"` (the default) for inline use within `PillsInput`. Use `size="md"` when `Pill` is displayed outside of a dense input context.
+- `Pill` is intentionally minimal. If you need rich styling (colour, icon) per tag, consider whether `Badge` or `Chip` better fits the use case.
+
+## Variants
+
+`Pill` does not expose semantic variants. It inherits Mantine's theming and displays consistently as a neutral tag. For colour-coded tags, use `Badge`.
+
+## States
+
+- **Default** — read-only token display
+- **With remove button** — adds an `×` button the user can click to deselect the value
+
+## Interaction notes
+
+When `withRemoveButton` is set, clicking the `×` triggers the `onRemove` callback. The remove action SHOULD immediately remove the item from the selection and return focus to the surrounding input.
+
+## Accessibility expectations
+
+- When `withRemoveButton` is used, the remove button MUST have an accessible label — Mantine sets this via `removeButtonProps`. Override it when the default label is not descriptive enough (e.g. use "Remove Python" instead of just "Remove").
+- `Pill` elements within an input SHOULD be keyboard-reachable, typically via `Tab` or focus management handled by the parent `PillsInput`.
+
+## Common anti-patterns
+
+- Using `Pill` as a status badge or category label outside an input context — use `Badge` instead.
+- Rendering a `Pill` with `withRemoveButton` but no `onRemove` handler, making the button a no-op.
+- Using `Pill` for navigation or action triggers — use `Chip` or `Button`.
+
+## What an AI agent should understand
+
+- `Pill` is a thin Plasma re-export of Mantine's `Pill` with no additional props.
+- It is primarily intended as a child of `PillsInput.Field` for custom multiselect implementations.
+- `withRemoveButton` controls the visible `×`; wire `onRemove` to remove the item from state.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `PillProps` from `@mantine/core`. Refer to [Mantine Pill documentation](https://mantine.dev/core/pill/) for the full prop list.
+
+Key props in practice:
+
+- **`children`** `ReactNode` · required — The value label displayed inside the pill
+- **`withRemoveButton`** `boolean` · optional · default: `false` — Shows the remove (`×`) button
+- **`onRemove`** `() => void` · optional — Callback fired when the remove button is clicked
+- **`size`** `'sm' | 'md'` · optional · default: `'sm'` — Controls the pill's overall size
+
+## Usage
+
+```tsx
+import {Pill} from '@coveord/plasma-mantine/components/Pill';
+import {useState} from 'react';
+
+function TagList() {
+    const [tags, setTags] = useState(['React', 'TypeScript', 'Python']);
+
+    return (
+        <div style={{display: 'flex', gap: 4, flexWrap: 'wrap'}}>
+            {tags.map((tag) => (
+                <Pill key={tag} withRemoveButton onRemove={() => setTags((prev) => prev.filter((t) => t !== tag))}>
+                    {tag}
+                </Pill>
+            ))}
+        </div>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Pill.md
+++ b/packages/llms/src/components/Pill.md
@@ -55,12 +55,6 @@ When `withRemoveButton` is set, clicking the `×` triggers the `onRemove` callba
 - Rendering a `Pill` with `withRemoveButton` but no `onRemove` handler, making the button a no-op.
 - Using `Pill` for navigation or action triggers — use `Chip` or `Button`.
 
-## What an AI agent should understand
-
-- `Pill` is a thin Plasma re-export of Mantine's `Pill` with no additional props.
-- It is primarily intended as a child of `PillsInput.Field` for custom multiselect implementations.
-- `withRemoveButton` controls the visible `×`; wire `onRemove` to remove the item from state.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Pill.md
+++ b/packages/llms/src/components/Pill.md
@@ -27,6 +27,7 @@ Do not use `Pill` when:
 
 ## Decision-making guidance
 
+- Prefer a ready-made `MultiSelect` over hand-building a `PillsInput` with `Pill` children whenever the values come from a known list.
 - Use `withRemoveButton` only when the user can remove the value. Do not show the remove button on read-only or display-only contexts.
 - Prefer `size="sm"` (the default) for inline use within `PillsInput`. Use `size="md"` when `Pill` is displayed outside of a dense input context.
 - `Pill` is intentionally minimal. If you need rich styling (colour, icon) per tag, consider whether `Badge` or `Chip` better fits the use case.
@@ -73,7 +74,7 @@ Key props in practice:
 ## Usage
 
 ```tsx
-import {Pill} from '@coveord/plasma-mantine/components/Pill';
+import {Pill} from '@coveord/plasma-mantine';
 import {useState} from 'react';
 
 function TagList() {

--- a/packages/llms/src/components/Progress.md
+++ b/packages/llms/src/components/Progress.md
@@ -1,0 +1,83 @@
+---
+name: Progress
+description: Horizontal bar that communicates how far along a task or process has advanced.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `Progress` bar gives users a quick, at-a-glance sense of completion for a task with a known end point. It replaces vague "loading…" text with a concrete, proportional signal.
+
+## When to use it
+
+Use `Progress` when:
+
+- a task has a measurable, bounded completion percentage (0–100)
+- you want to reinforce confidence that work is proceeding (file upload, onboarding steps, form completion)
+- colour coding is needed to convey the quality or status of a result alongside its magnitude
+
+## When not to use it
+
+Do not use `Progress` when:
+
+- the duration or completion percentage is unknown; use `Skeleton` or a spinner instead
+- you need a circular representation; consider Mantine's `RingProgress` or `SemiCircleProgress` available in Plasma
+- the value is not about progress but about a distribution or proportion; consider a different data visualisation
+
+## Decision-making guidance
+
+- Communicate semantic meaning through the `color` prop, mapped from four intents: `info` for neutral progress, `success` for completed or healthy, `caution` for warnings, `error` for failures or risk (see the mapping below).
+- Keep the bar width wide enough to be readable; the story default of 300 px is a useful minimum.
+- Pair the bar with a visible label or percentage when the exact value matters to the user.
+
+## Semantic colours
+
+`Progress` has no semantic `variant` prop. Map the intent to a colour token and pass it to Mantine's `color` prop:
+
+| Intent           | Colour token   |
+| ---------------- | -------------- |
+| `info` (default) | primary colour |
+| `success`        | `success`      |
+| `caution`        | `yellow`       |
+| `error`          | `red`          |
+
+## Accessibility expectations
+
+- A `Progress` bar SHOULD be accompanied by a visible text label or an `aria-label` so screen-reader users understand what is being measured.
+- When the value changes dynamically, the wrapping region SHOULD have `role="status"` or `aria-live` so assistive technology announces updates.
+
+## What an AI agent should understand
+
+- `Progress` is for bounded, percentage-based task feedback.
+- Semantic colour is communicated through Mantine's `color` prop mapped from four intent names (`info`, `success`, `caution`, `error`).
+- For unknown durations, prefer `Skeleton` or an indeterminate spinner.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `ProgressProps` from `@mantine/core`. Refer to Mantine documentation for all available props.
+
+## Usage
+
+```tsx
+import {Progress} from '@coveord/plasma-mantine';
+
+const colorMapping = {
+    info: 'var(--mantine-primary-color-filled)',
+    success: 'success',
+    caution: 'yellow',
+    error: 'red',
+} as const;
+
+function Example() {
+    return <Progress value={65} w={300} color={colorMapping['success']} aria-label="Profile completion" />;
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Progress.md
+++ b/packages/llms/src/components/Progress.md
@@ -7,7 +7,7 @@ description: Horizontal bar that communicates how far along a task or process ha
 
 ## What problem does it solve?
 
-The `Progress` bar gives users a quick, at-a-glance sense of completion for a task with a known end point. It replaces vague "loading…" text with a concrete, proportional signal.
+The `Progress` bar gives users a quick, at-a-glance sense of completion for a task with a known end point. It aims to replace the vague `Loader` component with a concrete, proportional signal when the information is available.
 
 ## When to use it
 
@@ -21,7 +21,7 @@ Use `Progress` when:
 
 Do not use `Progress` when:
 
-- the duration or completion percentage is unknown; use `Skeleton` or a spinner instead
+- the duration or completion percentage is unknown; use `Skeleton` or a `Loader` instead
 - you need a circular representation; consider Mantine's `RingProgress` or `SemiCircleProgress` available in Plasma
 - the value is not about progress but about a distribution or proportion; consider a different data visualisation
 

--- a/packages/llms/src/components/Progress.md
+++ b/packages/llms/src/components/Progress.md
@@ -47,12 +47,6 @@ Do not use `Progress` when:
 - A `Progress` bar SHOULD be accompanied by a visible text label or an `aria-label` so screen-reader users understand what is being measured.
 - When the value changes dynamically, the wrapping region SHOULD have `role="status"` or `aria-live` so assistive technology announces updates.
 
-## What an AI agent should understand
-
-- `Progress` is for bounded, percentage-based task feedback.
-- Semantic colour is communicated through Mantine's `color` prop mapped from four intent names (`info`, `success`, `caution`, `error`).
-- For unknown durations, prefer `Skeleton` or an indeterminate spinner.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Prompt.md
+++ b/packages/llms/src/components/Prompt.md
@@ -3,6 +3,61 @@ name: Prompt
 description: Confirmation modal with semantic variants and optional footer actions.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `Prompt` asks users to confirm or acknowledge an important decision in a focused modal with semantic intent.
+
+It is useful when the user must make a clear choice before continuing.
+
+## When to use it
+
+Use `Prompt` when:
+
+- the user must confirm a meaningful action
+- the decision has risk, consequence, or important feedback
+- semantic tone helps communicate information, success, warning, or critical impact
+- footer actions should clearly separate cancel and confirm choices
+
+## When not to use it
+
+Do not use `Prompt` when:
+
+- the overlay contains a larger form or custom task; use `Modal`
+- the message can remain inline; use `Alert`
+- the action is low-risk and does not need confirmation
+- users need to compare information on the underlying page while deciding
+
+## Decision-making guidance
+
+- Use `Prompt.Warning` when the action needs caution.
+- Use `Prompt.Critical` for destructive or high-risk confirmation.
+- Use `Prompt.Information` for neutral acknowledgment.
+- Use `Prompt.Success` for positive confirmation or completion messaging.
+- Use `Modal` when the content is more than a confirmation decision.
+
+## Content guidance
+
+- Titles SHOULD name the decision.
+- Body text SHOULD explain consequences and reversibility.
+- Confirm button text SHOULD describe the action, not say "OK."
+- Cancel button text SHOULD make the safe alternative clear.
+
+## Common anti-patterns
+
+- Asking for confirmation on routine low-risk actions.
+- Using vague button labels for destructive actions.
+- Putting complex forms inside a prompt.
+
+## What an AI agent should understand
+
+- `Prompt` is a semantic confirmation modal.
+- Use it for decisions, not general overlay content.
+- Use the semantic sub-component that matches the consequence.
+
+# API reference
+
 ## Props
 
 > Extends: `Omit<ModalRootProps, 'classNames' | 'styles' | 'vars' | 'attributes' | 'variant'>`, `Omit<StylesApiProps<PromptFactory>, 'variant'>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/Prompt.md
+++ b/packages/llms/src/components/Prompt.md
@@ -50,12 +50,6 @@ Do not use `Prompt` when:
 - Using vague button labels for destructive actions.
 - Putting complex forms inside a prompt.
 
-## What an AI agent should understand
-
-- `Prompt` is a semantic confirmation modal.
-- Use it for decisions, not general overlay content.
-- Use the semantic sub-component that matches the consequence.
-
 # API reference
 
 ## Props


### PR DESCRIPTION
## What

Carves the **I through P** component usage-guidance docs out of #4437 into a smaller, independently reviewable PR — the third split (after #4540 for A–B and #4542 for C–H). #4437 stays open as the tracking PR.

## Components in this slice (18)

**I–L** — Image, InfoToken, Input, Kbd, LastUpdated, Loader
**M–P** — Menu, Modal, MonthPickerInput, MultiSelect, NavLink, Notification, NumberInput, Pagination, PasswordInput, Pill, Progress, Prompt

## Review-pass refinements included

Cross-checked against each component's Mantine `llms` doc / type definitions (where a Mantine base exists); custom Coveo components (InfoToken, LastUpdated) reviewed on internal consistency.

- **Loader**: removed an inaccurate claim that Mantine renders `role="presentation"` by default (its source sets no ARIA role); kept the correct "not announced to screen readers" point. Simplified a Storybook-internal default-size sentence.
- **Progress** & **Notification**: both are pure Mantine re-exports with **no `variant` prop** — reframed their "Variants" sections as the real `color`-prop conventions (verified `color` exists in Mantine's type defs; Storybook just doesn't surface it).
- **NumberInput**: corrected "read-only not built-in" — Mantine supports `readOnly` natively.
- **Image**: added `fallbackSrc` guidance for broken-image handling.
- **MonthPickerInput** / **MultiSelect**: trimmed Storybook-internal `withLabelInfoProps` references.
- Verified in-repo that referenced components (`BackgroundImage`, `Code`, `CircleLoader`, `RingProgress`, `SemiCircleProgress`, `TagsInput`, `PillsInput`) all exist.

## Not included (belongs in later slices)

Global/shared parts of #4437 — aggregate build files (`llms-full-txt.ts`, `llms-txt.ts`, `skill.md`, `tsconfig.json`) and `src/content/*` changes.

## Follow-up for the API-reference owner (out of scope here)

- **Pill**: API reference lists `size` as `sm|md`, but it's a pure re-export accepting Mantine's `xs`–`xl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)