### PR TITLE
docs(llms): UX guidance for T–Z components

### DIFF
--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -16,7 +16,7 @@ It is useful for operational views where users need to inspect many records and 
 
 Use `Table` when:
 
-- data is naturally structured as rows and columns
+- each record has many fields which the user may need to consult
 - users need to compare values across records
 - filtering, pagination, row actions, selection, or expandable row content are needed
 - the view needs table-specific empty, loading, footer, or pagination patterns

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -27,6 +27,7 @@ Do not use `Table` when:
 - the data shows a progression over time, use chart components instead
 - users are editing a repeatable form list; use `Collection`
 - there are only a few simple values that can be shown as text or cards
+- the number of entries is static and pre-determined — a full table is overkill when all items are already known
 - the layout would require hiding the most important information in many columns
 
 ## Decision-making guidance
@@ -50,11 +51,7 @@ Important states include:
 
 ## Interaction notes
 
-- `store` MUST come from `useTable`.
-- `getRowId` SHOULD be provided when records have stable identifiers.
-- `getRowActions` SHOULD return only actions relevant to the selected row or rows.
 - Expandable row content SHOULD add detail without replacing the row's core scannable information.
-- Additional root nodes MAY be provided when related overlays should not clear row selection.
 
 ## Content guidance
 
@@ -143,7 +140,7 @@ export function Example() {
     const store = useTable<TData>({
         initialState: {
             totalEntries: data.length,
-            pagination: {pageIndex: 0, pageSize: 10},
+            pagination: {page: 0, perPage: 10},
         },
     });
 

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -3,6 +3,83 @@ name: Table
 description: Table for displaying tabular data with optional filtering, pagination, row actions, and layout switching.
 ---
 
+> **Note:** This component is currently under active redesign. Usage guidance will be updated once the initiative concludes. In the meantime, use this as a general reference only.
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `Table` lets users scan, compare, filter, paginate, select, and act on structured data in rows and columns.
+
+It is useful for operational views where users need to inspect many records and perform actions on one or more of them.
+
+## When to use it
+
+Use `Table` when:
+
+- data is naturally structured as rows and columns
+- users need to compare values across records
+- filtering, pagination, row actions, selection, or expandable row content are needed
+- the view needs table-specific empty, loading, footer, or pagination patterns
+
+## When not to use it
+
+Do not use `Table` when:
+
+- the content is primarily visual or card-like
+- users are editing a repeatable form list; use `Collection`
+- there are only a few simple values that can be shown as text or cards
+- the layout would require hiding the most important information in many columns
+
+## Decision-making guidance
+
+- Use `Table` for data display and operational record management.
+- Use `Collection` for editable repeated form items.
+- Use `Facet` or table filter sub-components when users need to narrow data.
+- Use row actions for item-specific commands and header/footer actions for table-level commands.
+
+## States
+
+Important states include:
+
+- initially loading with `data={null}`
+- loaded with rows
+- empty or no matching data
+- selected rows
+- expanded rows
+- paginated data
+- filtered data
+
+## Interaction notes
+
+- `store` MUST come from `useTable`.
+- `getRowId` SHOULD be provided when records have stable identifiers.
+- `getRowActions` SHOULD return only actions relevant to the selected row or rows.
+- Expandable row content SHOULD add detail without replacing the row's core scannable information.
+- Additional root nodes MAY be provided when related overlays should not clear row selection.
+
+## Content guidance
+
+- Column headers SHOULD be short and describe the data clearly.
+- Empty states SHOULD explain whether there is no data or no matching data.
+- Row actions SHOULD use clear verbs and destructive labels when appropriate.
+- Filter labels SHOULD match the terms users use to understand the data.
+
+## Common anti-patterns
+
+- Using a table for layout instead of data.
+- Putting editable repeated form fields in a table when `Collection` is the intended pattern.
+- Omitting stable row IDs for selectable or reorderable data.
+- Hiding key record identity in expandable content instead of visible columns.
+
+## What an AI agent should understand
+
+- `Table` is for structured data display and operational record actions.
+- Use it with `useTable`, stable columns, and row IDs when available.
+- Use `Collection` for editable repeated form inputs and simpler layouts for non-tabular content.
+
+# API reference
+
 ## Props
 
 > Extends: `BoxProps & StylesApiProps<PlasmaTableFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
@@ -74,7 +151,7 @@ export function Example() {
     const store = useTable<TData>({
         initialState: {
             totalEntries: data.length,
-            pagination: {page: 0, perPage: 10},
+            pagination: {pageIndex: 0, pageSize: 10},
         },
     });
 

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -25,7 +25,7 @@ Use `Table` when:
 
 Do not use `Table` when:
 
-- the content is primarily visual or card-like
+- the data shows a progression over time, use chart components instead
 - users are editing a repeatable form list; use `Collection`
 - there are only a few simple values that can be shown as text or cards
 - the layout would require hiding the most important information in many columns

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -3,7 +3,6 @@ name: Table
 description: Table for displaying tabular data with optional filtering, pagination, row actions, and layout switching.
 ---
 
-> **Note:** This component is currently under active redesign. Usage guidance will be updated once the initiative concludes. In the meantime, use this as a general reference only.
 
 # Usage guidance
 

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -3,7 +3,6 @@ name: Table
 description: Table for displaying tabular data with optional filtering, pagination, row actions, and layout switching.
 ---
 
-
 # Usage guidance
 
 ## What problem does it solve?
@@ -70,12 +69,6 @@ Important states include:
 - Putting editable repeated form fields in a table when `Collection` is the intended pattern.
 - Omitting stable row IDs for selectable or reorderable data.
 - Hiding key record identity in expandable content instead of visible columns.
-
-## What an AI agent should understand
-
-- `Table` is for structured data display and operational record actions.
-- Use it with `useTable`, stable columns, and row IDs when available.
-- Use `Collection` for editable repeated form inputs and simpler layouts for non-tabular content.
 
 # API reference
 

--- a/packages/llms/src/components/Tabs.md
+++ b/packages/llms/src/components/Tabs.md
@@ -1,0 +1,98 @@
+---
+name: Tabs
+description: Navigation pattern that organises related content into labelled panels, showing one at a time.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Tabs` divides a page section into peer content categories so users can switch between them without leaving the page or losing scroll position in the rest of the layout.
+
+## When to use it
+
+- Content belongs to parallel, peer categories of roughly equal importance (e.g., Overview / Settings / History).
+- All panels are part of the same conceptual entity (e.g., a resource's detail view).
+- The number of tabs is between two and roughly six.
+
+## When not to use it
+
+- The categories are sequential steps; use `Stepper`.
+- Only one panel exists; the tab bar adds noise without value.
+- The panels represent separate destinations or pages; use router-level navigation (`Link`, `NavLink`) instead.
+- More than six or seven tabs are needed; consider a secondary sidebar navigation or a `Select`-driven panel switcher.
+
+## Decision-making guidance
+
+- Prefer `defaultValue` (uncontrolled) unless the active tab must be driven by external state (URL hash, router).
+- Use `orientation="vertical"` when the tab list and panels sit side by side, typically in a two-column layout.
+- Tab labels MUST be short (one to three words). Do not use icons without accompanying text unless there is very limited space.
+
+## Variants
+
+- **Horizontal** (default): tab list appears above the panels.
+- **Vertical**: tab list appears to the left of the panels; set `orientation="vertical"`.
+
+## Interaction notes
+
+- Keyboard: arrow keys move focus between tabs; `Enter` or `Space` activates the focused tab.
+- Tabs activate on focus by default in Mantine; set `activateTabWithKeyboard` to `false` if panels have expensive loading cost.
+
+## Accessibility expectations
+
+- The component renders a `role="tablist"` with `role="tab"` items and associated `role="tabpanel"` elements, satisfying the ARIA Tabs pattern automatically.
+- Tab labels MUST be unique within the tab list.
+- Panels MUST not be empty; if a panel has no content yet, show a loading indicator or a placeholder message.
+
+## Common anti-patterns
+
+- Using tabs for navigation that changes the URL without wiring the `value` to the router, causing the active tab to reset on refresh.
+- Mixing tab-level and page-level navigation in the same `Tabs.List`.
+- Nesting tab sets inside tab panels (deeply nested tabs are disorienting).
+
+## What an AI agent should understand
+
+- `Tabs` is a thin re-export of Mantine's `Tabs` with sub-components `Tabs.List`, `Tabs.Tab`, and `Tabs.Panel` exposed.
+- The `value` on each `Tabs.Tab` and `Tabs.Panel` MUST match; mismatches silently hide panels.
+- Use `defaultValue` for uncontrolled usage and `value` + `onChange` for controlled.
+- No Plasma-specific props are added; the full Mantine `TabsProps` API applies.
+
+# API reference
+
+## Props
+
+> Extends: Mantine `TabsProps`. No additional Plasma-specific props — refer to [Mantine Tabs docs](https://mantine.dev/core/tabs/) for the full API.
+
+_No additional props beyond the Mantine base component._
+
+## Sub-components
+
+- `Tabs.List` — container for `Tabs.Tab` elements; renders as `role="tablist"`.
+- `Tabs.Tab` — individual tab button; requires a unique `value` prop.
+- `Tabs.Panel` — content area shown when its `value` matches the active tab.
+
+## Usage
+
+```tsx
+import {Tabs} from '@coveord/plasma-mantine';
+
+function Example() {
+    return (
+        <Tabs defaultValue="overview">
+            <Tabs.List>
+                <Tabs.Tab value="overview">Overview</Tabs.Tab>
+                <Tabs.Tab value="settings">Settings</Tabs.Tab>
+                <Tabs.Tab value="history">History</Tabs.Tab>
+            </Tabs.List>
+
+            <Tabs.Panel value="overview">Overview content</Tabs.Panel>
+            <Tabs.Panel value="settings">Settings content</Tabs.Panel>
+            <Tabs.Panel value="history">History content</Tabs.Panel>
+        </Tabs>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Tabs.md
+++ b/packages/llms/src/components/Tabs.md
@@ -20,7 +20,7 @@ description: Navigation pattern that organises related content into labelled pan
 - The categories are sequential steps; use `Stepper`.
 - Only one panel exists; the tab bar adds noise without value.
 - The panels represent separate destinations or pages; use router-level navigation (`Link`, `NavLink`) instead.
-- More than six or seven tabs are needed; consider a secondary sidebar navigation or a `Select`-driven panel switcher.
+- More than six or seven tabs are needed; consider a secondary sidebar navigation.
 
 ## Decision-making guidance
 
@@ -36,7 +36,6 @@ description: Navigation pattern that organises related content into labelled pan
 ## Interaction notes
 
 - Keyboard: arrow keys move focus between tabs; `Enter` or `Space` activates the focused tab.
-- Tabs activate on focus by default in Mantine; set `activateTabWithKeyboard` to `false` if panels have expensive loading cost.
 
 ## Accessibility expectations
 
@@ -48,7 +47,7 @@ description: Navigation pattern that organises related content into labelled pan
 
 - Using tabs for navigation that changes the URL without wiring the `value` to the router, causing the active tab to reset on refresh.
 - Mixing tab-level and page-level navigation in the same `Tabs.List`.
-- Nesting tab sets inside tab panels (deeply nested tabs are disorienting).
+- Nesting tab sets of the same orientation inside one another — disorienting; if nesting is unavoidable, use a different orientation for the inner set (e.g. vertical inside horizontal).
 
 # API reference
 

--- a/packages/llms/src/components/Tabs.md
+++ b/packages/llms/src/components/Tabs.md
@@ -50,13 +50,6 @@ description: Navigation pattern that organises related content into labelled pan
 - Mixing tab-level and page-level navigation in the same `Tabs.List`.
 - Nesting tab sets inside tab panels (deeply nested tabs are disorienting).
 
-## What an AI agent should understand
-
-- `Tabs` is a thin re-export of Mantine's `Tabs` with sub-components `Tabs.List`, `Tabs.Tab`, and `Tabs.Panel` exposed.
-- The `value` on each `Tabs.Tab` and `Tabs.Panel` MUST match; mismatches silently hide panels.
-- Use `defaultValue` for uncontrolled usage and `value` + `onChange` for controlled.
-- No Plasma-specific props are added; the full Mantine `TabsProps` API applies.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/TextInput.md
+++ b/packages/llms/src/components/TextInput.md
@@ -28,6 +28,7 @@ description: Single-line text field for free-form string input, with support for
 - Use `description` for concise help text that is always visible, not a tooltip.
 - Use `error` to surface validation messages inline; do not surface errors only in a toast or banner.
 - Mark fields `required` when empty submission would fail; this adds the visual required indicator and sets `aria-required`.
+- Set the HTML `type` prop to match the expected value (`email`, `tel`, `url`, `number`, `password`, …) so browsers show the right keyboard and apply native validation.
 
 ## States
 

--- a/packages/llms/src/components/TextInput.md
+++ b/packages/llms/src/components/TextInput.md
@@ -45,9 +45,7 @@ description: Single-line text field for free-form string input, with support for
 
 ## Accessibility expectations
 
-- The `label` prop renders a `<label>` associated with the `<input>` via `id`/`htmlFor`. You MUST always pair a visible label with the field.
-- `description` and `error` are linked to the input via `aria-describedby` automatically by Mantine.
-- When using only a `placeholder` and no `label`, add `aria-label` manually so screen readers announce the field's purpose.
+- The `label` prop renders a `<label>` associated with the `<input>` via `id`/`htmlFor`. Prefer a visible label; if you omit it, provide an accessible name with `aria-label` or `aria-labelledby`.
 - `required` sets `aria-required="true"` on the native input.
 
 ## Content guidance

--- a/packages/llms/src/components/TextInput.md
+++ b/packages/llms/src/components/TextInput.md
@@ -1,0 +1,117 @@
+---
+name: TextInput
+description: Single-line text field for free-form string input, with support for icons, labels, descriptions, and validation.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`TextInput` is the standard control for collecting a single line of free-form text — names, email addresses, search queries, URLs, and similar short strings.
+
+## When to use it
+
+- The user needs to enter a short, free-form string value.
+- The field belongs to a form and may require validation feedback.
+
+## When not to use it
+
+- The value spans multiple lines; use `Textarea` instead.
+- The value is numeric; use `NumberInput` to get proper type handling and increment/decrement controls.
+- The value must come from a fixed list; use `Select` or `Autocomplete`.
+- The value is a date or time; use `DatePickerInput` or `TimePicker`.
+
+## Decision-making guidance
+
+- Always provide a `label` unless the field's purpose is self-evident from context (e.g., a standalone search bar with a placeholder and a search icon).
+- Use `placeholder` as a hint about format or example value, not as a replacement for `label`.
+- Use `description` for concise help text that is always visible, not a tooltip.
+- Use `error` to surface validation messages inline; do not surface errors only in a toast or banner.
+- Mark fields `required` when empty submission would fail; this adds the visual required indicator and sets `aria-required`.
+
+## States
+
+- **Default**: editable, no value.
+- **With value**: user has typed or the field is pre-filled.
+- **Disabled**: non-interactive; typically used when a field's value is determined by another control.
+- **Read-only**: non-editable but the value can be selected and copied.
+- **Error**: red border and inline error message below the field.
+- **Required**: label marked with a required indicator.
+
+## Interaction notes
+
+- `leftSection` and `rightSection` accept any `ReactNode`; icons or small interactive elements (e.g., a clear button) work well here.
+- Section elements do not receive focus automatically; interactive elements inside sections MUST be individually focusable.
+
+## Accessibility expectations
+
+- The `label` prop renders a `<label>` associated with the `<input>` via `id`/`htmlFor`. You MUST always pair a visible label with the field.
+- `description` and `error` are linked to the input via `aria-describedby` automatically by Mantine.
+- When using only a `placeholder` and no `label`, add `aria-label` manually so screen readers announce the field's purpose.
+- `required` sets `aria-required="true"` on the native input.
+
+## Content guidance
+
+- Labels SHOULD be nouns or short noun phrases ("Email address", "First name").
+- Placeholders SHOULD show example input ("e.g. john@example.com") or format hints ("DD/MM/YYYY").
+- Error messages MUST be specific and actionable ("Email address must contain @" not "Invalid input").
+
+## Common anti-patterns
+
+- Using `placeholder` as the only label — placeholders disappear on input and are not read by all screen readers.
+- Putting interactive controls in `leftSection`/`rightSection` without making them keyboard-accessible.
+- Showing validation errors before the user has interacted with the field.
+
+## What an AI agent should understand
+
+- `TextInput` is a thin re-export of Mantine's `TextInput` with no Plasma-specific props.
+- All label, description, error, required, disabled, readOnly, placeholder, leftSection, and rightSection props come from Mantine.
+- Use `leftSection` for decorative icons (search, lock) and `rightSection` for actionable elements (clear, copy) or format hints.
+
+# API reference
+
+## Props
+
+> Extends: Mantine `TextInputProps`. No additional Plasma-specific props — refer to [Mantine TextInput docs](https://mantine.dev/core/text-input/) for the full API.
+
+_No additional props beyond the Mantine base component._
+
+## Usage
+
+```tsx
+import {TextInput} from '@coveord/plasma-mantine';
+import {IconSearch, IconX} from '@coveord/plasma-react-icons';
+
+// Standard form field
+function FormExample() {
+    return (
+        <TextInput
+            label="Email address"
+            description="We'll send confirmations here."
+            placeholder="e.g. john@example.com"
+            required
+        />
+    );
+}
+
+// Search field with icons
+function SearchExample() {
+    return (
+        <TextInput
+            aria-label="Search"
+            placeholder="Search…"
+            leftSection={<IconSearch size={16} />}
+            rightSection={<IconX size={16} />}
+        />
+    );
+}
+
+// Field with validation error
+function ErrorExample() {
+    return <TextInput label="Username" error="Username must be at least 3 characters." value="ab" />;
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/TextInput.md
+++ b/packages/llms/src/components/TextInput.md
@@ -60,12 +60,6 @@ description: Single-line text field for free-form string input, with support for
 - Putting interactive controls in `leftSection`/`rightSection` without making them keyboard-accessible.
 - Showing validation errors before the user has interacted with the field.
 
-## What an AI agent should understand
-
-- `TextInput` is a thin re-export of Mantine's `TextInput` with no Plasma-specific props.
-- All label, description, error, required, disabled, readOnly, placeholder, leftSection, and rightSection props come from Mantine.
-- Use `leftSection` for decorative icons (search, lock) and `rightSection` for actionable elements (clear, copy) or format hints.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Textarea.md
+++ b/packages/llms/src/components/Textarea.md
@@ -37,10 +37,7 @@ description: Multi-line text input for collecting longer-form free-text content 
 
 ## Interaction notes
 
-- When `autosize` is enabled, the textarea grows vertically as the user types, up to `maxRows` (if set), then scrolls internally.
-- When `resize` is `'both'` (the default), users can drag the resize handle in the bottom-right corner to manually adjust the field's dimensions.
-- Pressing Tab inside a `Textarea` inserts a tab character by default in most browsers; warn users in `description` if Tab focus-navigation is important in the surrounding form.
-
+- Pressing Tab inside a `Textarea` moves focus to the next control by default; if users must enter tab-indented content, use `CodeEditor` or implement custom key handling.
 ## Accessibility expectations
 
 - The field MUST have a visible label via the `label` prop or an external element connected with `aria-labelledby`.

--- a/packages/llms/src/components/Textarea.md
+++ b/packages/llms/src/components/Textarea.md
@@ -32,7 +32,7 @@ description: Multi-line text input for collecting longer-form free-text content 
 
 - **Default** — editable, showing `placeholder` when empty.
 - **Disabled** — visually dimmed; interaction is blocked. Use when the field is not applicable in the current context.
-- **Read-only** — displays the value without allowing edits. Use when the value must be visible but not changeable (e.g. a generated summary).
+- **Read-only** — displays the value without allowing edits. Use when the value must be visible but not changeable (e.g. the user lacks permissions to edit).
 - **Error** — the `error` prop renders a validation message below the field in red and marks the border accordingly.
 
 ## Interaction notes

--- a/packages/llms/src/components/Textarea.md
+++ b/packages/llms/src/components/Textarea.md
@@ -38,6 +38,7 @@ description: Multi-line text input for collecting longer-form free-text content 
 ## Interaction notes
 
 - Pressing Tab inside a `Textarea` moves focus to the next control by default; if users must enter tab-indented content, use `CodeEditor` or implement custom key handling.
+
 ## Accessibility expectations
 
 - The field MUST have a visible label via the `label` prop or an external element connected with `aria-labelledby`.
@@ -56,13 +57,6 @@ description: Multi-line text input for collecting longer-form free-text content 
 - Using `Textarea` for a single-line value such as a name or email address — this overstates the expected length and wastes vertical space.
 - Setting `autosize` and a fixed `rows` at the same time — `rows` is ignored when `autosize` is active; use `minRows` instead.
 - Omitting `label` and relying on `placeholder` alone — placeholder disappears when the user starts typing and is not a substitute for an accessible label.
-
-## What an AI agent should understand
-
-- `Textarea` is a thin Plasma re-export of `@mantine/core` `Textarea`. All Mantine props are available.
-- Plasma adds only a `displayName` for tooling; there is no additional logic.
-- `autosize` relies on `@mantine/hooks` `useResizeObserver` internally; no extra dependency is needed.
-- `resize` controls the CSS `resize` property on the underlying `<textarea>` element.
 
 # API reference
 

--- a/packages/llms/src/components/Textarea.md
+++ b/packages/llms/src/components/Textarea.md
@@ -1,0 +1,138 @@
+---
+name: Textarea
+description: Multi-line text input for collecting longer-form free-text content such as descriptions, comments, or notes.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Textarea` gives users a resizable multi-line input area for free-text that does not fit in a single-line `TextInput`, preventing content from being cut off and making the intended length of a response clear.
+
+## When to use it
+
+- Collecting descriptions, comments, notes, or any prose where the expected length exceeds one line.
+- Providing a feedback or message body field where users need to see several lines at once.
+- Situations where the rough length of a response is meaningful to communicate (e.g. a bio field or a search query explanation).
+
+## When not to use it
+
+- When a single line is sufficient — use `TextInput` instead; `Textarea` introduces extra visual weight and resize affordances that are unnecessary for short values.
+- When the content is structured (e.g. a list of values, tags) — use `Chip`, `Collection`, or `MultiSelect`.
+- When rich text formatting is required — use `CodeEditor` or an external rich-text editor, not `Textarea`.
+
+## Decision-making guidance
+
+- Default `rows` is sufficient for most use cases; only increase it when the expected content is substantially longer (e.g. a legal disclaimer or a full message body).
+- Enable `autosize` when the amount of text is unpredictable and you want the field to grow with the user's input rather than scroll internally; pair with `minRows` and `maxRows` to keep the layout bounded.
+- Set `resize="none"` in constrained layouts (e.g. inside cards or narrow panels) where user resizing would break the surrounding design.
+- `clearable` is not a prop on `Textarea`; to allow clearing, provide a separate clear button or use a controlled value.
+
+## States
+
+- **Default** — editable, showing `placeholder` when empty.
+- **Disabled** — visually dimmed; interaction is blocked. Use when the field is not applicable in the current context.
+- **Read-only** — displays the value without allowing edits. Use when the value must be visible but not changeable (e.g. a generated summary).
+- **Error** — the `error` prop renders a validation message below the field in red and marks the border accordingly.
+
+## Interaction notes
+
+- When `autosize` is enabled, the textarea grows vertically as the user types, up to `maxRows` (if set), then scrolls internally.
+- When `resize` is `'both'` (the default), users can drag the resize handle in the bottom-right corner to manually adjust the field's dimensions.
+- Pressing Tab inside a `Textarea` inserts a tab character by default in most browsers; warn users in `description` if Tab focus-navigation is important in the surrounding form.
+
+## Accessibility expectations
+
+- The field MUST have a visible label via the `label` prop or an external element connected with `aria-labelledby`.
+- Use `description` to communicate format hints or character limits; this renders in an accessible position below the label.
+- Use `error` for validation feedback rather than custom adjacent text, so the message is correctly associated with the input.
+- `required` adds a visual indicator and the `aria-required` attribute.
+
+## Content guidance
+
+- Labels SHOULD use noun phrases ("Description", "Additional notes") rather than imperative verbs ("Enter your description").
+- Placeholder text SHOULD give an example or a short hint, not repeat the label.
+- If there is a character limit, communicate it in `description` (e.g. "Max 500 characters") and enforce it with `maxLength`.
+
+## Common anti-patterns
+
+- Using `Textarea` for a single-line value such as a name or email address — this overstates the expected length and wastes vertical space.
+- Setting `autosize` and a fixed `rows` at the same time — `rows` is ignored when `autosize` is active; use `minRows` instead.
+- Omitting `label` and relying on `placeholder` alone — placeholder disappears when the user starts typing and is not a substitute for an accessible label.
+
+## What an AI agent should understand
+
+- `Textarea` is a thin Plasma re-export of `@mantine/core` `Textarea`. All Mantine props are available.
+- Plasma adds only a `displayName` for tooling; there is no additional logic.
+- `autosize` relies on `@mantine/hooks` `useResizeObserver` internally; no extra dependency is needed.
+- `resize` controls the CSS `resize` property on the underlying `<textarea>` element.
+
+# API reference
+
+## Props
+
+> Extends: `TextareaProps` from `@mantine/core`. No additional Plasma-specific props.
+
+Key props relevant to Plasma usage patterns:
+
+**`autosize`** `boolean` · optional · default: `false` — Grows the textarea vertically to fit its content instead of scrolling internally.
+
+**`minRows`** `number` · optional — Minimum number of visible rows when `autosize` is enabled.
+
+**`maxRows`** `number` · optional — Maximum number of visible rows when `autosize` is enabled; content scrolls beyond this.
+
+**`rows`** `number` · optional — Fixed number of visible text lines (ignored when `autosize` is true).
+
+**`resize`** `'none' | 'both' | 'horizontal' | 'vertical'` · optional · default: `'both'` — Controls the CSS resize handle.
+
+**`placeholder`** `string` · optional — Hint text shown when the field is empty.
+
+**`label`** `ReactNode` · optional — Visible field label rendered above the input.
+
+**`description`** `ReactNode` · optional — Helper text rendered below the label.
+
+**`error`** `ReactNode` · optional — Validation message rendered below the input in an error state.
+
+**`required`** `boolean` · optional · default: `false` — Marks the field as required with a visual indicator and `aria-required`.
+
+**`disabled`** `boolean` · optional · default: `false` — Prevents interaction and dims the field visually.
+
+**`readOnly`** `boolean` · optional · default: `false` — Displays the value without allowing edits.
+
+## Usage
+
+```tsx
+import {Textarea} from '@coveord/plasma-mantine';
+
+// Fixed-size textarea
+function FeedbackField() {
+    return (
+        <Textarea
+            label="Feedback"
+            description="Tell us what you think (max 500 characters)"
+            placeholder="Your feedback here…"
+            rows={5}
+            maxLength={500}
+            required
+        />
+    );
+}
+
+// Auto-growing textarea
+function NotesField() {
+    return (
+        <Textarea
+            label="Notes"
+            placeholder="Add any additional context…"
+            autosize
+            minRows={3}
+            maxRows={10}
+            resize="none"
+        />
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/TimePicker.md
+++ b/packages/llms/src/components/TimePicker.md
@@ -1,0 +1,104 @@
+---
+name: TimePicker
+description: Form input for selecting a specific time of day in 12-hour or 24-hour format, with optional seconds.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`TimePicker` provides a structured, keyboard-friendly way to enter a time value, removing the ambiguity and format errors that come from a plain text field (e.g. "2pm", "14:00", "2:00 PM") while keeping the interaction lightweight compared to a full clock widget.
+
+## When to use it
+
+- Collecting a specific time from the user (e.g. meeting start time, scheduled job time, alarm time).
+- Forms where a `DatePickerInput` captures the date portion separately and `TimePicker` captures the time portion.
+- Cases where the user likely knows the exact time they want to enter rather than needing to browse a visual representation.
+
+## When not to use it
+
+- When the user needs to select a time range — compose two `TimePicker` instances (start/end) and validate that start precedes end.
+- When precision below the minute level is never required in practice — hide seconds to reduce cognitive load.
+- When a relative time expression ("in 2 hours", "tomorrow morning") is more useful than an absolute time — use a `Select` with predefined options instead.
+
+## Decision-making guidance
+
+- Choose `format="12h"` (the default) for consumer-facing products and locales that use 12-hour time; choose `format="24h"` for technical, scientific, or international contexts.
+- Enable `withSeconds` only when seconds are actually meaningful to the use case (e.g. scheduling a precise cron job, recording a timestamp) — the additional segment adds cognitive overhead for everyday time selection.
+- Enable `clearable` whenever the time field is optional so users can remove a previously set value without reloading.
+
+## States
+
+- **Default** — editable, showing `placeholder` when empty.
+- **Disabled** — interaction blocked; use when the time field is not applicable given other form state.
+- **Read-only** — value visible but not editable.
+- **Error** — validation message shown below the field.
+
+## Interaction notes
+
+- The input uses segmented editing: clicking or tabbing into the field places the cursor in the hours, minutes, AM/PM, or seconds segment. Typing a number advances through segments automatically.
+- Arrow keys increment or decrement the value of the focused segment.
+- The clear button (when `clearable` is enabled) appears inside the input whenever a value is present.
+
+## Accessibility expectations
+
+- The field MUST have a visible label via `label` or an external element connected with `aria-labelledby`.
+- `description` SHOULD be used to communicate the expected time format if it is not obvious from context.
+- `error` SHOULD be used for validation messages so they are announced by screen readers in context.
+
+## Content guidance
+
+- Labels SHOULD be noun phrases ("Start time", "Scheduled time") rather than instructions ("Choose a start time").
+- If both date and time are collected, place `DatePickerInput` before `TimePicker` and group them under a common fieldset label to make the relationship clear.
+
+## What an AI agent should understand
+
+- `TimePicker` is a thin Plasma re-export of `@mantine/dates` `TimePicker`. All Mantine props are available.
+- Plasma adds only a `displayName` for tooling; there is no additional logic.
+- `TimePicker` outputs a time string, not a `Date` object; coordinate with the date input separately when a full datetime value is needed.
+
+# API reference
+
+## Props
+
+> Extends: `TimePickerProps` from `@mantine/dates`. No additional Plasma-specific props.
+
+Key props relevant to Plasma usage patterns:
+
+**`format`** `'12h' | '24h'` · optional · default: `'12h'` — Whether to show a 12-hour clock with AM/PM or a 24-hour clock.
+
+**`withSeconds`** `boolean` · optional · default: `false` — Adds a seconds segment to the picker.
+
+**`clearable`** `boolean` · optional · default: `false` — Renders a clear button inside the input when a value is present.
+
+**`label`** `ReactNode` · optional — Visible field label rendered above the input.
+
+**`description`** `ReactNode` · optional — Helper text rendered below the label.
+
+**`error`** `ReactNode` · optional — Validation message rendered below the input in an error state.
+
+**`required`** `boolean` · optional · default: `false` — Marks the field as required with a visual indicator and `aria-required`.
+
+**`disabled`** `boolean` · optional · default: `false` — Prevents interaction and dims the field.
+
+**`readOnly`** `boolean` · optional · default: `false` — Displays the value without allowing edits.
+
+## Usage
+
+```tsx
+import {TimePicker} from '@coveord/plasma-mantine';
+
+// 12-hour time picker (default)
+function MeetingTimeField() {
+    return <TimePicker label="Meeting time" description="Select the start time" format="12h" clearable />;
+}
+
+// 24-hour time picker with seconds
+function ScheduledJobField() {
+    return <TimePicker label="Scheduled time" format="24h" withSeconds required />;
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/TimePicker.md
+++ b/packages/llms/src/components/TimePicker.md
@@ -51,12 +51,6 @@ description: Form input for selecting a specific time of day in 12-hour or 24-ho
 - Labels SHOULD be noun phrases ("Start time", "Scheduled time") rather than instructions ("Choose a start time").
 - If both date and time are collected, place `DatePickerInput` before `TimePicker` and group them under a common fieldset label to make the relationship clear.
 
-## What an AI agent should understand
-
-- `TimePicker` is a thin Plasma re-export of `@mantine/dates` `TimePicker`. All Mantine props are available.
-- Plasma adds only a `displayName` for tooling; there is no additional logic.
-- `TimePicker` outputs a time string, not a `Date` object; coordinate with the date input separately when a full datetime value is needed.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Tooltip.md
+++ b/packages/llms/src/components/Tooltip.md
@@ -1,0 +1,126 @@
+---
+name: Tooltip
+description: Non-interactive popover that reveals supplementary text when a user hovers or focuses its trigger element.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Tooltip` surfaces contextual information on demand without cluttering the UI with persistent explanatory text, keeping layouts clean while still making details available to users who need them.
+
+## When to use it
+
+- Labelling icon-only buttons where a text label would take too much space (e.g. toolbar actions, `ActionIcon` controls).
+- Providing additional contextual information about a UI element without cluttering the interface.
+- Providing a short elaboration on a truncated label or an abbreviation.
+- Showing a full value when an `EllipsisText` component has truncated content.
+
+## When not to use it
+
+- When the information is critical for the user to complete their task — critical guidance MUST be visible at all times; use `description` on the form field or inline text instead.
+- When the content requires interaction (links, buttons, form elements) — a tooltip dismisses on mouse-out, making interactive content inside it inaccessible. Use a `Popover` instead.
+- When the content is longer than two short sentences — tooltips are for brief labels, not paragraphs. Use a `Popover` or a drawer for richer content.
+- On mobile touch targets where hover is unavailable — consider `Popover` with a tap trigger.
+
+## Decision-making guidance
+
+- Keep `label` to a single short phrase or sentence; if you need more space, reconsider whether a `Popover` or adjacent text is more appropriate.
+- Use `position` to avoid clipping against viewport edges or overlapping nearby UI; prefer `"top"` by default and override as needed.
+- Do not use `opened={true}` as a permanent substitute for visible text in production; it is a development/debugging affordance only.
+
+## Interaction notes
+
+- The tooltip appears on hover (pointer devices) and on keyboard focus of the trigger element.
+- It disappears when the pointer leaves the trigger or focus moves away.
+- The tooltip is non-interactive: users cannot move the pointer into the tooltip itself to click a link. Use `Popover` if any interaction inside the floating content is needed.
+- Setting `opened` to `true` pins the tooltip visible regardless of hover state, useful during development to inspect styling.
+
+## Accessibility expectations
+
+- The trigger element MUST be focusable (e.g. a `button`, an `a`, or an element with `tabIndex={0}`) so keyboard users can access the tooltip.
+- Mantine's `Tooltip` uses `aria-describedby` to associate the tooltip text with the trigger, ensuring screen readers announce it on focus.
+- Do not place the only label for an unlabelled icon entirely inside a tooltip for screen readers — the trigger element itself MUST have an accessible name (e.g. `aria-label`) independently of the tooltip.
+- Custom trigger components MUST use `forwardRef` to pass the ref required for tooltip positioning.
+
+## Common anti-patterns
+
+- Wrapping a non-focusable element (e.g. a plain `<div>` or `<span>`) without adding `tabIndex={0}` — keyboard users will never see the tooltip.
+- Putting actionable content (links, buttons) inside `label` — the tooltip hides before users can interact with it.
+- Using a tooltip to show required information that only some users will discover — if everyone needs it, show it inline.
+- Nesting a tooltip inside another tooltip — this creates confusing layering; redesign the interaction.
+
+## What an AI agent should understand
+
+- `Tooltip` is a thin Plasma re-export of `@mantine/core` `Tooltip`. All Mantine props are available.
+- Plasma adds only a `displayName` for tooling; there is no additional logic.
+- The trigger MUST be a single child element that can receive a `ref`. Wrap functional components that do not forward refs with `forwardRef`.
+- `Tooltip.Floating` (a Mantine sub-component) is available for tooltips that follow the cursor; this is an advanced use case.
+
+# API reference
+
+## Props
+
+> Extends: `TooltipProps` from `@mantine/core`. No additional Plasma-specific props.
+
+Key props relevant to Plasma usage patterns:
+
+**`label`** `ReactNode` · required — The content rendered inside the tooltip bubble.
+
+**`position`** `'top' | 'bottom' | 'left' | 'right' | ...` · optional — Preferred placement of the tooltip relative to the trigger. Mantine supports full compass positions and their `-start`/`-end` variants.
+
+**`opened`** `boolean` · optional — When `true`, forces the tooltip to stay visible regardless of hover state. Useful for debugging; avoid in production.
+
+**`children`** `ReactElement` · required — The trigger element. MUST be a single ref-forwarding element.
+
+## Sub-components
+
+**`Tooltip.Floating`** — A variant that positions the tooltip at the cursor location rather than relative to the trigger element. Use for large interactive surfaces (e.g. a chart canvas) where a fixed anchor is not meaningful.
+
+## Usage
+
+```tsx
+import {Tooltip, ActionIcon} from '@coveord/plasma-mantine';
+
+// Labelling an icon-only button
+function DeleteButton() {
+    return (
+        <Tooltip label="Delete item">
+            <ActionIcon aria-label="Delete item" color="red">
+                <DeleteIcon />
+            </ActionIcon>
+        </Tooltip>
+    );
+}
+
+// Showing a keyboard shortcut hint
+function SaveButton() {
+    return (
+        <Tooltip label="Save (Ctrl+S)" position="bottom">
+            <button>Save</button>
+        </Tooltip>
+    );
+}
+
+// Custom component as trigger — must use forwardRef
+import {forwardRef} from 'react';
+
+const TriggerCard = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>((props, ref) => (
+    <div ref={ref} {...props} tabIndex={0}>
+        Hover me
+    </div>
+));
+TriggerCard.displayName = 'TriggerCard';
+
+function TooltipOnCustomElement() {
+    return (
+        <Tooltip label="More information about this card">
+            <TriggerCard />
+        </Tooltip>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Tooltip.md
+++ b/packages/llms/src/components/Tooltip.md
@@ -25,7 +25,7 @@ description: Non-interactive popover that reveals supplementary text when a user
 ## Decision-making guidance
 
 - Keep `label` to a single short phrase or sentence; if you need more space, reconsider whether a `Popover` or adjacent text is more appropriate.
-- Use `position` to avoid clipping against viewport edges or overlapping nearby UI; prefer `"top"` by default and override as needed.
+- Let the tooltip manage its own position by default; only set `position` to fix a specific placement issue (clipping against viewport edges or overlapping nearby UI).
 - Do not use `opened={true}` as a permanent substitute for visible text in production; it is a development/debugging affordance only.
 
 ## Interaction notes
@@ -73,6 +73,7 @@ Key props relevant to Plasma usage patterns:
 
 ```tsx
 import {Tooltip, ActionIcon} from '@coveord/plasma-mantine';
+import {IconTrash} from '@coveord/plasma-react-icons';
 
 // Labelling an icon-only button
 function DeleteButton() {

--- a/packages/llms/src/components/Tooltip.md
+++ b/packages/llms/src/components/Tooltip.md
@@ -86,7 +86,7 @@ function DeleteButton() {
     return (
         <Tooltip label="Delete item">
             <ActionIcon aria-label="Delete item" color="red">
-                <DeleteIcon />
+                <IconTrash />
             </ActionIcon>
         </Tooltip>
     );

--- a/packages/llms/src/components/Tooltip.md
+++ b/packages/llms/src/components/Tooltip.md
@@ -49,13 +49,6 @@ description: Non-interactive popover that reveals supplementary text when a user
 - Using a tooltip to show required information that only some users will discover — if everyone needs it, show it inline.
 - Nesting a tooltip inside another tooltip — this creates confusing layering; redesign the interaction.
 
-## What an AI agent should understand
-
-- `Tooltip` is a thin Plasma re-export of `@mantine/core` `Tooltip`. All Mantine props are available.
-- Plasma adds only a `displayName` for tooling; there is no additional logic.
-- The trigger MUST be a single child element that can receive a `ref`. Wrap functional components that do not forward refs with `forwardRef`.
-- `Tooltip.Floating` (a Mantine sub-component) is available for tooltips that follow the cursor; this is an advanced use case.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Tooltip.md
+++ b/packages/llms/src/components/Tooltip.md
@@ -21,7 +21,6 @@ description: Non-interactive popover that reveals supplementary text when a user
 - When the information is critical for the user to complete their task — critical guidance MUST be visible at all times; use `description` on the form field or inline text instead.
 - When the content requires interaction (links, buttons, form elements) — a tooltip dismisses on mouse-out, making interactive content inside it inaccessible. Use a `Popover` instead.
 - When the content is longer than two short sentences — tooltips are for brief labels, not paragraphs. Use a `Popover` or a drawer for richer content.
-- On mobile touch targets where hover is unavailable — consider `Popover` with a tap trigger.
 
 ## Decision-making guidance
 

--- a/packages/llms/src/components/YearPickerInput.md
+++ b/packages/llms/src/components/YearPickerInput.md
@@ -1,0 +1,115 @@
+---
+name: YearPickerInput
+description: Form input that opens a year-grid popover for selecting one year, multiple years, or a year range.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`YearPickerInput` lets users pick a year (or span of years) from a structured grid rather than typing a number, preventing out-of-range entries and reducing the cognitive overhead of remembering valid year values in a given context.
+
+## When to use it
+
+- Filtering or scoping data to a fiscal or calendar year (e.g. "Show results from 2023").
+- Collecting a graduation year, a founding year, or any other single year value.
+- Defining a year range for a report or comparison (e.g. "Compare 2020–2024") — use `type="range"`.
+
+## When not to use it
+
+- When the user needs a specific date, not just a year — use `DatePickerInput` instead.
+- When the year is always the current year or is derived from another field — remove the field and compute the value programmatically.
+- When the set of valid years is small and well-known (e.g. four specific years) — a `Select` is simpler and does not introduce a popover interaction.
+
+## Decision-making guidance
+
+- Use `type="default"` for a single year selection and `type="range"` for a contiguous year span.
+- Enable `clearable` whenever the year is optional so users can remove a previously selected value without workarounds.
+- Provide `minDate` and `maxDate` (Mantine props) to bound the selectable range and prevent logically invalid values (e.g. a birth year in the future).
+
+## Variants
+
+`type` controls selection behaviour:
+
+- `'default'` — single year.
+- `'multiple'` — multiple individual years.
+- `'range'` — contiguous year range with start and end.
+
+## Interaction notes
+
+- Clicking the input opens a popover showing a grid of years.
+- In `type="range"` mode, the first click sets the start year and the second click sets the end year. Hovering previews the potential range.
+- The clear button (when `clearable` is enabled) appears inside the input once a value is selected.
+- Keyboard navigation within the popover uses arrow keys; Enter confirms, Escape closes.
+
+## Accessibility expectations
+
+- The field MUST have a visible label via `label` or an external element connected with `aria-labelledby`.
+- `description` and `error` SHOULD be used for supplementary guidance and validation feedback respectively.
+- `required` adds a visual indicator and the `aria-required` attribute.
+
+## Content guidance
+
+- Use a `placeholder` that reflects the selection mode (e.g. `"Pick a year"` or `"Pick a year range"`).
+- Labels SHOULD be noun phrases ("Report year", "Founding year") rather than instructions.
+- Error messages SHOULD be specific (e.g. "End year must be after start year") rather than generic ("Invalid selection").
+
+## Common anti-patterns
+
+- Using `YearPickerInput` when `DatePickerInput` is needed — if users must also specify month or day, `YearPickerInput` is the wrong component.
+- Omitting `clearable` on an optional year field, leaving users unable to remove a selection.
+- Leaving the year range unbounded when the domain clearly constrains it (e.g. no fiscal years before the company was founded) — always set `minDate`/`maxDate` to enforce valid ranges.
+
+## What an AI agent should understand
+
+- `YearPickerInput` is a thin Plasma re-export of `@mantine/dates` `YearPickerInput`. All Mantine props are available.
+- Plasma adds only a `displayName` for tooling; there is no additional logic.
+- The value type changes with `type`: a single `Date | null` for `'default'`, `Date[]` for `'multiple'`, and `[Date | null, Date | null]` for `'range'`.
+
+# API reference
+
+## Props
+
+> Extends: `YearPickerInputProps` from `@mantine/dates`. No additional Plasma-specific props.
+
+Key props relevant to Plasma usage patterns:
+
+**`type`** `'default' | 'multiple' | 'range'` · optional · default: `'default'` — Controls whether one year, many years, or a year range can be selected.
+
+**`clearable`** `boolean` · optional · default: `false` — Renders a clear button inside the input when a value is present.
+
+**`placeholder`** `string` · optional — Hint text shown when no year is selected.
+
+**`label`** `ReactNode` · optional — Visible field label rendered above the input.
+
+**`description`** `ReactNode` · optional — Helper text rendered below the label.
+
+**`error`** `ReactNode` · optional — Validation message rendered below the input in an error state.
+
+**`required`** `boolean` · optional · default: `false` — Marks the field as required.
+
+**`disabled`** `boolean` · optional · default: `false` — Prevents interaction and dims the field.
+
+**`readOnly`** `boolean` · optional · default: `false` — Displays the value without allowing edits.
+
+## Usage
+
+```tsx
+import {YearPickerInput} from '@coveord/plasma-mantine';
+
+// Single year selection
+function ReportYearField() {
+    return <YearPickerInput label="Report year" placeholder="Pick a year" clearable />;
+}
+
+// Year range selection
+function ComparisonRangeField() {
+    return (
+        <YearPickerInput type="range" label="Comparison period" placeholder="Pick a year range" clearable required />
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/YearPickerInput.md
+++ b/packages/llms/src/components/YearPickerInput.md
@@ -60,12 +60,6 @@ description: Form input that opens a year-grid popover for selecting one year, m
 - Omitting `clearable` on an optional year field, leaving users unable to remove a selection.
 - Leaving the year range unbounded when the domain clearly constrains it (e.g. no fiscal years before the company was founded) — always set `minDate`/`maxDate` to enforce valid ranges.
 
-## What an AI agent should understand
-
-- `YearPickerInput` is a thin Plasma re-export of `@mantine/dates` `YearPickerInput`. All Mantine props are available.
-- Plasma adds only a `displayName` for tooling; there is no additional logic.
-- The value type changes with `type`: a single `Date | null` for `'default'`, `Date[]` for `'multiple'`, and `[Date | null, Date | null]` for `'range'`.
-
 # API reference
 
 ## Props


### PR DESCRIPTION
## What

Carves the final **T through Z** component usage-guidance docs out of #4437 into a smaller, independently reviewable PR — the fifth and last component slice (after #4540 A–B, #4542 C–H, #4547 I–P, #4548 Q–S). #4437 stays open as the tracking PR.

## Components in this slice (7)

Table, Tabs, TextInput, Textarea, TimePicker, Tooltip, YearPickerInput

## Review-pass refinements

- **TextInput**: fixed a broken "when not to use" reference — `DateInput`/`DateTimePicker` don't exist in Plasma (verified in-repo); now points to `DatePickerInput`/`TimePicker`. (`Autocomplete` reference confirmed valid.)
- **Textarea**: corrected imprecise alternatives — `Input` → `TextInput` for single-line, and "a `Select` with multi-select" → `MultiSelect`.
- **Tooltip**: removed a Storybook-only `freezeOpen` story-prop mention; kept the real `opened` guidance.
- **Tabs / TimePicker / YearPickerInput**: reviewed, consistent with Mantine.
- **Table**: left as-is — it carries an "under active redesign" banner, so deep edits are deferred (same handling as Card).

## Not included (belongs in later slices)

Global/shared parts of #4437 — aggregate build files (`llms-full-txt.ts`, `llms-txt.ts`, `skill.md`, `tsconfig.json`) and `src/content/*` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)