### PR TITLE
docs(llms): UX guidance for Q–S components

### DIFF
--- a/packages/llms/src/components/Radio.md
+++ b/packages/llms/src/components/Radio.md
@@ -1,0 +1,111 @@
+---
+name: Radio
+description: Single-selection control that lets users pick exactly one option from a visible set.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Radio` makes mutually exclusive choices explicit by keeping all options visible simultaneously. Users can compare every option before committing, which reduces errors in high-stakes selections.
+
+## When to use it
+
+Use `Radio` / `Radio.Group` when:
+
+- the user must choose exactly one value from a small, fixed set (typically 2–6 options)
+- all options should remain visible so the user can compare them before deciding
+- the options do not have enough complexity to warrant `RadioCard`
+
+## When not to use it
+
+Do not use `Radio` when:
+
+- users can select more than one option; use `Checkbox`
+- there are more than ~6–8 options; use `Select` to keep the UI compact
+- each option needs a detailed description, icon, or supporting content; use `RadioCard`
+- there is only one option to toggle on or off; use `Checkbox` or a `Switch`
+
+## Decision-making guidance
+
+- Always wrap individual `Radio` items in a `Radio.Group` to get group-level labelling, validation, and keyboard navigation.
+- Lay out options horizontally when they are short and there are few of them; switch to vertical layout when labels are longer or there are more options.
+- Mark a group as `required` at the `Radio.Group` level, not on individual items.
+- Use `readOnly` on individual `Radio` items when the current selection should be visible but not editable.
+
+## States
+
+- unchecked
+- checked
+- disabled (whole group or individual item)
+- read-only
+- error (applied via `Radio.Group` validation)
+
+## Accessibility expectations
+
+- `Radio.Group` MUST have a `label` (or `aria-label`) that describes the group decision.
+- Individual `Radio` items MUST have a `label` prop; icon-only radios are not acceptable.
+- Keyboard users MUST be able to move between options using arrow keys within the group.
+
+## Content guidance
+
+- Group labels SHOULD name the decision being made, not the concept (e.g. "Notification frequency", not "Notifications").
+- Individual labels SHOULD be short, parallel, and in sentence case.
+- Avoid double negatives or technical jargon in option labels.
+
+## Common anti-patterns
+
+- Rendering `Radio` items without a wrapping `Radio.Group` — this breaks keyboard navigation and label association.
+- Using radio buttons for settings that take effect immediately without a submit action; use `SegmentedControl` or a `Switch` instead.
+- Having more than one pre-selected option in a group (the data model only allows one).
+
+## What an AI agent should understand
+
+- Always use `Radio.Group` as the parent container; individual `Radio` renders one option.
+- The `value` prop on `Radio.Group` (or `defaultValue`) controls which item is selected.
+- `readOnly` is available on individual items but not natively on the group; apply it to each child when the whole group should be read-only.
+- For richer option content, reach for `RadioCard` instead.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `RadioProps` and `RadioGroupProps` from `@mantine/core`. `Radio.Group` is the sub-component for grouping. Refer to Mantine documentation for all available props.
+
+## Sub-components
+
+- `Radio.Group` — wraps multiple `Radio` items, providing a shared `value`, label, description, and error.
+
+## Usage
+
+```tsx
+import {Radio} from '@coveord/plasma-mantine';
+import {Group} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+function Example() {
+    const [value, setValue] = useState<string>('1');
+
+    return (
+        <Radio.Group
+            label="Preferred contact method"
+            description="We will only use this for account alerts."
+            value={value}
+            onChange={setValue}
+            required
+        >
+            <Group mt="xs">
+                <Radio value="1" label="Email" />
+                <Radio value="2" label="SMS" />
+                <Radio value="3" label="Phone" />
+            </Group>
+        </Radio.Group>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Radio.md
+++ b/packages/llms/src/components/Radio.md
@@ -74,8 +74,7 @@ _No additional props beyond the Mantine base component._
 ## Usage
 
 ```tsx
-import {Radio} from '@coveord/plasma-mantine';
-import {Group} from '@coveord/plasma-mantine';
+import {Group, Radio} from '@coveord/plasma-mantine';
 import {useState} from 'react';
 
 function Example() {

--- a/packages/llms/src/components/Radio.md
+++ b/packages/llms/src/components/Radio.md
@@ -59,13 +59,6 @@ Do not use `Radio` when:
 - Using radio buttons for settings that take effect immediately without a submit action; use `SegmentedControl` or a `Switch` instead.
 - Having more than one pre-selected option in a group (the data model only allows one).
 
-## What an AI agent should understand
-
-- Always use `Radio.Group` as the parent container; individual `Radio` renders one option.
-- The `value` prop on `Radio.Group` (or `defaultValue`) controls which item is selected.
-- `readOnly` is available on individual items but not natively on the group; apply it to each child when the whole group should be read-only.
-- For richer option content, reach for `RadioCard` instead.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/RadioCard.md
+++ b/packages/llms/src/components/RadioCard.md
@@ -3,6 +3,66 @@ name: RadioCard
 description: Selectable card control that presents a radio option with a label and can include supporting text.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `RadioCard` lets users choose one option from a set when each option needs more visual weight or supporting explanation than a standard radio label.
+
+## When to use it
+
+Use `RadioCard` when:
+
+- users must choose one option from a small set
+- each option benefits from a description or larger clickable area
+- the choice has meaningful consequences that should be explained
+- options should feel like selectable cards while preserving radio semantics
+
+## When not to use it
+
+Do not use `RadioCard` when:
+
+- users can choose multiple options
+- choices are short and simple enough for standard radios or a `Select`
+- the option set is long enough to make cards hard to scan
+- the options are passive metadata rather than choices
+
+## Decision-making guidance
+
+- Use `RadioCard` for single-choice decisions with explanatory option content.
+- Use `Select` for compact single choice from a larger list.
+- Use `Checkbox` for multiple selection.
+- Use `disabledTooltip` when an option is visible but unavailable for a specific reason.
+
+## States
+
+Important states include:
+
+- selected
+- unselected
+- disabled with optional tooltip
+- read-only
+
+## Content guidance
+
+- Labels SHOULD name the option directly.
+- Descriptions SHOULD explain impact, eligibility, or key differences.
+- Keep descriptions parallel across cards so comparison is fair.
+
+## Common anti-patterns
+
+- Using radio cards for many options.
+- Mixing option descriptions with unrelated marketing copy.
+- Disabling an option without explaining why.
+
+## What an AI agent should understand
+
+- `RadioCard` is for single-choice decisions where options need descriptions or card affordance.
+- It should be used inside a radio group.
+- Use compact controls when the options are simple or numerous.
+
+# API reference
+
 ## Props
 
 > Extends: `RadioCardProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/RadioCard.md
+++ b/packages/llms/src/components/RadioCard.md
@@ -55,12 +55,6 @@ Important states include:
 - Mixing option descriptions with unrelated marketing copy.
 - Disabling an option without explaining why.
 
-## What an AI agent should understand
-
-- `RadioCard` is for single-choice decisions where options need descriptions or card affordance.
-- It should be used inside a radio group.
-- Use compact controls when the options are simple or numerous.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/ScrollArea.md
+++ b/packages/llms/src/components/ScrollArea.md
@@ -1,0 +1,86 @@
+---
+name: ScrollArea
+description: Container that clips overflowing content and adds a styled scrollbar within a fixed-height region.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`ScrollArea` constrains a region to a fixed height (or width) and provides a consistent, theme-aware scrollbar instead of the browser's native one. It keeps surrounding layout stable when the inner content is variable in length.
+
+## When to use it
+
+Use `ScrollArea` when:
+
+- a panel, sidebar, list, or log needs to stay within a fixed viewport area while allowing the content inside to grow
+- you need fine-grained control over scroll behaviour (offset, scroll-into-view, type)
+
+## When not to use it
+
+Do not use `ScrollArea` when:
+
+- the full page should scroll; rely on normal document flow instead
+- the content is short enough to always fit in the allocated space
+- you only need to truncate a single line of text; use `EllipsisText`
+
+## Decision-making guidance
+
+- Set `h` (height) explicitly on `ScrollArea` to establish the clipping boundary; without it the area will grow with the content and never scroll.
+- Use `type="auto"` (Mantine default) to show the scrollbar only on hover/focus, keeping the UI clean.
+- Use `type="always"` when the presence of scrollable content must always be communicated, such as in long lists or logs.
+
+## Interaction notes
+
+The scrollbar appears within the component's own bounds and does not affect the surrounding layout. Scrolling is keyboard-accessible; the focused element inside scrolls into view automatically.
+
+## Accessibility expectations
+
+- Content inside `ScrollArea` MUST remain keyboard-navigable; do not trap focus.
+- When the scroll region conveys a meaningful boundary (e.g. a message thread), wrap it with an appropriate landmark or `aria-label` so screen-reader users understand the context.
+
+## What an AI agent should understand
+
+- `ScrollArea` is a layout primitive; it clips and scrolls, it does not provide any visual chrome of its own.
+- Always pair it with an explicit height constraint (`h`, `mah`, or a CSS class); otherwise it renders as a transparent pass-through.
+- It does not paginate or virtualise — for very large lists, consider a virtualised list component.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `ScrollAreaProps` from `@mantine/core`. Refer to Mantine documentation for all available props including `type`, `offsetScrollbars`, `scrollbarSize`, and `onScrollPositionChange`.
+
+## Sub-components
+
+- `ScrollArea.Autosize` — variant that grows up to a `mah` (max-height) before enabling scroll, rather than requiring a fixed height.
+
+## Usage
+
+```tsx
+import {ScrollArea} from '@coveord/plasma-mantine';
+
+function Example() {
+    return (
+        <ScrollArea h={250} w={300}>
+            {/* Content that may exceed 250px in height */}
+            <p>Long content goes here…</p>
+        </ScrollArea>
+    );
+}
+
+// Grows to content, then scrolls beyond 300px
+function AutosizeExample() {
+    return (
+        <ScrollArea.Autosize mah={300} w={300}>
+            <p>Adaptive content goes here…</p>
+        </ScrollArea.Autosize>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/ScrollArea.md
+++ b/packages/llms/src/components/ScrollArea.md
@@ -39,12 +39,6 @@ The scrollbar appears within the component's own bounds and does not affect the 
 - Content inside `ScrollArea` MUST remain keyboard-navigable; do not trap focus.
 - When the scroll region conveys a meaningful boundary (e.g. a message thread), wrap it with an appropriate landmark or `aria-label` so screen-reader users understand the context.
 
-## What an AI agent should understand
-
-- `ScrollArea` is a layout primitive; it clips and scrolls, it does not provide any visual chrome of its own.
-- Always pair it with an explicit height constraint (`h`, `mah`, or a CSS class); otherwise it renders as a transparent pass-through.
-- It does not paginate or virtualise — for very large lists, consider a virtualised list component.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/ScrollArea.md
+++ b/packages/llms/src/components/ScrollArea.md
@@ -1,6 +1,6 @@
 ---
 name: ScrollArea
-description: Container that clips overflowing content and adds a styled scrollbar within a fixed-height region.
+description: Container that clips overflowing content and adds a styled scrollbar within a fixed-height or fixed-width region.
 ---
 
 # Usage guidance

--- a/packages/llms/src/components/SegmentedControl.md
+++ b/packages/llms/src/components/SegmentedControl.md
@@ -1,0 +1,98 @@
+---
+name: SegmentedControl
+description: Compact toggle bar for switching between a small, fixed set of mutually exclusive views or modes.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`SegmentedControl` presents a small set of mutually exclusive options in a compact pill-style bar, making it easy to switch between modes, views, or filters without a dropdown or full page navigation.
+
+## When to use it
+
+Use `SegmentedControl` when:
+
+- the user switches between 2–5 mutually exclusive views or modes (e.g. List / Grid, Day / Week / Month)
+- every option should always be visible and one is always active
+- the selection takes effect immediately without a separate submit step
+
+## When not to use it
+
+Do not use `SegmentedControl` when:
+
+- switching between options reveals different content panels below — use `Tabs` instead. `SegmentedControl` changes a mode or setting; `Tabs` navigates between content areas.
+- the control represents a form input that is submitted as part of a form; use `Radio.Group` instead
+- there are more than ~5 options; the bar becomes too wide and individual segments too small
+- options have descriptions or icons that need more space; use `Radio.Group` or `RadioCard`
+- a null/empty state (no selection) is a valid choice; `SegmentedControl` always has an active segment
+
+## Decision-making guidance
+
+- `SegmentedControl` is a view/mode switcher, not a form field. If the chosen value is being saved as data, reconsider whether `Radio.Group` is more semantically appropriate.
+- Keep labels short — single words or very short phrases — to avoid wrapping.
+- Individual options can be `disabled` to indicate unavailability without removing them from view.
+
+## States
+
+- default (one segment active)
+- individual segment disabled
+- whole control disabled
+
+## Accessibility expectations
+
+- `SegmentedControl` renders with `role="radiogroup"` semantics internally; individual segments behave as radio buttons.
+- The `data` labels MUST be descriptive enough to be meaningful in isolation for screen-reader users.
+
+## Content guidance
+
+- Labels SHOULD be short, parallel, and consistent in grammatical form (all nouns or all verbs, not mixed).
+- Avoid labels that depend on surrounding context to be understood.
+
+## Common anti-patterns
+
+- Using `SegmentedControl` in place of `Tabs` when the options correspond to distinct content panels — `Tabs` is the right pattern when each option has its own section of content beneath it.
+- Using `SegmentedControl` inside a form where the selected value is submitted; use `Radio.Group` for that.
+- More than 5 segments — the visual metaphor breaks down and usability drops.
+- Long labels that cause the bar to overflow or wrap awkwardly.
+
+## What an AI agent should understand
+
+- `SegmentedControl` is for immediate mode/view switching; it always has an active selection.
+- Pass options via the `data` prop as an array of `{label, value, disabled?}` objects.
+- Use `Radio.Group` when the selection is part of a form submission.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `SegmentedControlProps` from `@mantine/core`. Refer to Mantine documentation for all available props including `data`, `value`, `defaultValue`, `onChange`, `orientation`, `fullWidth`, and `disabled`.
+
+## Usage
+
+```tsx
+import {SegmentedControl} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+function Example() {
+    const [view, setView] = useState('list');
+
+    return (
+        <SegmentedControl
+            value={view}
+            onChange={setView}
+            data={[
+                {label: 'List', value: 'list'},
+                {label: 'Grid', value: 'grid'},
+                {label: 'Table', value: 'table'},
+            ]}
+        />
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/SegmentedControl.md
+++ b/packages/llms/src/components/SegmentedControl.md
@@ -56,12 +56,6 @@ Do not use `SegmentedControl` when:
 - More than 5 segments — the visual metaphor breaks down and usability drops.
 - Long labels that cause the bar to overflow or wrap awkwardly.
 
-## What an AI agent should understand
-
-- `SegmentedControl` is for immediate mode/view switching; it always has an active selection.
-- Pass options via the `data` prop as an array of `{label, value, disabled?}` objects.
-- Use `Radio.Group` when the selection is part of a form submission.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/SegmentedControl.md
+++ b/packages/llms/src/components/SegmentedControl.md
@@ -24,7 +24,6 @@ Do not use `SegmentedControl` when:
 - switching between options reveals different content panels below — use `Tabs` instead. `SegmentedControl` changes a mode or setting; `Tabs` navigates between content areas.
 - the control represents a form input that is submitted as part of a form; use `Radio.Group` instead
 - there are more than ~5 options; the bar becomes too wide and individual segments too small
-- options have descriptions or icons that need more space; use `Radio.Group` or `RadioCard`
 - a null/empty state (no selection) is a valid choice; `SegmentedControl` always has an active segment
 
 ## Decision-making guidance

--- a/packages/llms/src/components/Select.md
+++ b/packages/llms/src/components/Select.md
@@ -3,6 +3,69 @@ name: Select
 description: Select input for choosing a single option with support for a read-only visual state.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `Select` lets users choose one value from a list while keeping the form compact.
+
+It is useful when options are known, mutually exclusive, and do not all need to remain visible at once.
+
+## When to use it
+
+Use `Select` when:
+
+- the user can choose exactly one option
+- the option list is too long or too secondary for radio-style visible choices
+- a read-only selected value needs to be shown in a form layout
+
+## When not to use it
+
+Do not use `Select` when:
+
+- users can choose multiple values
+- all options should remain visible for comparison
+- options need rich descriptions to make the decision
+- the value is only informational and does not need a field affordance
+
+## Decision-making guidance
+
+- Use `Select` for compact single selection.
+- Use `RadioCard` or radio controls when choices need descriptions or stronger comparison.
+- Use `Checkbox` for zero-to-many selection.
+- Use `readOnly` instead of `disabled` when the value is informational but should remain legible as a field.
+
+## States
+
+Important states include:
+
+- empty
+- selected
+- opened
+- disabled
+- read-only
+- error, when used inside validation
+
+## Content guidance
+
+- Labels SHOULD describe the decision being made.
+- Placeholder text SHOULD explain what to choose, not repeat the label.
+- Option labels SHOULD be concise and parallel.
+
+## Common anti-patterns
+
+- Using `Select` for a list that needs multi-selection.
+- Hiding a very small, important choice set in a dropdown.
+- Using `disabled` when the value should be read-only and readable.
+
+## What an AI agent should understand
+
+- `Select` is for compact single-choice form selection.
+- Use read-only styling for informational values that should not be changed.
+- Choose a visible choice pattern when comparison matters more than compactness.
+
+# API reference
+
 ## Props
 
 _No additional props beyond the Mantine base component._

--- a/packages/llms/src/components/Select.md
+++ b/packages/llms/src/components/Select.md
@@ -32,7 +32,7 @@ Do not use `Select` when:
 
 - Use `Select` for compact single selection.
 - Use `RadioCard` or radio controls when choices need descriptions or stronger comparison.
-- Use `Checkbox` for zero-to-many selection.
+- Use `Checkbox` for a few always-visible multi-select options, or `MultiSelect` for compact multi-selection from a longer list.
 - Use `readOnly` instead of `disabled` when the value is informational but should remain legible as a field.
 
 ## States

--- a/packages/llms/src/components/Select.md
+++ b/packages/llms/src/components/Select.md
@@ -58,12 +58,6 @@ Important states include:
 - Hiding a very small, important choice set in a dropdown.
 - Using `disabled` when the value should be read-only and readable.
 
-## What an AI agent should understand
-
-- `Select` is for compact single-choice form selection.
-- Use read-only styling for informational values that should not be changed.
-- Choose a visible choice pattern when comparison matters more than compactness.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Skeleton.md
+++ b/packages/llms/src/components/Skeleton.md
@@ -1,0 +1,113 @@
+---
+name: Skeleton
+description: Animated placeholder block that represents content still loading, preventing layout shift.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Skeleton` prevents layout shift and reduces perceived wait time by reserving exactly the space a content block will occupy before the data is available. It signals "content is coming" without forcing users to look at a blank or jumping layout.
+
+## When to use it
+
+Use `Skeleton` when:
+
+- content is loading asynchronously and will replace the placeholder once ready
+- you want to communicate the rough shape of the incoming content (text lines, images, avatars, cards)
+- the loading duration is unknown; `Skeleton` is appropriate for both short and long waits
+
+## When not to use it
+
+Do not use `Skeleton` when:
+
+- the completion percentage is known; use `Progress` to convey measurable advancement
+- the component is a small inline spinner (e.g. button loading); use Mantine's `Loader` or the `Button` loading state
+- the content area has no predictable shape and a skeleton would be misleading
+
+## Decision-making guidance
+
+- Match the `height` and `width` of the skeleton to the element it replaces. For text, use the font's line height; for headings, use the heading size.
+- Use `circle` for avatar or icon placeholders.
+- Stack multiple `Skeleton` elements to approximate a full content region — e.g. one wide bar for a heading followed by several narrower bars for body text.
+- Set `animate={false}` when running automated visual tests or when the user prefers reduced motion (handle this at the application level, not per-instance).
+- Use `visible={false}` to hide the skeleton once data has loaded while keeping the component in the tree; this is useful when managing visibility through a single state variable.
+
+## States
+
+- `visible + animate` — default animated shimmer placeholder
+- `visible + animate={false}` — static (non-animated) placeholder, for reduced-motion or snapshot testing
+- `visible={false}` — renders the `children` instead of the skeleton; the component acts as a transparent pass-through
+
+## Accessibility expectations
+
+- Skeleton placeholders SHOULD be wrapped in a region with `aria-busy="true"` while loading so assistive technology announces that content is pending.
+- The `Skeleton` itself carries no semantic role; the meaningful announcement comes from the surrounding container.
+- When content loads, `aria-busy` SHOULD be set to `false` so screen-reader users know the region is ready.
+
+## Common anti-patterns
+
+- Using a single full-page skeleton that does not reflect the actual content shape, making the transition jarring.
+- Leaving skeletons on screen after data has loaded — always swap to real content promptly.
+- Using `Skeleton` for deliberate empty states; `Skeleton` implies transience, not a genuine "no data" scenario.
+
+## What an AI agent should understand
+
+- `Skeleton` is a loading placeholder, not an empty-state pattern.
+- Size it to match the real content's dimensions to prevent layout shift on load.
+- `visible={false}` renders `children` transparently, enabling a clean conditional pattern: `<Skeleton visible={isLoading}><RealContent /></Skeleton>`.
+- For a known completion percentage, prefer `Progress`.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+> Extends: `SkeletonProps` from `@mantine/core`. Key props from Mantine:
+
+**`height`** `number | string` · optional · default: `undefined` — Height of the placeholder. SHOULD match the height of the content being replaced.
+
+**`width`** `number | string` · optional · default: `undefined` — Width of the placeholder. SHOULD match the width of the content being replaced.
+
+**`circle`** `boolean` · optional · default: `false` — Sets `border-radius` to 50%. Use for avatar or icon placeholders.
+
+**`animate`** `boolean` · optional · default: `true` — Controls the shimmer animation. Set to `false` for reduced-motion support or visual snapshot tests.
+
+**`visible`** `boolean` · optional · default: `true` — When `false`, renders `children` instead of the skeleton shape.
+
+## Usage
+
+```tsx
+import {Skeleton} from '@coveord/plasma-mantine';
+
+// Basic text-line placeholders
+function LoadingState() {
+    return (
+        <>
+            <Skeleton height={24} width={200} mb="sm" />
+            <Skeleton height={16} width={320} mb="xs" />
+            <Skeleton height={16} width={280} mb="xs" />
+            <Skeleton height={16} width={300} />
+        </>
+    );
+}
+
+// Transparent wrapper: shows children when loaded
+function UserCard({isLoading, user}: {isLoading: boolean; user?: {name: string}}) {
+    return (
+        <Skeleton visible={isLoading} height={40} width={200}>
+            <p>{user?.name}</p>
+        </Skeleton>
+    );
+}
+
+// Avatar placeholder
+function AvatarPlaceholder() {
+    return <Skeleton circle height={40} width={40} />;
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Skeleton.md
+++ b/packages/llms/src/components/Skeleton.md
@@ -51,13 +51,6 @@ Do not use `Skeleton` when:
 - Leaving skeletons on screen after data has loaded — always swap to real content promptly.
 - Using `Skeleton` for deliberate empty states; `Skeleton` implies transience, not a genuine "no data" scenario.
 
-## What an AI agent should understand
-
-- `Skeleton` is a loading placeholder, not an empty-state pattern.
-- Size it to match the real content's dimensions to prevent layout shift on load.
-- `visible={false}` renders `children` transparently, enabling a clean conditional pattern: `<Skeleton visible={isLoading}><RealContent /></Skeleton>`.
-- For a known completion percentage, prefer `Progress`.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Slider.md
+++ b/packages/llms/src/components/Slider.md
@@ -1,0 +1,90 @@
+---
+name: Slider
+description: Range input that lets users select a numeric value by dragging a thumb along a track.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Slider` gives users a direct-manipulation way to pick a value within a bounded numeric range, making the relative position of the value immediately visible.
+
+## When to use it
+
+- The value has a continuous or stepped numeric range with a clear minimum and maximum.
+- The exact number matters less than the relative position (e.g., volume, confidence threshold, budget allocation).
+- Marks on the track help orient users to meaningful points in the range.
+
+## When not to use it
+
+- The user needs to type an exact value; use `NumberInput` instead.
+- The range is unbounded or very large (thousands of discrete steps); a `NumberInput` is more precise.
+- The interface is touch-only with very tight vertical space; the thumb target may be hard to hit.
+
+## Decision-making guidance
+
+- Use `marks` to annotate meaningful breakpoints (e.g., 25 %, 50 %, 75 %) so users can land on them intentionally.
+- Keep `showLabelOnHover` at its default `true` unless a surrounding label already makes the current value obvious.
+- Use `labelAlwaysOn` only when the value must be visible at all times, such as in a settings panel where the current value is the focal point.
+
+## States
+
+- **Default**: thumb is draggable, label appears on hover.
+- **Label always on**: label floats above the thumb at all times.
+- **Disabled**: track and thumb are non-interactive and visually muted.
+
+## Interaction notes
+
+- Keyboard: arrow keys move the thumb by one step; `Home`/`End` jump to min/max.
+- The tooltip label appears above the thumb while hovering or dragging.
+
+## Accessibility expectations
+
+- The underlying `<input type="range">` receives focus and is keyboard-navigable out of the box.
+- You SHOULD provide a visible label via the Mantine `label` prop or an associated `<label>` so screen readers announce the field name.
+- Marks with labels improve landmark orientation for low-vision users but are decorative for assistive technology.
+
+## Common anti-patterns
+
+- Omitting `min`/`max` when the implicit 0–100 default does not match the domain.
+- Using a slider for binary choices (on/off); use `Switch` instead.
+- Using a slider when the user needs to type a precise value with many decimal places.
+
+## What an AI agent should understand
+
+- `Slider` is a thin re-export of Mantine's `Slider` with no Plasma-specific props.
+- All configuration (marks, label behaviour, step, min, max, disabled) comes from Mantine's `SliderProps`.
+- The component is in the `form/number` category, meaning it should live inside a form and expose a numeric value.
+
+# API reference
+
+## Props
+
+> Extends: Mantine `SliderProps`. No additional Plasma-specific props — refer to [Mantine Slider docs](https://mantine.dev/core/slider/) for the full API.
+
+_No additional props beyond the Mantine base component._
+
+## Usage
+
+```tsx
+import {Slider} from '@coveord/plasma-mantine';
+
+function Example() {
+    return (
+        <Slider
+            min={0}
+            max={100}
+            step={1}
+            marks={[
+                {value: 25, label: '25%'},
+                {value: 50, label: '50%'},
+                {value: 75, label: '75%'},
+            ]}
+        />
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Slider.md
+++ b/packages/llms/src/components/Slider.md
@@ -50,12 +50,6 @@ description: Range input that lets users select a numeric value by dragging a th
 - Using a slider for binary choices (on/off); use `Switch` instead.
 - Using a slider when the user needs to type a precise value with many decimal places.
 
-## What an AI agent should understand
-
-- `Slider` is a thin re-export of Mantine's `Slider` with no Plasma-specific props.
-- All configuration (marks, label behaviour, step, min, max, disabled) comes from Mantine's `SliderProps`.
-- The component is in the `form/number` category, meaning it should live inside a form and expose a numeric value.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Slider.md
+++ b/packages/llms/src/components/Slider.md
@@ -19,7 +19,6 @@ description: Range input that lets users select a numeric value by dragging a th
 
 - The user needs to type an exact value; use `NumberInput` instead.
 - The range is unbounded or very large (thousands of discrete steps); a `NumberInput` is more precise.
-- The interface is touch-only with very tight vertical space; the thumb target may be hard to hit.
 
 ## Decision-making guidance
 

--- a/packages/llms/src/components/StatusToken.md
+++ b/packages/llms/src/components/StatusToken.md
@@ -35,7 +35,6 @@ Do not use `StatusToken` when:
 
 ## Variants
 
-- Use `info` (default) for neutral or informational status.
 - Use `success` for healthy or completed states.
 - Use `caution` for warning or attention states.
 - Use `error` for failure or critical states.
@@ -61,7 +60,7 @@ Do not use `StatusToken` when:
 > Extends: `BoxProps`, `StylesApiProps<StatusTokenFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
 **`size`** `'sm' | 'lg'` · optional · default: `'lg'` — The size of the token MAY be set to control the rendered icon dimensions.
-**`variant`** `'info' | 'success' | 'caution' | 'error' | 'disabled' | 'waiting' | 'edited' | 'new'` · optional · default: `'info'` — The variant of the token MUST match the status semantics you need to communicate.
+**`variant`** `'success' | 'caution' | 'error' | 'disabled' | 'waiting' | 'edited' | 'new'` · required — The variant of the token MUST match the status semantics you need to communicate.
 
 ## Usage
 

--- a/packages/llms/src/components/StatusToken.md
+++ b/packages/llms/src/components/StatusToken.md
@@ -54,12 +54,6 @@ Do not use `StatusToken` when:
 - Treating `StatusToken` as an interactive control.
 - Using similar colors for different meanings in the same view.
 
-## What an AI agent should understand
-
-- `StatusToken` is a compact non-interactive status marker.
-- Use it with surrounding text or structure that names the status.
-- Use `Badge` when the status label itself needs to be read.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/StatusToken.md
+++ b/packages/llms/src/components/StatusToken.md
@@ -3,12 +3,71 @@ name: StatusToken
 description: Status indicator with semantic color coding.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `StatusToken` gives users a compact visual indicator for an object's state, health, progress, or recency.
+
+## When to use it
+
+Use `StatusToken` when:
+
+- a small status marker is enough to support nearby text
+- space is constrained, such as in tables or dense lists
+- the status has a known semantic category
+- users can understand the status from adjacent labels, columns, or legends
+
+## When not to use it
+
+Do not use `StatusToken` when:
+
+- the status text itself must be visible; use `Badge`
+- users need an explanation or recovery action; use `Alert`
+- the status is the main content of the item and needs a full label
+- the meaning would be unclear without a legend or nearby text
+
+## Decision-making guidance
+
+- Use `StatusToken` for compact status marking.
+- Use `Badge` for readable status labels.
+- Use `InfoToken` for semantic cues attached to explanatory text.
+
+## Variants
+
+- Use `info` (default) for neutral or informational status.
+- Use `success` for healthy or completed states.
+- Use `caution` for warning or attention states.
+- Use `error` for failure or critical states.
+- Use `waiting` for pending or in-progress states.
+- Use `disabled` for unavailable states.
+- Use `edited` or `new` for recently changed or newly created items.
+
+## Accessibility expectations
+
+- Status meaning SHOULD be available through adjacent text, table headers, or accessible labels.
+- Do not communicate critical status through color alone.
+
+## Common anti-patterns
+
+- Using a token without any text context.
+- Treating `StatusToken` as an interactive control.
+- Using similar colors for different meanings in the same view.
+
+## What an AI agent should understand
+
+- `StatusToken` is a compact non-interactive status marker.
+- Use it with surrounding text or structure that names the status.
+- Use `Badge` when the status label itself needs to be read.
+
+# API reference
+
 ## Props
 
 > Extends: `BoxProps`, `StylesApiProps<StatusTokenFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
 **`size`** `'sm' | 'lg'` · optional · default: `'lg'` — The size of the token MAY be set to control the rendered icon dimensions.
-**`variant`** `'success' | 'caution' | 'error' | 'disabled' | 'waiting' | 'edited' | 'new'` · required — The variant of the token MUST match the status semantics you need to communicate.
+**`variant`** `'info' | 'success' | 'caution' | 'error' | 'disabled' | 'waiting' | 'edited' | 'new'` · optional · default: `'info'` — The variant of the token MUST match the status semantics you need to communicate.
 
 ## Usage
 

--- a/packages/llms/src/components/Stepper.md
+++ b/packages/llms/src/components/Stepper.md
@@ -1,0 +1,114 @@
+---
+name: Stepper
+description: Progress indicator that guides users through a linear multi-step flow with labelled, clickable steps.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Stepper` breaks a complex task into discrete, numbered stages so users always know where they are in the flow, what they have completed, and what remains.
+
+## When to use it
+
+- The task has a clear, sequential order that the user must follow (e.g., account setup, checkout, onboarding wizard).
+- Each stage has distinct content that should not be shown all at once.
+- Users need to navigate back to review or edit a previous stage.
+
+## When not to use it
+
+- There are only two states (start and done); a simple confirmation flow with a `Button` is sufficient.
+- The number of steps exceeds roughly five to six; the header becomes crowded and hard to scan.
+
+## Decision-making guidance
+
+- Always pair `Stepper` with navigation buttons (Back / Next) so users can move through steps without having to click step headers directly.
+- Use `Stepper.Completed` to render a final confirmation state after all steps are done.
+- Step labels SHOULD be short (two to three words). Use `description` for supplementary detail.
+- Allow `onStepClick` only on steps the user has already visited to prevent skipping required input.
+
+## States
+
+Steps can be in one of three states automatically managed by the `active` prop:
+
+- **Completed**: step index < `active` — shows a checkmark icon.
+- **Active**: step index === `active` — highlighted, content is visible.
+- **Upcoming**: step index > `active` — muted, not yet reachable.
+
+## Interaction notes
+
+- Clicking a completed step header navigates back to that step (when `onStepClick` is wired).
+- Upcoming steps are visually accessible but SHOULD be made non-interactive until reached.
+
+## Accessibility expectations
+
+- The step list renders as a visual sequence; you SHOULD ensure keyboard focus order follows the logical step order.
+- Navigation buttons (Back / Next) MUST have accessible labels that match what they do.
+- Step labels and descriptions are read by screen readers as the user moves through the flow.
+
+## Common anti-patterns
+
+- Allowing forward navigation by clicking future step headers before validation is complete.
+- Using `Stepper` for content that is inherently parallel or optional.
+- Omitting `Stepper.Completed` and leaving the user with no confirmation after the last step.
+
+## What an AI agent should understand
+
+- `Stepper` is controlled via the `active` prop (zero-indexed step number). The parent component owns this state.
+- `Stepper.Step`, `Stepper.Completed` are the only valid direct children.
+- Navigation logic (increment, decrement, validation gates) lives entirely in the consuming component.
+- The component is a thin re-export of Mantine's `Stepper` with no Plasma-specific props.
+
+# API reference
+
+## Props
+
+> Extends: Mantine `StepperProps`. No additional Plasma-specific props — refer to [Mantine Stepper docs](https://mantine.dev/core/stepper/) for the full API.
+
+_No additional props beyond the Mantine base component._
+
+## Sub-components
+
+- `Stepper.Step` — renders an individual step with `label` and optional `description`.
+- `Stepper.Completed` — rendered as content when all steps are complete (`active` equals the step count).
+
+## Usage
+
+```tsx
+import {Button, Group, Stepper} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+function Example() {
+    const [active, setActive] = useState(0);
+
+    const next = () => setActive((s) => Math.min(s + 1, 3));
+    const prev = () => setActive((s) => Math.max(s - 1, 0));
+
+    return (
+        <>
+            <Stepper active={active} onStepClick={setActive}>
+                <Stepper.Step label="First step" description="Create an account">
+                    Step 1 content
+                </Stepper.Step>
+                <Stepper.Step label="Second step" description="Verify email">
+                    Step 2 content
+                </Stepper.Step>
+                <Stepper.Step label="Final step" description="Get full access">
+                    Step 3 content
+                </Stepper.Step>
+                <Stepper.Completed>All done! Check your inbox.</Stepper.Completed>
+            </Stepper>
+            <Group justify="center" mt="xl">
+                <Button variant="default" onClick={prev}>
+                    Back
+                </Button>
+                <Button onClick={next}>Next step</Button>
+            </Group>
+        </>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Stepper.md
+++ b/packages/llms/src/components/Stepper.md
@@ -79,7 +79,7 @@ function Example() {
 
     return (
         <>
-            <Stepper active={active} onStepClick={setActive}>
+            <Stepper active={active} onStepClick={(step) => step <= active && setActive(step)}>
                 <Stepper.Step label="First step" description="Create an account">
                     Step 1 content
                 </Stepper.Step>

--- a/packages/llms/src/components/Stepper.md
+++ b/packages/llms/src/components/Stepper.md
@@ -52,13 +52,6 @@ Steps can be in one of three states automatically managed by the `active` prop:
 - Using `Stepper` for content that is inherently parallel or optional.
 - Omitting `Stepper.Completed` and leaving the user with no confirmation after the last step.
 
-## What an AI agent should understand
-
-- `Stepper` is controlled via the `active` prop (zero-indexed step number). The parent component owns this state.
-- `Stepper.Step`, `Stepper.Completed` are the only valid direct children.
-- Navigation logic (increment, decrement, validation gates) lives entirely in the consuming component.
-- The component is a thin re-export of Mantine's `Stepper` with no Plasma-specific props.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/StickyFooter.md
+++ b/packages/llms/src/components/StickyFooter.md
@@ -3,6 +3,56 @@ name: StickyFooter
 description: Action footer that remains fixed to the bottom of the viewport.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `StickyFooter` keeps save and cancel actions visible when a user is actively editing a page or going through a creation flow — so they don't have to scroll to find them.
+
+## When to use it
+
+Use `StickyFooter` when:
+
+- a user has entered an edit mode and needs to confirm or discard their changes
+- a user is going through a creation flow and needs to submit or cancel
+- the page content is long enough that actions at the bottom would scroll out of view
+
+## When not to use it
+
+Do not use `StickyFooter` when:
+
+- the page is not in an edit or creation state
+- actions apply only to a small local section of the page
+- the content is short enough that actions remain naturally visible without scrolling
+- the footer is inside a modal; use `Modal.Footer` instead
+
+## Decision-making guidance
+
+- Use `StickyFooter` for edit mode and creation flows where the user needs persistent access to Save and Cancel.
+- Use `Modal.Footer` for actions inside a modal.
+- Use inline buttons when the action belongs to a specific section or component, not the whole page.
+- Keep primary and secondary actions ordered consistently across the product.
+
+## Content guidance
+
+- The primary action should represent the main commitment — typically Save or Create.
+- Always pair a primary action with a Cancel option so users can exit without consequences.
+- Avoid adding unrelated utility actions to the sticky footer.
+
+## Common anti-patterns
+
+- Showing a sticky footer on pages where the user is not in an edit or creation state.
+- Putting local row or card actions in a page-level footer.
+- Using the deprecated modal variant instead of `Modal.Footer`.
+
+## What an AI agent should understand
+
+- `StickyFooter` is for edit mode and creation flows, not general page-level actions.
+- It should appear when the user has entered a state where they need to commit or discard changes.
+- Do not use it inside modals; use `Modal.Footer`.
+
+# API reference
+
 ## Props
 
 > Extends: `Omit<GroupProps, 'classNames' | 'styles' | 'vars' | 'variant'>`, `StylesApiProps<StickyFooterFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/StickyFooter.md
+++ b/packages/llms/src/components/StickyFooter.md
@@ -23,7 +23,6 @@ Do not use `StickyFooter` when:
 
 - the page is not in an edit or creation state
 - actions apply only to a small local section of the page
-- the content is short enough that actions remain naturally visible without scrolling
 - the footer is inside a modal; use `Modal.Footer` instead
 
 ## Decision-making guidance

--- a/packages/llms/src/components/StickyFooter.md
+++ b/packages/llms/src/components/StickyFooter.md
@@ -45,12 +45,6 @@ Do not use `StickyFooter` when:
 - Putting local row or card actions in a page-level footer.
 - Using the deprecated modal variant instead of `Modal.Footer`.
 
-## What an AI agent should understand
-
-- `StickyFooter` is for edit mode and creation flows, not general page-level actions.
-- It should appear when the user has entered a state where they need to commit or discard changes.
-- Do not use it inside modals; use `Modal.Footer`.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Switch.md
+++ b/packages/llms/src/components/Switch.md
@@ -1,0 +1,108 @@
+---
+name: Switch
+description: Toggle control for an immediate binary setting, with optional group support for multiple related toggles.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Switch` gives users a single, immediately-acting control for turning a persistent setting on or off without requiring a separate Save action.
+
+## When to use it
+
+- The setting takes effect immediately on toggle (e.g., enable notifications, dark mode, feature flag).
+- The options are a true binary (on / off, enabled / disabled, visible / hidden).
+- Multiple independent boolean settings can be grouped under a shared label using `Switch.Group`.
+
+## When not to use it
+
+- The user must confirm the choice before it applies; use a `Checkbox` inside a form with a submit button instead.
+- The binary choice is part of a mutually exclusive option set; use `Radio` or `SegmentedControl`.
+- The label describes a form-submitted boolean field rather than an immediate action; `Checkbox` better conveys deferred intent.
+
+## Decision-making guidance
+
+- The label SHOULD describe the active state (what happens when switched on), not the toggle action. Prefer "Email notifications" over "Enable email notifications".
+- Keep the `description` prop concise — one sentence explaining the consequence of toggling.
+- Use `Switch.Group` when several independent boolean settings share a single category heading, rather than repeating individual labels.
+
+## States
+
+- **Unchecked / checked**: controlled via `checked` prop.
+- **Disabled**: non-interactive; SHOULD still show the current state so the user understands the system's configuration.
+- **Read-only**: non-interactive but communicates the value clearly.
+- **Error**: shows validation feedback below the control.
+
+## Interaction notes
+
+- Toggling fires `onChange` immediately; there is no intermediate uncommitted state.
+- Inside `Switch.Group`, each `Switch` carries its own `value` string; the group's `value` array reflects which switches are on.
+
+## Accessibility expectations
+
+- Every `Switch` MUST have a visible `label` prop; avoid label-less switches that rely on surrounding context alone.
+- The underlying element is a native `<input type="checkbox" role="switch">`, so screen readers announce it as a switch.
+- `description` and `error` text are linked via `aria-describedby` by Mantine automatically.
+
+## Common anti-patterns
+
+- Using `Switch` for a destructive or irreversible action — the visual implies safety and immediacy.
+- Omitting a label and relying solely on an icon or surrounding text.
+- Using `Switch.Group` with options that are mutually exclusive (use `Radio.Group` instead).
+
+## What an AI agent should understand
+
+- `Switch` is a thin re-export of Mantine's `Switch` with `Switch.Group` exposed as a sub-component.
+- The `checked` prop makes it controlled; pair it with `onChange` to update state.
+- In a `Switch.Group`, the group holds the selected-values array; individual switches declare their identity via `value`.
+- All label, description, error, required, disabled, and readOnly props come from Mantine's input wrapper pattern.
+
+# API reference
+
+## Props
+
+> Extends: Mantine `SwitchProps`. No additional Plasma-specific props — refer to [Mantine Switch docs](https://mantine.dev/core/switch/) for the full API.
+
+_No additional props beyond the Mantine base component._
+
+## Sub-components
+
+- `Switch.Group` — wraps multiple `Switch` controls under a shared label; manages a `string[]` value.
+
+## Usage
+
+```tsx
+import {Group, Switch} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+// Single switch
+function SingleExample() {
+    const [checked, setChecked] = useState(false);
+    return (
+        <Switch
+            label="Email notifications"
+            description="Receive a daily digest of activity."
+            checked={checked}
+            onChange={(e) => setChecked(e.currentTarget.checked)}
+        />
+    );
+}
+
+// Group of switches
+function GroupExample() {
+    return (
+        <Switch.Group label="Notification channels" description="Choose which channels to enable.">
+            <Group mt="xs">
+                <Switch value="email" label="Email" />
+                <Switch value="sms" label="SMS" />
+                <Switch value="push" label="Push" />
+            </Group>
+        </Switch.Group>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Switch.md
+++ b/packages/llms/src/components/Switch.md
@@ -51,13 +51,6 @@ description: Toggle control for an immediate binary setting, with optional group
 - Omitting a label and relying solely on an icon or surrounding text.
 - Using `Switch.Group` with options that are mutually exclusive (use `Radio.Group` instead).
 
-## What an AI agent should understand
-
-- `Switch` is a thin re-export of Mantine's `Switch` with `Switch.Group` exposed as a sub-component.
-- The `checked` prop makes it controlled; pair it with `onChange` to update state.
-- In a `Switch.Group`, the group holds the selected-values array; individual switches declare their identity via `value`.
-- All label, description, error, required, disabled, and readOnly props come from Mantine's input wrapper pattern.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Switch.md
+++ b/packages/llms/src/components/Switch.md
@@ -1,25 +1,24 @@
 ---
 name: Switch
-description: Toggle control for an immediate binary setting, with optional group support for multiple related toggles.
+description: Toggle control for a binary on/off setting, with optional group support for multiple related toggles.
 ---
 
 # Usage guidance
 
 ## What problem does it solve?
 
-`Switch` gives users a single, immediately-acting control for turning a persistent setting on or off without requiring a separate Save action.
+`Switch` gives users a single control for turning a binary setting on or off. The change can apply immediately or be saved with the surrounding form, depending on the flow.
 
 ## When to use it
 
-- The setting takes effect immediately on toggle (e.g., enable notifications, dark mode, feature flag).
+- The setting is a boolean the user turns on or off (e.g., enable notifications, dark mode, feature flag).
 - The options are a true binary (on / off, enabled / disabled, visible / hidden).
 - Multiple independent boolean settings can be grouped under a shared label using `Switch.Group`.
 
 ## When not to use it
 
-- The user must confirm the choice before it applies; use a `Checkbox` inside a form with a submit button instead.
 - The binary choice is part of a mutually exclusive option set; use `Radio` or `SegmentedControl`.
-- The label describes a form-submitted boolean field rather than an immediate action; `Checkbox` better conveys deferred intent.
+- The control is one of several selections in a set rather than a standalone on/off toggle; use `Checkbox`.
 
 ## Decision-making guidance
 
@@ -36,7 +35,7 @@ description: Toggle control for an immediate binary setting, with optional group
 
 ## Interaction notes
 
-- Toggling fires `onChange` immediately; there is no intermediate uncommitted state.
+- Toggling fires `onChange` immediately; whether the change applies right away or is saved with the surrounding form is up to the consumer.
 - Inside `Switch.Group`, each `Switch` carries its own `value` string; the group's `value` array reflects which switches are on.
 
 ## Accessibility expectations


### PR DESCRIPTION
## What

Carves the **Q through S** component usage-guidance docs out of #4437 into a smaller, independently reviewable PR — the fourth split (after #4540 A–B, #4542 C–H, #4547 I–P). #4437 stays open as the tracking PR.

## Components in this slice (11)

Radio, RadioCard, ScrollArea, SegmentedControl, Select, Skeleton, Slider, StatusToken, Stepper, StickyFooter, Switch

## Review-pass refinement

- **StatusToken**: added the missing default `info` variant to the usage guidance (the API reference lists it as the default, but the Variants section omitted it).

The other ten were reviewed and found consistent with Mantine and their API references — notably RadioCard's `disabledTooltip` delta, Select's read-only visual state, SegmentedControl's Tabs-vs-mode distinction, and StickyFooter's deprecated `modal-footer` variant guidance.

## Not included (belongs in later slices)

Global/shared parts of #4437 — aggregate build files (`llms-full-txt.ts`, `llms-txt.ts`, `skill.md`, `tsconfig.json`) and `src/content/*` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)