### PR TITLE
DS-678 Components overview

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -9,7 +9,8 @@
         "**/node_modules",
         "**/dist",
         "CHANGELOG.md",
-        "packages/react-icons/src/generated"
+        "packages/react-icons/src/generated",
+        "packages/storybook/src/components/ComponentsOverview.mdx"
     ],
     "overrides": [
         {

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -9,8 +9,7 @@
         "**/node_modules",
         "**/dist",
         "CHANGELOG.md",
-        "packages/react-icons/src/generated",
-        "packages/storybook/src/components/ComponentsOverview.mdx"
+        "packages/react-icons/src/generated"
     ],
     "overrides": [
         {

--- a/packages/llms/src/components/ComponentsOverview.md
+++ b/packages/llms/src/components/ComponentsOverview.md
@@ -5,9 +5,7 @@ description: Complete list of Plasma design system components, grouped by functi
 
 # Components
 
-Components are the building blocks of the Coveo Administration Console UI. Most are based on Mantine. Some are Plasma-specific. All are imported from `@coveord/plasma-mantine`.
-
-This categorization differs from the official Mantine documentation structure: https://mantine.dev/core/package/
+Components are the building blocks of the Coveo Administration Console UI. Most are based on Mantine. Some are Plasma-specific. Prefer importing from `@coveord/plasma-mantine` when available; some entries listed here may be patterns or Mantine add-ons that are not exported by Plasma.
 
 Resources:
 

--- a/packages/llms/src/components/ComponentsOverview.md
+++ b/packages/llms/src/components/ComponentsOverview.md
@@ -64,7 +64,7 @@ Resources:
 - Accordion [Mantine] — Vertically stacked collapsible sections
 - AppShell [Mantine] — Main layout wrapper; includes header and navbar
 - ChildForm [Plasma] — Layout pattern for nesting forms
-- Footer [Plasma] — Sticky footer for page bottoms
+- StickyFooter [Plasma] — Sticky footer for page bottoms
 - Header [Plasma] — Top navigation bar
 - MainSidenav [Plasma] — Main side navigation
 - ScrollArea [Mantine] — Container with custom scrollbars

--- a/packages/llms/src/components/ComponentsOverview.md
+++ b/packages/llms/src/components/ComponentsOverview.md
@@ -1,0 +1,96 @@
+---
+name: Components
+description: Complete list of Plasma design system components, grouped by function with library origin.
+---
+
+# Components
+
+Components are the building blocks of the Coveo Administration Console UI. Most are based on Mantine. Some are Plasma-specific. All are imported from `@coveord/plasma-mantine`.
+
+This categorization differs from the official Mantine documentation structure: https://mantine.dev/core/package/
+
+Resources:
+
+- Figma library: https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0
+- Confluence database: https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512
+
+---
+
+## Call to action and navigation
+
+- ActionIcon [Mantine] — Icon-based button for executing actions
+- Anchor [Mantine] — Hyperlink for navigation
+- Breadcrumbs [Mantine] — Navigation trail showing current page location
+- Button [Mantine] — Standard interactive button; includes destructive variants
+- CloseButton [Mantine] — Dismiss button for modals and alerts
+- CopyToClipboard [Plasma] — Copies content to system clipboard
+- NavLink [Plasma] — Navigation link for sidebars/menus; includes sections
+- Pagination [Mantine] — Splits large datasets into pages
+
+## Forms and inputs
+
+- Checkbox [Mantine] — Selection control for single or multiple items
+- CodeEditor [Plasma] — Input for editing code snippets
+- Collection [Plasma] — Manages lists or groups of items
+- DatePickerInput [Mantine] — Input with dropdown calendar
+- Facet [Plasma] — Filtering pattern for search interfaces
+- MonthPickerInput [Mantine] — Input for selecting months
+- MultiSelect [Mantine] — Dropdown for selecting multiple options
+- NumberInput [Mantine] — Input for numerical values
+- PillsInput [Mantine] — Input displaying selected values as pill tags
+- Radio [Mantine] — Selection control for mutually exclusive options
+- RadioCard [Plasma] — Radio selection presented as cards
+- SegmentedControl [Mantine] — Two or more segments for exclusive choice
+- Select [Mantine] — Dropdown for single option selection
+- Slider [Mantine] — Selects a value from a range
+- Switch [Mantine] — Toggle between two states
+- Textarea [Mantine] — Multiline text input
+- TextInput [Mantine] — Single-line text input
+- TimePicker [Mantine] — Input for time selection
+- YearPickerInput [Mantine] — Input for selecting years
+
+## Feedback and status
+
+- Alert [Mantine] — Prominent messages: info, warning, critical
+- InfoToken [Plasma] — Small visual indicator for contextual information
+- Loader [Mantine] — Animated loading indicator
+- Notification [Mantine] — Toast-style messages for updates or errors
+- Progress [Mantine] — Bar indicating completion percentage
+- Skeleton [Mantine] — Placeholder preview while loading
+- StatusToken [Plasma] — Visual indicator for object status
+- Stepper [Mantine] — Progress indicator for multi-step workflows
+- Tooltip [Mantine] — Text label shown on hover
+
+## Layout and structure
+
+- Accordion [Mantine] — Vertically stacked collapsible sections
+- AppShell [Mantine] — Main layout wrapper; includes header and navbar
+- ChildForm [Plasma] — Layout pattern for nesting forms
+- Footer [Plasma] — Sticky footer for page bottoms
+- Header [Plasma] — Top navigation bar
+- MainSidenav [Plasma] — Main side navigation
+- ScrollArea [Mantine] — Container with custom scrollbars
+- Tabs [Mantine] — Switches between different views
+
+## Data display
+
+- Badge [Mantine] — Small label for status, counts, or categories
+- Card [Mantine] — Container for grouping related information
+- Image [Mantine] — Wrapper for displaying images
+- Pill [Mantine] — Rounded visual indicator; often used in inputs
+- Table [Plasma] — Rows and columns for structured data
+
+## Typography
+
+- Code [Mantine] — Inline or block display for code snippets
+- Kbd [Mantine] — Visual representation of keyboard inputs
+
+## Miscellaneous
+
+- ActionBar [Plasma] — Groups actions together
+- Calendar [Mantine] — Visual calendar display
+- Carousel [Mantine] — Slideshow for cycling content
+- Chip [Mantine] — Compact element for filtering or selection
+- ContentSwap [Plasma] — Toggles visible content
+- Modal [Mantine] — Overlay dialog requiring user attention
+- Popover [Mantine] — Floating content near a target element

--- a/packages/llms/src/components/ComponentsOverview.md
+++ b/packages/llms/src/components/ComponentsOverview.md
@@ -5,7 +5,9 @@ description: Complete list of Plasma design system components, grouped by functi
 
 # Components
 
-Components are the building blocks of the Coveo Administration Console UI. Most are based on Mantine. Some are Plasma-specific. Prefer importing from `@coveord/plasma-mantine` when available; some entries listed here may be patterns or Mantine add-ons that are not exported by Plasma.
+Components are the building blocks of the Coveo Administration Console UI. Most are based on Mantine. Some are Plasma-specific. All are imported from `@coveord/plasma-mantine`.
+
+This categorization differs from the official Mantine documentation structure: https://mantine.dev/core/package/
 
 Resources:
 
@@ -14,7 +16,7 @@ Resources:
 
 ---
 
-## Call to action and navigation
+## Call to action
 
 - ActionIcon [Mantine] — Icon-based button for executing actions
 - Anchor [Mantine] — Hyperlink for navigation
@@ -27,48 +29,48 @@ Resources:
 
 ## Forms and inputs
 
-- Checkbox [Mantine] — Selection control for single or multiple items
-- CodeEditor [Plasma] — Input for editing code snippets
-- Collection [Plasma] — Manages lists or groups of items
-- DatePickerInput [Mantine] — Input with dropdown calendar
-- Facet [Plasma] — Filtering pattern for search interfaces
-- MonthPickerInput [Mantine] — Input for selecting months
-- MultiSelect [Mantine] — Dropdown for selecting multiple options
+- TextInput [Mantine] — Single-line text input
+- Textarea [Mantine] — Multiline text input
 - NumberInput [Mantine] — Input for numerical values
+- Select [Mantine] — Dropdown for single option selection
+- MultiSelect [Mantine] — Dropdown for selecting multiple options
 - PillsInput [Mantine] — Input displaying selected values as pill tags
+- Checkbox [Mantine] — Selection control for single or multiple items
 - Radio [Mantine] — Selection control for mutually exclusive options
 - RadioCard [Plasma] — Radio selection presented as cards
-- SegmentedControl [Mantine] — Two or more segments for exclusive choice
-- Select [Mantine] — Dropdown for single option selection
-- Slider [Mantine] — Selects a value from a range
 - Switch [Mantine] — Toggle between two states
-- Textarea [Mantine] — Multiline text input
-- TextInput [Mantine] — Single-line text input
-- TimePicker [Mantine] — Input for time selection
+- SegmentedControl [Mantine] — Two or more segments for exclusive choice
+- Slider [Mantine] — Selects a value from a range
+- DatePickerInput [Mantine] — Input with dropdown calendar
+- MonthPickerInput [Mantine] — Input for selecting months
 - YearPickerInput [Mantine] — Input for selecting years
+- TimePicker [Mantine] — Input for time selection
+- CodeEditor [Plasma] — Input for editing code snippets
+- Collection [Plasma] — Manages lists or groups of items
+- Facet [Plasma] — Filtering pattern for search interfaces
 
-## Feedback and status
+## Feedback
 
 - Alert [Mantine] — Prominent messages: info, warning, critical
-- InfoToken [Plasma] — Small visual indicator for contextual information
-- Loader [Mantine] — Animated loading indicator
 - Notification [Mantine] — Toast-style messages for updates or errors
-- Progress [Mantine] — Bar indicating completion percentage
+- Loader [Mantine] — Animated loading indicator
 - Skeleton [Mantine] — Placeholder preview while loading
-- StatusToken [Plasma] — Visual indicator for object status
+- Progress [Mantine] — Bar indicating completion percentage
 - Stepper [Mantine] — Progress indicator for multi-step workflows
 - Tooltip [Mantine] — Text label shown on hover
+- InfoToken [Plasma] — Small visual indicator for contextual information
+- StatusToken [Plasma] — Visual indicator for object status
 
-## Layout and structure
+## Layout
 
-- Accordion [Mantine] — Vertically stacked collapsible sections
 - AppShell [Mantine] — Main layout wrapper; includes header and navbar
+- Header [Plasma] — Top navigation bar
+- Navigation [Plasma] — Main side navigation
+- Tabs [Mantine] — Switches between different views
+- Accordion [Mantine] — Vertically stacked collapsible sections
+- ScrollArea [Mantine] — Container with custom scrollbars
 - ChildForm [Plasma] — Layout pattern for nesting forms
 - StickyFooter [Plasma] — Sticky footer for page bottoms
-- Header [Plasma] — Top navigation bar
-- MainSidenav [Plasma] — Main side navigation
-- ScrollArea [Mantine] — Container with custom scrollbars
-- Tabs [Mantine] — Switches between different views
 
 ## Data display
 
@@ -85,10 +87,7 @@ Resources:
 
 ## Miscellaneous
 
-- ActionBar [Plasma] — Groups actions together
-- Calendar [Mantine] — Visual calendar display
 - Carousel [Mantine] — Slideshow for cycling content
 - Chip [Mantine] — Compact element for filtering or selection
-- ContentSwap [Plasma] — Toggles visible content
 - Modal [Mantine] — Overlay dialog requiring user attention
 - Popover [Mantine] — Floating content near a target element

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -361,7 +361,7 @@ Components used to arrange and structure page content.
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td>Footer</Table.Td>
+            <Table.Td>StickyFooter</Table.Td>
             <Table.Td>Sticky footer pattern for page bottoms.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -20,7 +20,6 @@ The components are sorted into groups by function:
 - [Miscellaneous](#miscellaneous)
 
 <Unstyled>
-    {/* oxfmt-ignore */}
     <Alert.Information title="Related resources" mb="md">
         View the components in the <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-526&p=f&t=LgsAqJbTOuPL7eGh-0">Figma library</a>, or for additional details and links, the <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.
     </Alert.Information>

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -20,14 +20,13 @@ The components are sorted by function into groups:
 - [Miscellaneous](#miscellaneous)
 
 <Unstyled>
-    <Alert.Information title="Related resources" mb="md">
-        You can also view the components in the{' '}
-        <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">
-            Figma library
-        </a>
-        , or for relevant links and resources, the{' '}
-        <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.
-    </Alert.Information>
+<Alert.Information title="Related resources" mb="md">
+    {"View the components in "}
+    <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">Figma</a>
+    {" or the "}
+    <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>
+    {"."}
+</Alert.Information>
 </Unstyled>
 
 ## Call to action and navigation

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -21,7 +21,12 @@ The components are sorted by function into groups:
 
 <Unstyled>
     <Alert.Information title="Related resources" mb="md">
-        You can also view the components in the <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">Figma library</a>, or for relevant links and resources, the <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.
+        You can also view the components in the{' '}
+        <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">
+            Figma library
+        </a>
+        , or for relevant links and resources, the{' '}
+        <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.
     </Alert.Information>
 </Unstyled>
 
@@ -39,42 +44,58 @@ Components used to trigger actions or navigate between views.
     </Table.Thead>
     <Table.Tbody>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/actionicon--demo">ActionIcon</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/actionicon--demo">ActionIcon</a>
+            </Table.Td>
             <Table.Td>Icon-based button for executing actions.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/anchor--demo">Anchor</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/anchor--demo">Anchor</a>
+            </Table.Td>
             <Table.Td>Hyperlink component for navigation.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/breadcrumbs--demo">Breadcrumbs</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/breadcrumbs--demo">Breadcrumbs</a>
+            </Table.Td>
             <Table.Td>Navigation trail indicating the current page location.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/button--demo">Button</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/button--demo">Button</a>
+            </Table.Td>
             <Table.Td>Standard interactive button, including destructive variants.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/closebutton--demo">CloseButton</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/closebutton--demo">CloseButton</a>
+            </Table.Td>
             <Table.Td>Button used to dismiss content like modals and alerts.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/copytoclipboard--demo">CopyToClipboard</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/copytoclipboard--demo">CopyToClipboard</a>
+            </Table.Td>
             <Table.Td>Action component to copy content to the system clipboard.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/navlink--demo">NavLink</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/navlink--demo">NavLink</a>
+            </Table.Td>
             <Table.Td>Navigation link for sidebars or menus, including sections.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/pagination--demo">Pagination</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/pagination--demo">Pagination</a>
+            </Table.Td>
             <Table.Td>Navigation for splitting large datasets into pages.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
@@ -95,42 +116,58 @@ Components used for data entry and user selections.
     </Table.Thead>
     <Table.Tbody>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/checkbox--checkbox-item">Checkbox</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/checkbox--checkbox-item">Checkbox</a>
+            </Table.Td>
             <Table.Td>Selection control for single or multiple items.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/codeeditor--demo">CodeEditor</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/codeeditor--demo">CodeEditor</a>
+            </Table.Td>
             <Table.Td>Specialized input for editing code snippets.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/collection--demo">Collection</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/collection--demo">Collection</a>
+            </Table.Td>
             <Table.Td>Pattern for managing lists or groups of items.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/datepickerinput--demo">DatePickerInput</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/datepickerinput--demo">DatePickerInput</a>
+            </Table.Td>
             <Table.Td>Input field with a dropdown calendar.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/facet--demo">Facet</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/facet--demo">Facet</a>
+            </Table.Td>
             <Table.Td>Filtering pattern for search interfaces.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/monthpickerinput--demo">MonthPickerInput</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/monthpickerinput--demo">MonthPickerInput</a>
+            </Table.Td>
             <Table.Td>Input field for selecting specific months.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/multiselect--demo">MultiSelect</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/multiselect--demo">MultiSelect</a>
+            </Table.Td>
             <Table.Td>Dropdown for selecting multiple options.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/numberinput--demo">NumberInput</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/numberinput--demo">NumberInput</a>
+            </Table.Td>
             <Table.Td>Input field optimized for numerical values.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
@@ -140,52 +177,72 @@ Components used for data entry and user selections.
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/radio--radio-item">Radio</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/radio--radio-item">Radio</a>
+            </Table.Td>
             <Table.Td>Selection control for mutually exclusive options.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/radiocard--demo">RadioCard</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/radiocard--demo">RadioCard</a>
+            </Table.Td>
             <Table.Td>Enhanced radio selection presented as cards.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/segmentedcontrol--demo">SegmentedControl</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/segmentedcontrol--demo">SegmentedControl</a>
+            </Table.Td>
             <Table.Td>Linear set of two or more segments for exclusive choice.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/select--demo">Select</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/select--demo">Select</a>
+            </Table.Td>
             <Table.Td>Dropdown menu for single option selection.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/slider--demo">Slider</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/slider--demo">Slider</a>
+            </Table.Td>
             <Table.Td>Input for selecting a value from a range.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/switch--default">Switch</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/switch--default">Switch</a>
+            </Table.Td>
             <Table.Td>Toggle control for switching between two states.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/textarea--demo">Textarea</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/textarea--demo">Textarea</a>
+            </Table.Td>
             <Table.Td>Multiline text input field.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/textinput--demo">TextInput</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/textinput--demo">TextInput</a>
+            </Table.Td>
             <Table.Td>Single-line text input field.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/timepicker--demo">TimePicker</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/timepicker--demo">TimePicker</a>
+            </Table.Td>
             <Table.Td>Input component for time selection.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/yearpickerinput--demo">YearPickerInput</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/yearpickerinput--demo">YearPickerInput</a>
+            </Table.Td>
             <Table.Td>Input field for selecting specific years.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
@@ -206,47 +263,65 @@ Components that provide visual feedback on system state or user interactions.
     </Table.Thead>
     <Table.Tbody>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/alert--demo">Alert</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/alert--demo">Alert</a>
+            </Table.Td>
             <Table.Td>Shows prominent messages: info, warning, or critical.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/infotoken--demo">InfoToken</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/infotoken--demo">InfoToken</a>
+            </Table.Td>
             <Table.Td>Small visual indicator for contextual information.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/loader--demo">Loader</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/loader--demo">Loader</a>
+            </Table.Td>
             <Table.Td>Animated indicator for loading states.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/notification--demo">Notification</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/notification--demo">Notification</a>
+            </Table.Td>
             <Table.Td>Toast-style messages for updates or errors.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/progress--demo">Progress</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/progress--demo">Progress</a>
+            </Table.Td>
             <Table.Td>Visual bar indicating completion percentage.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/skeleton--demo">Skeleton</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/skeleton--demo">Skeleton</a>
+            </Table.Td>
             <Table.Td>Placeholder preview for content while loading.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/statustoken--demo">StatusToken</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/statustoken--demo">StatusToken</a>
+            </Table.Td>
             <Table.Td>Visual indicator for object status.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/stepper--default">Stepper</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/stepper--default">Stepper</a>
+            </Table.Td>
             <Table.Td>Progress indicator for multi-step workflows.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/tooltip--demo">Tooltip</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/tooltip--demo">Tooltip</a>
+            </Table.Td>
             <Table.Td>Text label shown on hover.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
@@ -267,17 +342,23 @@ Components used to arrange and structure page content.
     </Table.Thead>
     <Table.Tbody>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/accordion--demo">Accordion</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/accordion--demo">Accordion</a>
+            </Table.Td>
             <Table.Td>Vertically stacked headers that reveal content.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/appshell--demo">AppShell</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/appshell--demo">AppShell</a>
+            </Table.Td>
             <Table.Td>Main layout wrapper, including header and navbar.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/childform--demo">ChildForm</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/childform--demo">ChildForm</a>
+            </Table.Td>
             <Table.Td>Layout pattern for nesting forms.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
@@ -287,7 +368,9 @@ Components used to arrange and structure page content.
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/header--demo">Header</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/header--demo">Header</a>
+            </Table.Td>
             <Table.Td>Top navigation bar pattern.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
@@ -297,12 +380,16 @@ Components used to arrange and structure page content.
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/scrollarea--demo">ScrollArea</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/scrollarea--demo">ScrollArea</a>
+            </Table.Td>
             <Table.Td>Container that manages custom scrollbars.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/tabs--demo">Tabs</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/tabs--demo">Tabs</a>
+            </Table.Td>
             <Table.Td>Interface for switching between different views.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
@@ -323,27 +410,37 @@ Components designed to present information to the user.
     </Table.Thead>
     <Table.Tbody>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/badge--demo">Badge</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/badge--demo">Badge</a>
+            </Table.Td>
             <Table.Td>Small label for status, counts, or categories.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/card--demo">Card</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/card--demo">Card</a>
+            </Table.Td>
             <Table.Td>Container for grouping related information.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/image--demo">Image</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/image--demo">Image</a>
+            </Table.Td>
             <Table.Td>Wrapper for displaying images with support.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/pill--demo">Pill</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/pill--demo">Pill</a>
+            </Table.Td>
             <Table.Td>Rounded visual indicator, often used in inputs.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/table--demo">Table</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/table--demo">Table</a>
+            </Table.Td>
             <Table.Td>Rows and columns for structured data.</Table.Td>
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
@@ -369,7 +466,9 @@ Components for text content.
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/kbd--demo">Kbd</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/kbd--demo">Kbd</a>
+            </Table.Td>
             <Table.Td>Visual representation of keyboard inputs.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
@@ -405,7 +504,9 @@ Components and patterns not yet assigned to a specific category.
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/chip--demo">Chip</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/chip--demo">Chip</a>
+            </Table.Td>
             <Table.Td>Compact interactive element for filtering or selection.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
@@ -415,7 +516,9 @@ Components and patterns not yet assigned to a specific category.
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td><a href="?path=/story/modal--demo">Modal</a></Table.Td>
+            <Table.Td>
+                <a href="?path=/story/modal--demo">Modal</a>
+            </Table.Td>
             <Table.Td>Overlay dialog that requires user attention.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -11,10 +11,10 @@ import {Table} from '@mantine/core';
 Most components in the Plasma design system are based on the [Mantine library](https://mantine.dev/core/package/) and some are Plasma-specific, added over time.
 The components are sorted into groups by function:
 
-- [Call to action and navigation](#call-to-action-and-navigation)
+- [Call to action](#call-to-action)
 - [Forms and inputs](#forms-and-inputs)
-- [Feedback and status](#feedback-and-status)
-- [Layout and structure](#layout-and-structure)
+- [Feedback](#feedback)
+- [Layout](#layout)
 - [Data display](#data-display)
 - [Typography](#typography)
 - [Miscellaneous](#miscellaneous)

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -28,7 +28,7 @@ The components are sorted into groups by function:
     </Alert.Information>
 </Unstyled>
 
-## Call to action and navigation
+## Call to action
 
 Components used to trigger actions or navigate between views.
 
@@ -115,51 +115,16 @@ Components used for data entry and user selections.
     <Table.Tbody>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/checkbox--checkbox-item">Checkbox</a>
+                <a href="?path=/story/textinput--demo">TextInput</a>
             </Table.Td>
-            <Table.Td>Selection control for single or multiple items.</Table.Td>
+            <Table.Td>Single-line text input field.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/codeeditor--demo">CodeEditor</a>
+                <a href="?path=/story/textarea--demo">Textarea</a>
             </Table.Td>
-            <Table.Td>Specialized input for editing code snippets.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
-                <a href="?path=/story/collection--demo">Collection</a>
-            </Table.Td>
-            <Table.Td>Pattern for managing lists or groups of items.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
-                <a href="?path=/story/datepickerinput--demo">DatePickerInput</a>
-            </Table.Td>
-            <Table.Td>Input field with a dropdown calendar.</Table.Td>
-            <Table.Td>Mantine</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
-                <a href="?path=/story/facet--demo">Facet</a>
-            </Table.Td>
-            <Table.Td>Filtering pattern for search interfaces.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
-                <a href="?path=/story/monthpickerinput--demo">MonthPickerInput</a>
-            </Table.Td>
-            <Table.Td>Input field for selecting specific months.</Table.Td>
-            <Table.Td>Mantine</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
-                <a href="?path=/story/multiselect--demo">MultiSelect</a>
-            </Table.Td>
-            <Table.Td>Dropdown for selecting multiple options.</Table.Td>
+            <Table.Td>Multiline text input field.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
@@ -170,8 +135,29 @@ Components used for data entry and user selections.
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/select--demo">Select</a>
+            </Table.Td>
+            <Table.Td>Dropdown menu for single option selection.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/multiselect--demo">MultiSelect</a>
+            </Table.Td>
+            <Table.Td>Dropdown for selecting multiple options.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
             <Table.Td>PillsInput</Table.Td>
             <Table.Td>Input that shows selected values as pill tags.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/checkbox--checkbox-item">Checkbox</a>
+            </Table.Td>
+            <Table.Td>Selection control for single or multiple items.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
@@ -190,16 +176,16 @@ Components used for data entry and user selections.
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/segmentedcontrol--demo">SegmentedControl</a>
+                <a href="?path=/story/switch--default">Switch</a>
             </Table.Td>
-            <Table.Td>Linear set of two or more segments for exclusive choice.</Table.Td>
+            <Table.Td>Toggle control for switching between two states.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/select--demo">Select</a>
+                <a href="?path=/story/segmentedcontrol--demo">SegmentedControl</a>
             </Table.Td>
-            <Table.Td>Dropdown menu for single option selection.</Table.Td>
+            <Table.Td>Linear set of two or more segments for exclusive choice.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
@@ -211,23 +197,23 @@ Components used for data entry and user selections.
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/switch--default">Switch</a>
+                <a href="?path=/story/datepickerinput--demo">DatePickerInput</a>
             </Table.Td>
-            <Table.Td>Toggle control for switching between two states.</Table.Td>
+            <Table.Td>Input field with a dropdown calendar.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/textarea--demo">Textarea</a>
+                <a href="?path=/story/monthpickerinput--demo">MonthPickerInput</a>
             </Table.Td>
-            <Table.Td>Multiline text input field.</Table.Td>
+            <Table.Td>Input field for selecting specific months.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/textinput--demo">TextInput</a>
+                <a href="?path=/story/yearpickerinput--demo">YearPickerInput</a>
             </Table.Td>
-            <Table.Td>Single-line text input field.</Table.Td>
+            <Table.Td>Input field for selecting specific years.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
@@ -239,15 +225,29 @@ Components used for data entry and user selections.
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/yearpickerinput--demo">YearPickerInput</a>
+                <a href="?path=/story/codeeditor--demo">CodeEditor</a>
             </Table.Td>
-            <Table.Td>Input field for selecting specific years.</Table.Td>
-            <Table.Td>Mantine</Table.Td>
+            <Table.Td>Specialized input for editing code snippets.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/collection--demo">Collection</a>
+            </Table.Td>
+            <Table.Td>Pattern for managing lists or groups of items.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/facet--demo">Facet</a>
+            </Table.Td>
+            <Table.Td>Filtering pattern for search interfaces.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
         </Table.Tr>
     </Table.Tbody>
 </Table>
 
-## Feedback and status
+## Feedback
 
 Components that provide visual feedback on system state or user interactions.
 
@@ -269,20 +269,6 @@ Components that provide visual feedback on system state or user interactions.
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/infotoken--demo">InfoToken</a>
-            </Table.Td>
-            <Table.Td>Small visual indicator for contextual information.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
-                <a href="?path=/story/loader--demo">Loader</a>
-            </Table.Td>
-            <Table.Td>Animated indicator for loading states.</Table.Td>
-            <Table.Td>Mantine</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
                 <a href="?path=/story/notification--demo">Notification</a>
             </Table.Td>
             <Table.Td>Toast-style messages for updates or errors.</Table.Td>
@@ -290,9 +276,9 @@ Components that provide visual feedback on system state or user interactions.
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/progress--demo">Progress</a>
+                <a href="?path=/story/loader--demo">Loader</a>
             </Table.Td>
-            <Table.Td>Visual bar indicating completion percentage.</Table.Td>
+            <Table.Td>Animated indicator for loading states.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
@@ -304,10 +290,10 @@ Components that provide visual feedback on system state or user interactions.
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/statustoken--demo">StatusToken</a>
+                <a href="?path=/story/progress--demo">Progress</a>
             </Table.Td>
-            <Table.Td>Visual indicator for object status.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
+            <Table.Td>Visual bar indicating completion percentage.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
@@ -323,12 +309,26 @@ Components that provide visual feedback on system state or user interactions.
             <Table.Td>Text label shown on hover.</Table.Td>
             <Table.Td>Mantine</Table.Td>
         </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/infotoken--demo">InfoToken</a>
+            </Table.Td>
+            <Table.Td>Small visual indicator for contextual information.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/statustoken--demo">StatusToken</a>
+            </Table.Td>
+            <Table.Td>Visual indicator for object status.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
     </Table.Tbody>
 </Table>
 
-## Layout and structure
+## Layout
 
-Components used to arrange and structure page content.
+Components used to arrange and structure the page content.
 
 <Table withTableBorder withColumnBorders>
     <Table.Thead>
@@ -341,29 +341,10 @@ Components used to arrange and structure page content.
     <Table.Tbody>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/accordion--demo">Accordion</a>
-            </Table.Td>
-            <Table.Td>Vertically stacked headers that reveal content.</Table.Td>
-            <Table.Td>Mantine</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
                 <a href="?path=/story/appshell--demo">AppShell</a>
             </Table.Td>
             <Table.Td>Main layout wrapper, including header and navbar.</Table.Td>
             <Table.Td>Mantine</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>
-                <a href="?path=/story/childform--demo">ChildForm</a>
-            </Table.Td>
-            <Table.Td>Layout pattern for nesting forms.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>StickyFooter</Table.Td>
-            <Table.Td>Sticky footer pattern for page bottoms.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
@@ -373,9 +354,25 @@ Components used to arrange and structure page content.
             <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
-            <Table.Td>MainSidenav</Table.Td>
+            <Table.Td>
+                <a href="?path=/story/navigation--demo">Navigation</a>
+            </Table.Td>
             <Table.Td>Main side navigation pattern.</Table.Td>
             <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/tabs--demo">Tabs</a>
+            </Table.Td>
+            <Table.Td>Interface for switching between different views.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/accordion--demo">Accordion</a>
+            </Table.Td>
+            <Table.Td>Vertically stacked headers that reveal content.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
@@ -386,10 +383,17 @@ Components used to arrange and structure page content.
         </Table.Tr>
         <Table.Tr>
             <Table.Td>
-                <a href="?path=/story/tabs--demo">Tabs</a>
+                <a href="?path=/story/childform--demo">ChildForm</a>
             </Table.Td>
-            <Table.Td>Interface for switching between different views.</Table.Td>
-            <Table.Td>Mantine</Table.Td>
+            <Table.Td>Layout pattern for nesting forms.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>
+                <a href="?path=/story/stickyfooter--default">StickyFooter</a>
+            </Table.Td>
+            <Table.Td>Sticky footer pattern for page bottoms.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
         </Table.Tr>
     </Table.Tbody>
 </Table>
@@ -487,16 +491,6 @@ Components and patterns not yet assigned to a specific category.
     </Table.Thead>
     <Table.Tbody>
         <Table.Tr>
-            <Table.Td>ActionBar</Table.Td>
-            <Table.Td>Layout pattern for grouping actions.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>Calendar</Table.Td>
-            <Table.Td>Visual calendar display.</Table.Td>
-            <Table.Td>Mantine</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
             <Table.Td>Carousel</Table.Td>
             <Table.Td>Slideshow component for cycling content.</Table.Td>
             <Table.Td>Mantine</Table.Td>
@@ -507,11 +501,6 @@ Components and patterns not yet assigned to a specific category.
             </Table.Td>
             <Table.Td>Compact interactive element for filtering or selection.</Table.Td>
             <Table.Td>Mantine</Table.Td>
-        </Table.Tr>
-        <Table.Tr>
-            <Table.Td>ContentSwap</Table.Td>
-            <Table.Td>Utility for toggling visible content.</Table.Td>
-            <Table.Td>Plasma</Table.Td>
         </Table.Tr>
         <Table.Tr>
             <Table.Td>

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -1,0 +1,431 @@
+import {Meta, Unstyled} from '@storybook/addon-docs/blocks';
+import {Alert} from '@coveord/plasma-mantine';
+import {Table} from '@mantine/core';
+
+<Meta title="@components" id="components-overview" />
+
+# Components
+
+The building blocks used to create interfaces in the Coveo Administration Console.
+
+Most components in the Coveo design system are based on the [Mantine library](https://mantine.dev/core/package/) and some are Plasma-specific, added over time.
+The components are sorted by function into groups:
+
+- [Call to action and navigation](#call-to-action-and-navigation)
+- [Forms and inputs](#forms-and-inputs)
+- [Feedback and status](#feedback-and-status)
+- [Layout and structure](#layout-and-structure)
+- [Data display](#data-display)
+- [Typography](#typography) 
+- [Miscellaneous](#miscellaneous)
+
+<Unstyled>
+    <Alert.Information title="Related resources" mb="md">
+        <ul>
+            <li>See the components in the <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">Figma library</a>.</li>
+            <li>For relevant links and resources, see the <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.</li>
+        </ul>
+    </Alert.Information>
+</Unstyled>
+
+## Call to action and navigation
+
+Components used to trigger actions or navigate between views.
+
+<Table withTableBorder withColumnBorders>
+    <Table.Thead>
+        <Table.Tr>
+            <Table.Th>Component</Table.Th>
+            <Table.Th>Description</Table.Th>
+            <Table.Th>Library origin</Table.Th>
+        </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/actionicon--demo">ActionIcon</a></Table.Td>
+            <Table.Td>Icon-based button for executing actions.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/anchor--demo">Anchor</a></Table.Td>
+            <Table.Td>Hyperlink component for navigation.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/breadcrumbs--demo">Breadcrumbs</a></Table.Td>
+            <Table.Td>Navigation trail indicating the current page location.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/button--demo">Button</a></Table.Td>
+            <Table.Td>Standard interactive button, including destructive variants.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/closebutton--demo">CloseButton</a></Table.Td>
+            <Table.Td>Button used to dismiss content like modals and alerts.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/copytoclipboard--demo">CopyToClipboard</a></Table.Td>
+            <Table.Td>Action component to copy content to the system clipboard.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/navlink--demo">NavLink</a></Table.Td>
+            <Table.Td>Navigation link for sidebars or menus, including sections.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/pagination--demo">Pagination</a></Table.Td>
+            <Table.Td>Navigation for splitting large datasets into pages.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+    </Table.Tbody>
+</Table>
+
+## Forms and inputs
+
+Components used for data entry and user selections.
+
+<Table withTableBorder withColumnBorders>
+    <Table.Thead>
+        <Table.Tr>
+            <Table.Th>Component</Table.Th>
+            <Table.Th>Description</Table.Th>
+            <Table.Th>Library origin</Table.Th>
+        </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/checkbox--checkbox-item">Checkbox</a></Table.Td>
+            <Table.Td>Selection control for single or multiple items.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/codeeditor--demo">CodeEditor</a></Table.Td>
+            <Table.Td>Specialized input for editing code snippets.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/collection--demo">Collection</a></Table.Td>
+            <Table.Td>Pattern for managing lists or groups of items.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/datepickerinput--demo">DatePickerInput</a></Table.Td>
+            <Table.Td>Input field with a dropdown calendar.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/facet--demo">Facet</a></Table.Td>
+            <Table.Td>Filtering pattern for search interfaces.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/monthpickerinput--demo">MonthPickerInput</a></Table.Td>
+            <Table.Td>Input field for selecting specific months.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/multiselect--demo">MultiSelect</a></Table.Td>
+            <Table.Td>Dropdown for selecting multiple options.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/numberinput--demo">NumberInput</a></Table.Td>
+            <Table.Td>Input field optimized for numerical values.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>PillsInput</Table.Td>
+            <Table.Td>Input that shows selected values as pill tags.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/radio--radio-item">Radio</a></Table.Td>
+            <Table.Td>Selection control for mutually exclusive options.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/radiocard--demo">RadioCard</a></Table.Td>
+            <Table.Td>Enhanced radio selection presented as cards.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/segmentedcontrol--demo">SegmentedControl</a></Table.Td>
+            <Table.Td>Linear set of two or more segments for exclusive choice.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/select--demo">Select</a></Table.Td>
+            <Table.Td>Dropdown menu for single option selection.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/slider--demo">Slider</a></Table.Td>
+            <Table.Td>Input for selecting a value from a range.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/switch--default">Switch</a></Table.Td>
+            <Table.Td>Toggle control for switching between two states.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/textarea--demo">Textarea</a></Table.Td>
+            <Table.Td>Multiline text input field.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/textinput--demo">TextInput</a></Table.Td>
+            <Table.Td>Single-line text input field.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/timepicker--demo">TimePicker</a></Table.Td>
+            <Table.Td>Input component for time selection.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/yearpickerinput--demo">YearPickerInput</a></Table.Td>
+            <Table.Td>Input field for selecting specific years.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+    </Table.Tbody>
+</Table>
+
+## Feedback and status
+
+Components that provide visual feedback on system state or user interactions.
+
+<Table withTableBorder withColumnBorders>
+    <Table.Thead>
+        <Table.Tr>
+            <Table.Th>Component</Table.Th>
+            <Table.Th>Description</Table.Th>
+            <Table.Th>Library origin</Table.Th>
+        </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/alert--demo">Alert</a></Table.Td>
+            <Table.Td>Shows prominent messages: info, warning, or critical.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/infotoken--demo">InfoToken</a></Table.Td>
+            <Table.Td>Small visual indicator for contextual information.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/loader--demo">Loader</a></Table.Td>
+            <Table.Td>Animated indicator for loading states.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/notification--demo">Notification</a></Table.Td>
+            <Table.Td>Toast-style messages for updates or errors.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/progress--demo">Progress</a></Table.Td>
+            <Table.Td>Visual bar indicating completion percentage.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/skeleton--demo">Skeleton</a></Table.Td>
+            <Table.Td>Placeholder preview for content while loading.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/statustoken--demo">StatusToken</a></Table.Td>
+            <Table.Td>Visual indicator for object status.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/stepper--default">Stepper</a></Table.Td>
+            <Table.Td>Progress indicator for multi-step workflows.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/tooltip--demo">Tooltip</a></Table.Td>
+            <Table.Td>Text label shown on hover.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+    </Table.Tbody>
+</Table>
+
+## Layout and structure
+
+Components used to arrange and structure page content.
+
+<Table withTableBorder withColumnBorders>
+    <Table.Thead>
+        <Table.Tr>
+            <Table.Th>Component</Table.Th>
+            <Table.Th>Description</Table.Th>
+            <Table.Th>Library origin</Table.Th>
+        </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/accordion--demo">Accordion</a></Table.Td>
+            <Table.Td>Vertically stacked headers that reveal content.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/appshell--demo">AppShell</a></Table.Td>
+            <Table.Td>Main layout wrapper, including header and navbar.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/childform--demo">ChildForm</a></Table.Td>
+            <Table.Td>Layout pattern for nesting forms.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>Footer</Table.Td>
+            <Table.Td>Sticky footer pattern for page bottoms.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/header--demo">Header</a></Table.Td>
+            <Table.Td>Top navigation bar pattern.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>MainSidenav</Table.Td>
+            <Table.Td>Main side navigation pattern.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/scrollarea--demo">ScrollArea</a></Table.Td>
+            <Table.Td>Container that manages custom scrollbars.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/tabs--demo">Tabs</a></Table.Td>
+            <Table.Td>Interface for switching between different views.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+    </Table.Tbody>
+</Table>
+
+## Data display
+
+Components designed to present information to the user.
+
+<Table withTableBorder withColumnBorders>
+    <Table.Thead>
+        <Table.Tr>
+            <Table.Th>Component</Table.Th>
+            <Table.Th>Description</Table.Th>
+            <Table.Th>Library origin</Table.Th>
+        </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/badge--demo">Badge</a></Table.Td>
+            <Table.Td>Small label for status, counts, or categories.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/card--demo">Card</a></Table.Td>
+            <Table.Td>Container for grouping related information.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/image--demo">Image</a></Table.Td>
+            <Table.Td>Wrapper for displaying images with support.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/pill--demo">Pill</a></Table.Td>
+            <Table.Td>Rounded visual indicator, often used in inputs.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/table--demo">Table</a></Table.Td>
+            <Table.Td>Rows and columns for structured data.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+    </Table.Tbody>
+</Table>
+
+## Typography
+
+Components for text content.
+
+<Table withTableBorder withColumnBorders>
+    <Table.Thead>
+        <Table.Tr>
+            <Table.Th>Component</Table.Th>
+            <Table.Th>Description</Table.Th>
+            <Table.Th>Library origin</Table.Th>
+        </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+        <Table.Tr>
+            <Table.Td>Code</Table.Td>
+            <Table.Td>Inline or block display for code snippets.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/kbd--demo">Kbd</a></Table.Td>
+            <Table.Td>Visual representation of keyboard inputs.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+    </Table.Tbody>
+</Table>
+
+## Miscellaneous
+
+Components and patterns not yet assigned to a specific category.
+
+<Table withTableBorder withColumnBorders>
+    <Table.Thead>
+        <Table.Tr>
+            <Table.Th>Component</Table.Th>
+            <Table.Th>Description</Table.Th>
+            <Table.Th>Library origin</Table.Th>
+        </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+        <Table.Tr>
+            <Table.Td>ActionBar</Table.Td>
+            <Table.Td>Layout pattern for grouping actions.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>Calendar</Table.Td>
+            <Table.Td>Visual calendar display.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>Carousel</Table.Td>
+            <Table.Td>Slideshow component for cycling content.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/chip--demo">Chip</a></Table.Td>
+            <Table.Td>Compact interactive element for filtering or selection.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>ContentSwap</Table.Td>
+            <Table.Td>Utility for toggling visible content.</Table.Td>
+            <Table.Td>Plasma</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td><a href="?path=/story/modal--demo">Modal</a></Table.Td>
+            <Table.Td>Overlay dialog that requires user attention.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+            <Table.Td>Popover</Table.Td>
+            <Table.Td>Floating content shown near a target element.</Table.Td>
+            <Table.Td>Mantine</Table.Td>
+        </Table.Tr>
+    </Table.Tbody>
+</Table>

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -21,7 +21,10 @@ The components are sorted into groups by function:
 
 <Unstyled>
     <Alert.Information title="Related resources" mb="md">
-        View the components in the <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-526&p=f&t=LgsAqJbTOuPL7eGh-0">Figma library</a>, or for additional details and links, the <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.
+        View the components in the [Figma
+        library](https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-526&p=f&t=LgsAqJbTOuPL7eGh-0),
+        or for additional details and links, the [Confluence
+        Database](https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512).
     </Alert.Information>
 </Unstyled>
 

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -20,13 +20,15 @@ The components are sorted by function into groups:
 - [Miscellaneous](#miscellaneous)
 
 <Unstyled>
-<Alert.Information title="Related resources" mb="md">
-    {"View the components in "}
-    <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">Figma</a>
-    {" or the "}
-    <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>
-    {"."}
-</Alert.Information>
+    <Alert.Information title="Related resources" mb="md">
+        {'View the components in '}
+        <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">
+            Figma
+        </a>
+        {' or the '}
+        <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>
+        {'.'}
+    </Alert.Information>
 </Unstyled>
 
 ## Call to action and navigation

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -1,12 +1,12 @@
 import {Meta, Unstyled} from '@storybook/addon-docs/blocks';
-import {Alert} from '@coveord/plasma-mantine';
+import {Alert, Header} from '@coveord/plasma-mantine';
 import {Table} from '@mantine/core';
 
-<Meta title="@components" id="components-overview" />
+<Meta title="@components/Overview" id="components-overview" />
 
-# Components
-
-The building blocks used to create interfaces in the Coveo Administration Console.
+<Header p={0} description="The building blocks used to create interfaces in the Coveo Administration Console.">
+    Components
+</Header>
 
 Most components in the Coveo design system are based on the [Mantine library](https://mantine.dev/core/package/) and some are Plasma-specific, added over time.
 The components are sorted by function into groups:
@@ -16,15 +16,12 @@ The components are sorted by function into groups:
 - [Feedback and status](#feedback-and-status)
 - [Layout and structure](#layout-and-structure)
 - [Data display](#data-display)
-- [Typography](#typography) 
+- [Typography](#typography)
 - [Miscellaneous](#miscellaneous)
 
 <Unstyled>
     <Alert.Information title="Related resources" mb="md">
-        <ul>
-            <li>See the components in the <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">Figma library</a>.</li>
-            <li>For relevant links and resources, see the <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.</li>
-        </ul>
+        You can also view the components in the <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">Figma library</a>, or for relevant links and resources, the <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.
     </Alert.Information>
 </Unstyled>
 

--- a/packages/storybook/src/components/ComponentsOverview.mdx
+++ b/packages/storybook/src/components/ComponentsOverview.mdx
@@ -8,8 +8,8 @@ import {Table} from '@mantine/core';
     Components
 </Header>
 
-Most components in the Coveo design system are based on the [Mantine library](https://mantine.dev/core/package/) and some are Plasma-specific, added over time.
-The components are sorted by function into groups:
+Most components in the Plasma design system are based on the [Mantine library](https://mantine.dev/core/package/) and some are Plasma-specific, added over time.
+The components are sorted into groups by function:
 
 - [Call to action and navigation](#call-to-action-and-navigation)
 - [Forms and inputs](#forms-and-inputs)
@@ -20,14 +20,9 @@ The components are sorted by function into groups:
 - [Miscellaneous](#miscellaneous)
 
 <Unstyled>
+    {/* oxfmt-ignore */}
     <Alert.Information title="Related resources" mb="md">
-        {'View the components in '}
-        <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-836&p=f&t=RQEKGXIiw1gRK3St-0">
-            Figma
-        </a>
-        {' or the '}
-        <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>
-        {'.'}
+        View the components in the <a href="https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma---Components?node-id=3156-526&p=f&t=LgsAqJbTOuPL7eGh-0">Figma library</a>, or for additional details and links, the <a href="https://coveord.atlassian.net/wiki/spaces/dsys/database/5936873512">Confluence Database</a>.
     </Alert.Information>
 </Unstyled>
 


### PR DESCRIPTION
### Purpose:
This pull request introduces an overview for components, reflecting Sam's [Components](https://coveord.atlassian.net/wiki/x/O4B_YwE) article. This is one part of the goal of moving the necessary Confluence docs to Storybook.

### Jira ticket: [DS-678](https://coveord.atlassian.net/browse/DS-678)

### Target audience:
**Coveo users:**
- [x] Developers (DS)
- [x] Designers (DS)
- [x] Writers (DS, Docs)
- [x] Other teams
- [x] AI agents

**Non-Coveo users:**
- [ ] Administration Console

### Changes:
* Added a new `ComponentsOverview.mdx` file to the `packages/storybook/src/components/` directory, listing all Plasma and Mantine UI components, grouped by function (e.g., navigation, forms, feedback, layout, data display, typography, miscellaneous), including links to Figma and Confluence resources. 
* Added a `ComponentsOverview.md` version to the `packages/llms/src/components/` directory for agents.

### Demos:

[Components overview](https://ds-678-confluence-docs--69e1126f9e24a5e560359ac2.chromatic.com/?path=/docs/components-overview--docs)

[DS-678]: https://coveord.atlassian.net/browse/DS-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
