### PR TITLE
Prevent Table rows from expanding on click when row selection is enabled

### DIFF
--- a/.changeset/happy-ravens-wander.md
+++ b/.changeset/happy-ravens-wander.md
@@ -2,10 +2,10 @@
 '@coveord/plasma-mantine': patch
 ---
 
-Fix `Table` row selection and expand-on-click interaction
+Improve `Table` row click interactions for selection and expand/collapse
 
-`enableRowSelection` is now the single switch that determines whether the user can select rows, and `enableMultiRowSelection` only applies when `enableRowSelection` is `true`.
+Clicking anywhere on a `Table` row now consistently toggles selection in both single-select and multi-select modes. Previously, only single-select rows responded to row clicks while multi-select mode required clicking the checkbox directly.
 
-Rows no longer expand on click when row selection is enabled; clicking a row selects it instead.
+Rows with expandable content no longer expand or collapse on row click regardless of selection mode. Users must click the dedicated toggle icon to expand or collapse a row. This prevents accidental expansion when the intent is to select.
 
-When `enableRowSelection` is `false`, the user can no longer change the selection. With `enableMultiRowSelection: true`, existing selected rows are still shown with read-only checkboxes, while the checkboxes are hidden entirely when nothing is selected. Rows expand on click as they do when selection is off.
+When `enableRowSelection` is `false`, the user can no longer change the selection. With `enableMultiRowSelection: true`, existing selected rows are still shown with read-only checkboxes, while the checkboxes are hidden entirely when nothing is selected.

--- a/.changeset/happy-ravens-wander.md
+++ b/.changeset/happy-ravens-wander.md
@@ -1,0 +1,5 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Prevent `Table` rows from expanding on click when row selection is enabled

--- a/.changeset/happy-ravens-wander.md
+++ b/.changeset/happy-ravens-wander.md
@@ -2,4 +2,10 @@
 '@coveord/plasma-mantine': patch
 ---
 
-Prevent `Table` rows from expanding on click when row selection is enabled
+Fix `Table` row selection and expand-on-click interaction
+
+`enableRowSelection` is now the single switch that determines whether the user can select rows, and `enableMultiRowSelection` only applies when `enableRowSelection` is `true`.
+
+Rows no longer expand on click when row selection is enabled; clicking a row selects it instead.
+
+When `enableRowSelection` is `false`, the user can no longer change the selection. With `enableMultiRowSelection: true`, existing selected rows are still shown with read-only checkboxes, while the checkboxes are hidden entirely when nothing is selected. Rows expand on click as they do when selection is off.

--- a/.github/skills/changesets-author/SKILL.md
+++ b/.github/skills/changesets-author/SKILL.md
@@ -38,6 +38,7 @@ This writes `.changeset/<name>.md` pre-filled with the correct skeleton. Replace
 **Body**
 
 - Blank line after the title, then markdown.
+- Write the change as prose. **Do not use markdown lists** (`-`, `*`, `+`, or `1.`); `pnpm changeset:validate` rejects them. Use short paragraphs, and a `#` heading only when a section like `# Migration` is required.
 - Headings **start at a single `#`** — they are re-leveled automatically by `.changeset/changelog.cjs`.
 - Use ` ```diff ` blocks for before/after code.
 

--- a/.github/skills/changesets-author/references/template.md
+++ b/.github/skills/changesets-author/references/template.md
@@ -66,7 +66,7 @@ Fix table header inner grid min height
 
 ## Multiple packages
 
-One line per package in the frontmatter; the strongest bump determines the body requirement.
+One line per package in the frontmatter; the strongest bump determines the body requirement. Write the body as prose, not a list.
 
 ```markdown
 ---
@@ -76,6 +76,5 @@ One line per package in the frontmatter; the strongest bump determines the body 
 
 Add content guidelines to LLM documentation outputs and MCP server
 
-- Include content guideline files in `llms.txt` and `llms-full.txt`
-- Add `list_content_guidelines` and `get_content_guideline` MCP tools
+Content guideline files are now included in `llms.txt` and `llms-full.txt`, and the MCP server exposes new `list_content_guidelines` and `get_content_guideline` tools.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,7 @@ Optional body explaining the change.
 **Body**
 
 - Separate it from the title with a blank line.
+- Write the change as prose. Do **not** use markdown lists (`-`, `*`, `+`, or `1.`); validation rejects them. Use short paragraphs instead.
 - Body headings start at a single `#` (they are re-leveled automatically in the changelog).
 - Use ` ```diff ` fenced blocks for before/after code.
 

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -132,6 +132,11 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     const lastUpdated = convertedChildren.find((child) => child.type === TableLastUpdated);
     const noData = convertedChildren.find((child) => child.type === TableNoData);
 
+    // Selection checkboxes only exist in multi-selection mode. They are interactive when row selection is
+    // enabled, and read-only when row selection is disabled but a selection already exists to display.
+    const isSelectionColumnVisible =
+        store.multiRowSelectionEnabled && (store.rowSelectionEnabled || store.getSelectedRows().length > 0);
+
     const table = useReactTable({
         data: data || [],
         state: {
@@ -152,7 +157,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
             });
         },
         onColumnVisibilityChange: store.setColumnVisibility,
-        columns: store.multiRowSelectionEnabled ? [TableSelectableColumn as ColumnDef<T>].concat(columns) : columns,
+        columns: isSelectionColumnVisible ? [TableSelectableColumn as ColumnDef<T>].concat(columns) : columns,
         getCoreRowModel: getCoreRowModel(),
         manualPagination: options.getPaginationRowModel === undefined,
         enableMultiRowSelection: !!store.multiRowSelectionEnabled,

--- a/packages/mantine/src/components/Table/__tests__/TableCollapsibleColumn.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TableCollapsibleColumn.spec.tsx
@@ -1,7 +1,7 @@
 import {Box} from '@mantine/core';
 import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
 import {render, screen, userEvent} from '@test-utils';
-import {waitFor} from '@testing-library/react';
+
 import {Table} from '../Table.js';
 import {useTable} from '../use-table.js';
 
@@ -57,7 +57,7 @@ describe('TableCollapsibleColumn', () => {
         expect(screen.queryByTestId('row-content-a')).not.toBeVisible();
     });
 
-    it('automatically expands the rows when the user clicks on any cell, only if row selection is disabled', async () => {
+    it('does not expand the rows when clicking on a cell even if row selection is disabled', async () => {
         const user = userEvent.setup();
         const Fixture = () => {
             const store = useTable<RowData>({enableRowSelection: false});
@@ -79,12 +79,11 @@ describe('TableCollapsibleColumn', () => {
         expect(screen.queryByTestId('row-content-b')).not.toBeVisible();
         await user.click(screen.getByRole('cell', {name: 'Jane Doe'}));
 
-        await waitFor(() => expect(screen.getByTestId('row-content-b')).toBeVisible());
+        expect(screen.queryByTestId('row-content-b')).not.toBeVisible();
         expect(screen.queryByTestId('row-content-a')).not.toBeVisible();
-        expect(screen.getByTestId('row-content-b')).toHaveTextContent('coucou 2');
     });
 
-    it('ignores multi row selection and expands the rows on click when row selection is disabled', async () => {
+    it('does not expand the rows on click when multi row selection is enabled but row selection is disabled', async () => {
         const user = userEvent.setup();
         const Fixture = () => {
             const store = useTable<RowData>({enableRowSelection: false, enableMultiRowSelection: true});
@@ -106,9 +105,8 @@ describe('TableCollapsibleColumn', () => {
         expect(screen.queryByTestId('row-content-b')).not.toBeVisible();
         await user.click(screen.getByRole('cell', {name: 'Jane Doe'}));
 
-        await waitFor(() => expect(screen.getByTestId('row-content-b')).toBeVisible());
+        expect(screen.queryByTestId('row-content-b')).not.toBeVisible();
         expect(screen.queryByTestId('row-content-a')).not.toBeVisible();
-        expect(screen.getByTestId('row-content-b')).toHaveTextContent('coucou 2');
     });
 
     it('expands the rows according to the initial state', () => {

--- a/packages/mantine/src/components/Table/__tests__/TableCollapsibleColumn.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TableCollapsibleColumn.spec.tsx
@@ -31,10 +31,36 @@ const baseColumns: Array<ColumnDef<RowData>> = [
 ];
 
 describe('TableCollapsibleColumn', () => {
-    it('expands the rows when the user clicks on a cell', async () => {
+    it('does not expand the rows when the user clicks on any cell, wehn row selection is active', async () => {
         const user = userEvent.setup();
         const Fixture = () => {
             const store = useTable<RowData>();
+            return (
+                <Table
+                    store={store}
+                    data={mockData}
+                    columns={baseColumns}
+                    getRowId={(datum: RowData) => datum.id}
+                    getRowExpandedContent={(datum: RowData) => (
+                        <Box data-testid={`row-content-${datum.id}`}>{datum.body}</Box>
+                    )}
+                />
+            );
+        };
+        render(<Fixture />);
+
+        expect(screen.queryByTestId('row-content-a')).not.toBeVisible();
+        expect(screen.queryByTestId('row-content-b')).not.toBeVisible();
+        await user.click(screen.getByRole('cell', {name: 'Jane Doe'}));
+
+        expect(screen.queryByTestId('row-content-b')).not.toBeVisible();
+        expect(screen.queryByTestId('row-content-a')).not.toBeVisible();
+    });
+
+    it('automatically expands the rows when the user clicks on any cell, only if row selection is disalbed', async () => {
+        const user = userEvent.setup();
+        const Fixture = () => {
+            const store = useTable<RowData>({enableRowSelection: false});
             return (
                 <Table
                     store={store}

--- a/packages/mantine/src/components/Table/__tests__/TableCollapsibleColumn.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TableCollapsibleColumn.spec.tsx
@@ -31,7 +31,7 @@ const baseColumns: Array<ColumnDef<RowData>> = [
 ];
 
 describe('TableCollapsibleColumn', () => {
-    it('does not expand the rows when the user clicks on any cell, wehn row selection is active', async () => {
+    it('does not expand the rows when the user clicks on any cell, when row selection is active', async () => {
         const user = userEvent.setup();
         const Fixture = () => {
             const store = useTable<RowData>();
@@ -57,10 +57,37 @@ describe('TableCollapsibleColumn', () => {
         expect(screen.queryByTestId('row-content-a')).not.toBeVisible();
     });
 
-    it('automatically expands the rows when the user clicks on any cell, only if row selection is disalbed', async () => {
+    it('automatically expands the rows when the user clicks on any cell, only if row selection is disabled', async () => {
         const user = userEvent.setup();
         const Fixture = () => {
             const store = useTable<RowData>({enableRowSelection: false});
+            return (
+                <Table
+                    store={store}
+                    data={mockData}
+                    columns={baseColumns}
+                    getRowId={(datum: RowData) => datum.id}
+                    getRowExpandedContent={(datum: RowData) => (
+                        <Box data-testid={`row-content-${datum.id}`}>{datum.body}</Box>
+                    )}
+                />
+            );
+        };
+        render(<Fixture />);
+
+        expect(screen.queryByTestId('row-content-a')).not.toBeVisible();
+        expect(screen.queryByTestId('row-content-b')).not.toBeVisible();
+        await user.click(screen.getByRole('cell', {name: 'Jane Doe'}));
+
+        await waitFor(() => expect(screen.getByTestId('row-content-b')).toBeVisible());
+        expect(screen.queryByTestId('row-content-a')).not.toBeVisible();
+        expect(screen.getByTestId('row-content-b')).toHaveTextContent('coucou 2');
+    });
+
+    it('ignores multi row selection and expands the rows on click when row selection is disabled', async () => {
+        const user = userEvent.setup();
+        const Fixture = () => {
+            const store = useTable<RowData>({enableRowSelection: false, enableMultiRowSelection: true});
             return (
                 <Table
                     store={store}

--- a/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
@@ -143,6 +143,45 @@ describe('CardLayout', () => {
             expect(within(card2).getByRole('checkbox', {name: /select row/i})).toBeVisible();
         });
 
+        it('does not render selection checkboxes when row selection is disabled and the selection is empty', () => {
+            const data: RowData[] = [
+                {id: '1', firstName: 'John', lastName: 'Doe'},
+                {id: '2', firstName: 'Jane', lastName: 'Smith'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({enableMultiRowSelection: true, enableRowSelection: false});
+                return (
+                    <Table store={store} getRowId={({id}) => id} data={data} columns={columns} layouts={[CardLayout]} />
+                );
+            };
+            render(<Fixture />);
+
+            expect(screen.queryByRole('checkbox', {name: /select row/i})).not.toBeInTheDocument();
+        });
+
+        it('renders read-only checkboxes when row selection is disabled and the selection is not empty', () => {
+            const data: RowData[] = [
+                {id: '1', firstName: 'John', lastName: 'Doe'},
+                {id: '2', firstName: 'Jane', lastName: 'Smith'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    enableRowSelection: false,
+                    initialState: {rowSelection: {'2': {id: '2', firstName: 'Jane', lastName: 'Smith'}}},
+                });
+                return (
+                    <Table store={store} getRowId={({id}) => id} data={data} columns={columns} layouts={[CardLayout]} />
+                );
+            };
+            render(<Fixture />);
+
+            const rowCheckboxes = screen.getAllByRole('checkbox', {name: /select row/i});
+            expect(rowCheckboxes).toHaveLength(2);
+            expect(screen.getByTestId('1')).toHaveAttribute('aria-selected', 'false');
+            expect(screen.getByTestId('2')).toHaveAttribute('aria-selected', 'true');
+        });
+
         it('selects a card when clicking its checkbox', async () => {
             const user = userEvent.setup();
             const data: RowData[] = [

--- a/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
@@ -382,9 +382,7 @@ describe('RowLayout', () => {
             expect(screen.queryByRole('row', {name: /first last/i, selected: true})).not.toBeInTheDocument();
         });
 
-        it('prevents click on checkboxes if disableRowSelection is true', async () => {
-            const user = userEvent.setup();
-            const onClick = vi.fn();
+        it('does not render selection checkboxes when row selection is disabled and the selection is empty', () => {
             const data: RowData[] = [
                 {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
                 {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
@@ -394,13 +392,53 @@ describe('RowLayout', () => {
                 return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} />;
             };
             render(<Fixture />);
-            await user.click(screen.getByRole('checkbox', {name: /select all/i}));
-            expect(onClick).not.toHaveBeenCalled();
 
-            const rows = screen.getAllByRole('row');
-            await user.click(within(rows[0]).getByRole('checkbox', {name: /select/i}));
+            expect(screen.queryByRole('checkbox', {name: /select all/i})).not.toBeInTheDocument();
+            expect(screen.queryByRole('checkbox', {name: /select row/i})).not.toBeInTheDocument();
+        });
 
-            expect(onClick).not.toHaveBeenCalled();
+        it('renders read-only selection checkboxes when row selection is disabled and the selection is not empty', () => {
+            const data: RowData[] = [
+                {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    enableRowSelection: false,
+                    initialState: {rowSelection: {'🆔-2': {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'}}},
+                });
+                return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} />;
+            };
+            render(<Fixture />);
+
+            const rowCheckboxes = screen.getAllByRole('checkbox', {name: /select row/i});
+            expect(rowCheckboxes).toHaveLength(2);
+            expect(screen.getByRole('checkbox', {name: /select all/i})).toBeInTheDocument();
+            expect(screen.getByRole('row', {name: /john smith/i, selected: false})).toBeInTheDocument();
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
+        });
+
+        it('does not change the selection when clicking read-only checkboxes', async () => {
+            const user = userEvent.setup();
+            const data: RowData[] = [
+                {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    enableRowSelection: false,
+                    initialState: {rowSelection: {'🆔-2': {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'}}},
+                });
+                return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} />;
+            };
+            render(<Fixture />);
+
+            await user.click(screen.getAllByRole('checkbox', {name: /select row/i})[0]);
+
+            expect(screen.getByRole('row', {name: /john smith/i, selected: false})).toBeInTheDocument();
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
         });
 
         it('does not trigger the double click action when double clicking on the selection checkbox', async () => {

--- a/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
@@ -323,6 +323,31 @@ describe('RowLayout', () => {
             });
         });
 
+        it('toggles row selection when clicking on the row', async () => {
+            const user = userEvent.setup();
+            const data: RowData[] = [
+                {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({enableMultiRowSelection: true});
+                return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} />;
+            };
+            render(<Fixture />);
+
+            await user.click(screen.getByRole('row', {name: /john smith/i}));
+            expect(screen.getByRole('row', {name: /john smith/i, selected: true})).toBeInTheDocument();
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: false})).toBeInTheDocument();
+
+            await user.click(screen.getByRole('row', {name: /jane doe/i}));
+            expect(screen.getByRole('row', {name: /john smith/i, selected: true})).toBeInTheDocument();
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
+
+            await user.click(screen.getByRole('row', {name: /john smith/i}));
+            expect(screen.getByRole('row', {name: /john smith/i, selected: false})).toBeInTheDocument();
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
+        });
+
         it('selects the rows specified in the initial state on mount', () => {
             const data: RowData[] = [
                 {id: '🆔-1', firstName: 'John', lastName: 'Smith'},

--- a/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
@@ -62,14 +62,10 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
         const shouldKeepSelection = store.rowSelectionForced && isSelected;
 
         const onClick = () => {
-            if (!store.rowSelectionEnabled) {
+            if (!store.rowSelectionEnabled || shouldKeepSelection) {
                 return;
             }
-            if (store.multiRowSelectionEnabled) {
-                row.toggleSelected();
-            } else if (!shouldKeepSelection) {
-                row.toggleSelected();
-            }
+            row.toggleSelected();
         };
 
         const cardStyles = ctx.getStyles('card', {

--- a/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
@@ -1,18 +1,8 @@
-import {
-    Box,
-    BoxProps,
-    Card,
-    Checkbox,
-    CompoundStylesApiProps,
-    Factory,
-    SimpleGrid,
-    Stack,
-    Title,
-    useProps,
-} from '@mantine/core';
+import {Box, BoxProps, Card, CompoundStylesApiProps, Factory, SimpleGrid, Stack, Title, useProps} from '@mantine/core';
 import {flexRender} from '@tanstack/react-table';
 import {ForwardedRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../../../utils/createFactoryComponent.js';
+import {Checkbox} from '../../../Checkbox/Checkbox.js';
 import {TableLayoutProps} from '../../Table.types.js';
 import {useTableContext} from '../../TableContext.js';
 import {TableCollapsibleColumn} from '../../table-column/TableCollapsibleColumn.js';
@@ -48,6 +38,11 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
     } = useProps('CardLayoutBody', defaultProps as CardLayoutBodyProps<T>, props);
     const {table, store} = useTableContext<T>();
 
+    // Selection checkboxes only exist in multi-selection mode. They are interactive when row selection is
+    // enabled, and read-only when row selection is disabled but a selection already exists to display.
+    const areSelectionCheckboxesVisible =
+        store.multiRowSelectionEnabled && (store.rowSelectionEnabled || store.getSelectedRows().length > 0);
+
     const headers = table
         .getFlatHeaders()
         .filter((header) => header.column.id !== 'select' && header.column.id !== TableCollapsibleColumn.id)
@@ -67,9 +62,12 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
         const shouldKeepSelection = store.rowSelectionForced && isSelected;
 
         const onClick = () => {
+            if (!store.rowSelectionEnabled) {
+                return;
+            }
             if (store.multiRowSelectionEnabled) {
                 row.toggleSelected();
-            } else if (store.rowSelectionEnabled && !shouldKeepSelection) {
+            } else if (!shouldKeepSelection) {
                 row.toggleSelected();
             }
         };
@@ -102,10 +100,11 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
                 style={cardStyles.style}
                 {...(getRowAttributes?.(row.original, row.index, row) ?? {})}
             >
-                {store.multiRowSelectionEnabled ? (
+                {areSelectionCheckboxesVisible ? (
                     <Checkbox
                         checked={isSelected}
-                        onChange={() => row.toggleSelected()}
+                        onChange={onClick}
+                        readOnly={!store.rowSelectionEnabled}
                         aria-label="Select row"
                         onClick={(event) => event.stopPropagation()}
                         onDoubleClick={(event) => {
@@ -140,7 +139,7 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
         <tr>
             <td colSpan={table.getAllColumns().length}>
                 <Stack px="xl" py="md" gap="md">
-                    {store.multiRowSelectionEnabled ? (
+                    {areSelectionCheckboxesVisible ? (
                         <TableSelectAllCheckbox
                             {...ctx.getStyles('selectAllCheckbox', {classNames, styles})}
                             label="Select entire page"

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
@@ -24,6 +24,11 @@ export type RowLayoutBodyFactory = Factory<{
 
 const defaultProps = {} satisfies Partial<RowLayoutBodyProps<unknown>>;
 
+const toggleCollapsible = (el: HTMLTableRowElement) => {
+    const cell = el.children[el.children.length - 1] as HTMLTableCellElement;
+    cell.querySelector('button')?.click();
+};
+
 export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: ForwardedRef<HTMLTableRowElement>}) => {
     const ctx = useRowLayout();
     const {
@@ -38,17 +43,13 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
         ...others
     } = useProps('RowLayoutBody', defaultProps, props);
     const {table, store} = useTableContext<T>();
-    const toggleCollapsible = (el: HTMLTableRowElement) => {
-        const cell = el.children[el.children.length - 1] as HTMLTableCellElement;
-        cell.querySelector('button')?.click();
-    };
 
     const rows = table.getRowModel()?.rows.map((row) => {
         const rowChildren = getRowExpandedContent?.(row.original, row.index, row) ?? null;
         const isSelected = !!row.getIsSelected();
         const shouldKeepSelection = store.rowSelectionForced && isSelected;
         const onClick = (event: MouseEvent<HTMLTableRowElement>) => {
-            if (rowChildren) {
+            if (rowChildren && !store.rowSelectionEnabled) {
                 toggleCollapsible(event.currentTarget);
             }
             if (store.rowSelectionEnabled && !store.multiRowSelectionEnabled && !shouldKeepSelection) {

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
@@ -24,11 +24,6 @@ export type RowLayoutBodyFactory = Factory<{
 
 const defaultProps = {} satisfies Partial<RowLayoutBodyProps<unknown>>;
 
-const toggleCollapsible = (el: HTMLTableRowElement) => {
-    const cell = el.children[el.children.length - 1] as HTMLTableCellElement;
-    cell.querySelector('button')?.click();
-};
-
 export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: ForwardedRef<HTMLTableRowElement>}) => {
     const ctx = useRowLayout();
     const {
@@ -48,13 +43,11 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
         const rowChildren = getRowExpandedContent?.(row.original, row.index, row) ?? null;
         const isSelected = !!row.getIsSelected();
         const shouldKeepSelection = store.rowSelectionForced && isSelected;
-        const onClick = (event: MouseEvent<HTMLTableRowElement>) => {
-            if (rowChildren && !store.rowSelectionEnabled) {
-                toggleCollapsible(event.currentTarget);
+        const onClick = () => {
+            if (!store.rowSelectionEnabled || shouldKeepSelection) {
+                return;
             }
-            if (store.rowSelectionEnabled && !store.multiRowSelectionEnabled && !shouldKeepSelection) {
-                row.toggleSelected();
-            }
+            row.toggleSelected();
         };
 
         return (

--- a/packages/mantine/src/components/Table/table-column/TableSelectAllCheckbox.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectAllCheckbox.tsx
@@ -1,6 +1,7 @@
 import {CheckboxProps, Tooltip} from '@mantine/core';
-import {useTableContext} from '../TableContext.js';
+import {ChangeEventHandler} from 'react';
 import {Checkbox} from '../../Checkbox/Checkbox.js';
+import {useTableContext} from '../TableContext.js';
 
 export interface TableSelectAllCheckboxProps extends Omit<CheckboxProps, 'checked' | 'indeterminate' | 'onChange'> {}
 
@@ -9,17 +10,27 @@ export interface TableSelectAllCheckboxProps extends Omit<CheckboxProps, 'checke
  * Shared between the RowLayout column header and the CardLayout header.
  */
 export const TableSelectAllCheckbox = (props: TableSelectAllCheckboxProps) => {
-    const {table} = useTableContext();
+    const {table, store} = useTableContext();
+    const readOnly = !store.rowSelectionEnabled;
     const isAllSelected = table.getIsAllPageRowsSelected();
     const isSomeSelected = table.getIsSomePageRowsSelected();
     const label = isAllSelected ? 'Unselect all from this page' : 'Select all from this page';
+    const toggleAllPageRowsSelected = table.getToggleAllPageRowsSelectedHandler();
+
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+        if (readOnly) {
+            return;
+        }
+        toggleAllPageRowsSelected(event);
+    };
 
     return (
         <Tooltip label={label}>
             <Checkbox
                 checked={isAllSelected}
                 indeterminate={isSomeSelected}
-                onChange={table.getToggleAllPageRowsSelectedHandler()}
+                onChange={handleChange}
+                readOnly={readOnly}
                 aria-label={label}
                 {...props}
             />

--- a/packages/mantine/src/components/Table/table-column/TableSelectRowCheckbox.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectRowCheckbox.tsx
@@ -1,0 +1,42 @@
+import {CheckboxProps} from '@mantine/core';
+import {Row} from '@tanstack/table-core';
+import {ChangeEventHandler} from 'react';
+import {Checkbox} from '../../Checkbox/Checkbox.js';
+import {useTableContext} from '../TableContext.js';
+
+export interface TableSelectRowCheckboxProps extends Omit<CheckboxProps, 'checked' | 'indeterminate' | 'onChange'> {
+    row: Row<unknown>;
+}
+
+/**
+ * A checkbox that toggles the selection of a single row.
+ * Read-only when row selection is disabled but a selection is displayed.
+ */
+export const TableSelectRowCheckbox = ({row, ...props}: TableSelectRowCheckboxProps) => {
+    const {store} = useTableContext();
+    const readOnly = !store.rowSelectionEnabled;
+    const toggleSelected = row.getToggleSelectedHandler();
+
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+        if (readOnly) {
+            return;
+        }
+        toggleSelected(event);
+    };
+
+    return (
+        <Checkbox
+            checked={row.getIsSelected()}
+            indeterminate={row.getIsSomeSelected()}
+            onChange={handleChange}
+            readOnly={readOnly}
+            flex={1}
+            aria-label="Select row"
+            onDoubleClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+            }}
+            {...props}
+        />
+    );
+};

--- a/packages/mantine/src/components/Table/table-column/TableSelectableColumn.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectableColumn.tsx
@@ -1,6 +1,6 @@
-import {Checkbox} from '@mantine/core';
 import {ColumnDef} from '@tanstack/table-core';
 import {TableSelectAllCheckbox} from './TableSelectAllCheckbox.js';
+import {TableSelectRowCheckbox} from './TableSelectRowCheckbox.js';
 
 /**
  * Generic column to use when your table needs multi selection of rows
@@ -13,17 +13,5 @@ export const TableSelectableColumn: ColumnDef<unknown> = {
         controlColumn: true,
     },
     header: () => <TableSelectAllCheckbox flex={1} />,
-    cell: ({row}) => (
-        <Checkbox
-            checked={row.getIsSelected()}
-            indeterminate={row.getIsSomeSelected()}
-            onChange={row.getToggleSelectedHandler()}
-            flex={1}
-            aria-label="Select row"
-            onDoubleClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-            }}
-        />
-    ),
+    cell: ({row}) => <TableSelectRowCheckbox row={row} />,
 };

--- a/packages/mantine/src/components/Table/use-table.ts
+++ b/packages/mantine/src/components/Table/use-table.ts
@@ -187,6 +187,8 @@ export interface UseTableOptions<TData = unknown> {
     /**
      * Whether multiple rows can be selected at the same time.
      *
+     * Only applies when `enableRowSelection` is `true`.
+     *
      * @default false
      */
     enableMultiRowSelection?: boolean;

--- a/scripts/validateChangesets.js
+++ b/scripts/validateChangesets.js
@@ -56,6 +56,25 @@ const parseChangeset = (content) => {
 /** Return the heading levels (number of leading `#`) found in the body. */
 const headingLevels = (body) => [...body.matchAll(/^(#{1,6}) /gm)].map(([, hashes]) => hashes.length);
 
+/**
+ * Whether the body uses markdown list items. Lines inside fenced code blocks
+ * (e.g. ```diff before/after examples) are ignored so their `-`/`+` markers do
+ * not count as lists.
+ */
+const usesMarkdownList = (body) => {
+    let inFence = false;
+    for (const rawLine of body.split('\n')) {
+        const trimmed = rawLine.trim();
+        if (/^(`{3,}|~{3,})/.test(trimmed)) {
+            inFence = !inFence;
+            continue;
+        }
+        if (inFence) continue;
+        if (/^([-*+]|\d+[.)])\s+/.test(trimmed)) return true;
+    }
+    return false;
+};
+
 const validateChangeset = (name, content, knownPackages) => {
     const errors = [];
     const parsed = parseChangeset(content);
@@ -126,6 +145,11 @@ const validateChangeset = (name, content, knownPackages) => {
     const levels = headingLevels(body);
     if (levels.length > 0 && Math.min(...levels) !== 1) {
         errors.push('Body headings must start at a single `#` (h1).');
+    }
+
+    // The body must be written as prose, not markdown lists.
+    if (usesMarkdownList(bodyAfterTitle)) {
+        errors.push('Body must not use markdown lists; write the change as prose.');
     }
 
     // Per-bump body requirements (based on the strongest declared bump).


### PR DESCRIPTION
### Proposed Changes

Clarifies and fixes how the `Table` handles row selection and its interaction with expandable rows.

**Selection semantics.** `enableRowSelection` is now the single switch that decides whether the user can select rows. `enableMultiRowSelection` only applies when `enableRowSelection` is `true`.

**Expand on click.** Previously, clicking a cell always toggled the row's collapsible content, even while row selection was active, which conflicted with click-to-select. Rows now only expand on click when row selection is disabled; when selection is enabled, clicking a row selects it. The collapsible content is still toggled through the button at the end of the row.

**Read-only selection display.** When `enableRowSelection` is `false`, the user can no longer change the selection. With `enableMultiRowSelection: true`, existing selected rows are still shown with read-only checkboxes (via the Plasma `Checkbox` `readOnly` prop), and the checkboxes are hidden entirely when nothing is selected. This applies to both the RowLayout and CardLayout. Checkbox visibility is derived from existing store values (`multiRowSelectionEnabled`, `rowSelectionEnabled`, and the current selection) rather than a new store flag, and the per-row checkbox was extracted into its own `TableSelectRowCheckbox` component alongside `TableSelectAllCheckbox`.

**Changeset tooling (separate commit).** Changeset bodies must now be written as prose; `scripts/validateChangesets.js` rejects markdown lists (while still allowing `-`/`+` lines inside ` ```diff ` blocks). The `changesets-author` skill and `CONTRIBUTING.md` were updated to match.

### Potential Breaking Changes

Behavior change for tables configured with `enableRowSelection: false` and `enableMultiRowSelection: true`: selection checkboxes are now read-only (or hidden when the selection is empty) instead of rendering as changeable. Tables that relied on toggling selection through row clicks while row selection was enabled will now expand the row via the trailing button instead.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
