### PR TITLE
chore: add missing exports for the Table component

### DIFF
--- a/.changeset/calm-foxes-dream.md
+++ b/.changeset/calm-foxes-dream.md
@@ -1,0 +1,7 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Add missing `Table` exports
+
+Some `Table` interfaces were missing from the public API. This commit adds them and exports them from `@coveord/plasma-mantine` for external use.

--- a/.changeset/gentle-badgers-jump.md
+++ b/.changeset/gentle-badgers-jump.md
@@ -1,0 +1,7 @@
+---
+'@coveord/plasma-mantine': minor
+---
+
+Add Mantine-style `Table` type aliases
+
+`Table` and its factory-backed compound components expose `Props`, `StylesNames`, and `Factory` namespace aliases with matching named type exports.

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -71,7 +71,7 @@ Important states include:
 
 ## Props
 
-> Extends: `BoxProps & StylesApiProps<PlasmaTableFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+> Extends: `BoxProps & StylesApiProps<TableFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
 **`store`** `TableStore<TData>` · required · default: `undefined` — You MUST pass the table store returned by `useTable`.
 **`data`** `TData[] | null` · required · default: `undefined` — Data to display in the table. You MUST use `null` when the table is initially loading.

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import {Box, Center, Factory, Loader, useProps, useStyles} from '@mantine/core';
+import {Box, Center, Factory, Loader, type SkeletonProps, useProps, useStyles} from '@mantine/core';
 import {useClickOutside, useMergedRef} from '@mantine/hooks';
 import {
     ColumnDef,
@@ -13,35 +13,77 @@ import isEqual from 'fast-deep-equal';
 import {Children, ForwardedRef, ReactElement, useEffect, useRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../utils/createFactoryComponent.js';
 import {TableLayouts} from './layouts/TableLayouts.js';
-import {TableActionItem, TableActionItemStylesNames} from './table-actions/TableActionItem.js';
-import {TableActionsListStylesNames} from './table-actions/TableActionsList.js';
-import {TableHeaderActionsStylesNames} from './table-actions/TableHeaderActions.js';
-import {TableCell} from './table-cell/TableCell.js';
+import {
+    TableActionItem,
+    type TableActionItemFactory,
+    type TableActionItemProps,
+    type TableActionItemStylesNames,
+} from './table-actions/TableActionItem.js';
+import {type TableActionsListStylesNames} from './table-actions/TableActionsList.js';
+import {type TableHeaderActionsStylesNames} from './table-actions/TableHeaderActions.js';
+import {
+    TableCell,
+    type TableCellFactory,
+    type TableCellProps,
+    type TableCellStylesNames,
+} from './table-cell/TableCell.js';
 import {TableActionsColumn} from './table-column/TableActionsColumn.js';
 import {
     TableAccordionColumn,
     TableCollapsibleColumn,
-    TableCollapsibleColumnStylesNames,
+    type TableCollapsibleColumnStylesNames,
 } from './table-column/TableCollapsibleColumn.js';
 import {TableSelectableColumn} from './table-column/TableSelectableColumn.js';
-import {TableDateRangePicker, TableDateRangePickerStylesNames} from './table-date-range-picker/TableDateRangePicker.js';
-import {TableFilter, TableFilterStylesNames} from './table-filter/TableFilter.js';
-import {TableFooter} from './table-footer/TableFooter.js';
-import {TableHeader, TableHeaderStylesNames} from './table-header/TableHeader.js';
-import {TableThStylesNames} from './table-header/Th.js';
-import {TableLastUpdated, TableLastUpdatedStylesNames} from './table-last-updated/TableLastUpdated.js';
+import {
+    TableDateRangePicker,
+    type TableDateRangePickerFactory,
+    type TableDateRangePickerProps,
+    type TableDateRangePickerStylesNames,
+} from './table-date-range-picker/TableDateRangePicker.js';
+import {
+    TableFilter,
+    type TableFilterFactory,
+    type TableFilterProps,
+    type TableFilterStylesNames,
+} from './table-filter/TableFilter.js';
+import {TableFooter, type TableFooterProps} from './table-footer/TableFooter.js';
+import {
+    TableHeader,
+    type TableHeaderFactory,
+    type TableHeaderProps,
+    type TableHeaderStylesNames,
+} from './table-header/TableHeader.js';
+import {type TableThStylesNames} from './table-header/Th.js';
+import {
+    TableLastUpdated,
+    type TableLastUpdatedFactory,
+    type TableLastUpdatedProps,
+    type TableLastUpdatedStylesNames,
+} from './table-last-updated/TableLastUpdated.js';
 import {TableLoading} from './table-loading/TableLoading.js';
-import {TableNoData} from './table-no-data/TableNoData.js';
+import {TableNoData, type TableNoDataProps} from './table-no-data/TableNoData.js';
 import {TablePagination} from './table-pagination/TablePagination.js';
+import {type TablePaginationProps} from './table-pagination/TablePagination.types.js';
 import {TablePerPage} from './table-per-page/TablePerPage.js';
-import {TablePredicate, TablePredicateStylesNames} from './table-predicate/TablePredicate.js';
-import {TableToolbar, TableToolbarStylesNames} from './table-toolbar/TableToolbar.js';
+import {type TablePerPageProps} from './table-per-page/TablePerPage.types.js';
+import {
+    TablePredicate,
+    type TablePredicateFactory,
+    type TablePredicateProps,
+    type TablePredicateStylesNames,
+} from './table-predicate/TablePredicate.js';
+import {
+    TableToolbar,
+    type TableToolbarFactory,
+    type TableToolbarProps,
+    type TableToolbarStylesNames,
+} from './table-toolbar/TableToolbar.js';
 import classes from './Table.module.css';
-import {TableLayout, TableProps} from './Table.types.js';
+import {type TableLayout, type TableProps} from './Table.types.js';
 import {TableProvider} from './TableContext.js';
 import {TableState} from './use-table.js';
 
-type TableStylesNames =
+export type TableStylesNames =
     | 'root'
     | 'table'
     | 'header'
@@ -82,6 +124,8 @@ export type PlasmaTableFactory = Factory<{
         Toolbar: typeof TableToolbar;
     };
 }>;
+
+export type TableFactory = PlasmaTableFactory;
 
 const defaultProps = {
     layouts: [TableLayouts.Rows as TableLayout],
@@ -399,3 +443,77 @@ Table.Predicate = TablePredicate;
 Table.Toolbar = TableToolbar;
 
 Table.extend = identity as CustomComponentThemeExtend<PlasmaTableFactory>;
+
+export namespace Table {
+    export type Props<TData> = TableProps<TData>;
+    export type StylesNames = TableStylesNames;
+    export type Factory = TableFactory;
+
+    export namespace ActionItem {
+        export type Props = TableActionItemProps;
+        export type StylesNames = TableActionItemStylesNames;
+        export type Factory = TableActionItemFactory;
+    }
+
+    export namespace Cell {
+        export type Props = TableCellProps;
+        export type StylesNames = TableCellStylesNames;
+        export type Factory = TableCellFactory;
+    }
+
+    export namespace DateRangePicker {
+        export type Props = TableDateRangePickerProps;
+        export type StylesNames = TableDateRangePickerStylesNames;
+        export type Factory = TableDateRangePickerFactory;
+    }
+
+    export namespace Filter {
+        export type Props = TableFilterProps;
+        export type StylesNames = TableFilterStylesNames;
+        export type Factory = TableFilterFactory;
+    }
+
+    export namespace Footer {
+        export type Props = TableFooterProps;
+    }
+
+    export namespace Header {
+        export type Props = TableHeaderProps;
+        export type StylesNames = TableHeaderStylesNames;
+        export type Factory = TableHeaderFactory;
+    }
+
+    export namespace LastUpdated {
+        export type Props = TableLastUpdatedProps;
+        export type StylesNames = TableLastUpdatedStylesNames;
+        export type Factory = TableLastUpdatedFactory;
+    }
+
+    export namespace Loading {
+        export type Props = SkeletonProps;
+    }
+
+    export namespace NoData {
+        export type Props = TableNoDataProps;
+    }
+
+    export namespace Pagination {
+        export type Props = TablePaginationProps;
+    }
+
+    export namespace PerPage {
+        export type Props = TablePerPageProps;
+    }
+
+    export namespace Predicate {
+        export type Props = TablePredicateProps;
+        export type StylesNames = TablePredicateStylesNames;
+        export type Factory = TablePredicateFactory;
+    }
+
+    export namespace Toolbar {
+        export type Props = TableToolbarProps;
+        export type StylesNames = TableToolbarStylesNames;
+        export type Factory = TableToolbarFactory;
+    }
+}

--- a/packages/mantine/src/components/Table/table-actions/TableActionItem.tsx
+++ b/packages/mantine/src/components/Table/table-actions/TableActionItem.tsx
@@ -22,7 +22,7 @@ export interface TableActionItemProps
     leftSection?: ReactNode;
 }
 
-type TableActionItemFactory = PolymorphicFactory<{
+export type TableActionItemFactory = PolymorphicFactory<{
     props: TableActionItemProps;
     defaultRef: HTMLButtonElement;
     defaultComponent: 'button';

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -397,15 +397,59 @@ export * from './components/Switch/Switch.js';
 
 // Table - override Mantine Table
 export {flexRender as renderTableCell} from '@tanstack/react-table';
+export {
+    type TableActionItemFactory,
+    type TableActionItemProps,
+    type TableActionItemStylesNames,
+} from './components/Table/table-actions/TableActionItem.js';
 export {TableActionsColumn} from './components/Table/table-column/TableActionsColumn.js';
+export {type TableActionsColumnMeta} from './components/Table/table-column/TableActionsColumn.js';
 export {
     type TableCellProps,
     type TableCellFactory,
     type TableCellStylesNames,
 } from './components/Table/table-cell/TableCell.js';
-export {type TablePredicateProps} from './components/Table/table-predicate/TablePredicate.js';
-export {type TableToolbarProps} from './components/Table/table-toolbar/TableToolbar.js';
-export {Table, TableComponentsOrder, type PlasmaTableFactory} from './components/Table/Table.js';
+export {
+    type TableDateRangePickerFactory,
+    type TableDateRangePickerProps,
+    type TableDateRangePickerStylesNames,
+} from './components/Table/table-date-range-picker/TableDateRangePicker.js';
+export {
+    type TableFilterFactory,
+    type TableFilterProps,
+    type TableFilterStylesNames,
+} from './components/Table/table-filter/TableFilter.js';
+export {type TableFooterProps} from './components/Table/table-footer/TableFooter.js';
+export {
+    type TableHeaderFactory,
+    type TableHeaderProps,
+    type TableHeaderStylesNames,
+} from './components/Table/table-header/TableHeader.js';
+export {
+    type TableLastUpdatedFactory,
+    type TableLastUpdatedProps,
+    type TableLastUpdatedStylesNames,
+} from './components/Table/table-last-updated/TableLastUpdated.js';
+export {type TableNoDataProps} from './components/Table/table-no-data/TableNoData.js';
+export {type TablePaginationProps} from './components/Table/table-pagination/TablePagination.types.js';
+export {type TablePerPageProps} from './components/Table/table-per-page/TablePerPage.types.js';
+export {
+    type TablePredicateFactory,
+    type TablePredicateProps,
+    type TablePredicateStylesNames,
+} from './components/Table/table-predicate/TablePredicate.js';
+export {
+    type TableToolbarFactory,
+    type TableToolbarProps,
+    type TableToolbarStylesNames,
+} from './components/Table/table-toolbar/TableToolbar.js';
+export {
+    Table,
+    TableComponentsOrder,
+    type PlasmaTableFactory,
+    type TableFactory,
+    type TableStylesNames,
+} from './components/Table/Table.js';
 export {
     type TableAction,
     type TableLayout,


### PR DESCRIPTION
### Proposed Changes

Add missing type exports for the Table component.
Add Mantine style namespace exports so consumer can leverage `.Props`, e.g., `Table.Header.Props` instead of importing `TableHeaderProps`

### Potential Breaking Changes

None, adding exports
