### PR TITLE
feat(mantine): add namespace type alias to components

### DIFF
--- a/.changeset/gentle-badgers-jump.md
+++ b/.changeset/gentle-badgers-jump.md
@@ -1,7 +1,0 @@
----
-'@coveord/plasma-mantine': minor
----
-
-Add Mantine-style `Table` type aliases
-
-`Table` and its factory-backed compound components expose `Props`, `StylesNames`, and `Factory` namespace aliases with matching named type exports.

--- a/.changeset/gentle-lions-sing.md
+++ b/.changeset/gentle-lions-sing.md
@@ -1,0 +1,8 @@
+---
+'@coveord/plasma-mantine': minor
+'@coveord/plasma-llms': patch
+---
+
+Add component namespace type aliases
+
+Components expose type-only `Props`, `StylesNames`, `CssVariables`, and `Factory` aliases for public, resolvable types. Compound component aliases are available only through their parent namespace paths and add no runtime properties.

--- a/.github/skills/plasma-component-docs/references/format.md
+++ b/.github/skills/plasma-component-docs/references/format.md
@@ -50,6 +50,22 @@ description: One-sentence description used in llms.txt index.  ← REQUIRED
 
 ---
 
+## TypeScript namespace aliases
+
+When a component exposes generated Mantine-style type aliases, document them in this optional section after `Props` and `Sub-components`, and before `Usage`. State that aliases are type-only and list only aliases that the component actually exposes. List a resolvable compound child's aliases only through its qualifying parent namespace (for example, `Modal.Footer.Props`), never as standalone child aliases.
+
+```markdown
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Component.Props`
+- `Component.StylesNames`
+- `Component.Factory`
+```
+
+---
+
 ## Usage section
 
 MUST appear after all other sections (Props, Sub-components) and before the footer link. MUST show the most common real-world usage as a self-contained `tsx` snippet. SHOULD use Plasma sub-components where they exist. MAY include 2–3 examples for components with multiple important patterns (e.g. async click, disabled state). MUST NOT be exhaustive — the Props table covers the full API.

--- a/packages/llms/src/components/ActionIcon.md
+++ b/packages/llms/src/components/ActionIcon.md
@@ -81,6 +81,15 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 - `ActionIcon.DestructiveTertiary`
 - `ActionIcon.DestructiveQuaternary`
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `ActionIcon.Props`
+- `ActionIcon.StylesNames`
+- `ActionIcon.CssVariables`
+- `ActionIcon.{Primary, Secondary, Tertiary, Quaternary, DestructivePrimary, DestructiveSecondary, DestructiveTertiary, DestructiveQuaternary}.Props`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/ActionIcon.md
+++ b/packages/llms/src/components/ActionIcon.md
@@ -88,6 +88,7 @@ These type-only aliases are available for annotations and do not add runtime sta
 - `ActionIcon.Props`
 - `ActionIcon.StylesNames`
 - `ActionIcon.CssVariables`
+- `ActionIcon.Factory`
 - `ActionIcon.{Primary, Secondary, Tertiary, Quaternary, DestructivePrimary, DestructiveSecondary, DestructiveTertiary, DestructiveQuaternary}.Props`
 
 ## Usage

--- a/packages/llms/src/components/Alert.md
+++ b/packages/llms/src/components/Alert.md
@@ -70,6 +70,15 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 - `Alert.Critical`
 - `Alert.Success`
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Alert.Props`
+- `Alert.StylesNames`
+- `Alert.CssVariables`
+- `Alert.{Information, Advice, Warning, Critical, Success}.Props`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/Alert.md
+++ b/packages/llms/src/components/Alert.md
@@ -77,6 +77,7 @@ These type-only aliases are available for annotations and do not add runtime sta
 - `Alert.Props`
 - `Alert.StylesNames`
 - `Alert.CssVariables`
+- `Alert.Factory`
 - `Alert.{Information, Advice, Warning, Critical, Success}.Props`
 
 ## Usage

--- a/packages/llms/src/components/Badge.md
+++ b/packages/llms/src/components/Badge.md
@@ -82,6 +82,7 @@ These type-only aliases are available for annotations and do not add runtime sta
 - `Badge.Props`
 - `Badge.StylesNames`
 - `Badge.CssVariables`
+- `Badge.Factory`
 - `Badge.{Primary, Secondary, Success, Warning, Critical, Disabled}.Props`
 
 ## Usage

--- a/packages/llms/src/components/Badge.md
+++ b/packages/llms/src/components/Badge.md
@@ -75,6 +75,15 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 - `Badge.Critical`
 - `Badge.Disabled`
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Badge.Props`
+- `Badge.StylesNames`
+- `Badge.CssVariables`
+- `Badge.{Primary, Secondary, Success, Warning, Critical, Disabled}.Props`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/BrowserPreview.md
+++ b/packages/llms/src/components/BrowserPreview.md
@@ -54,6 +54,12 @@ Do not use `BrowserPreview` when:
 **`headerTooltip`** `string` · optional · default: `undefined` — Text displayed in a tooltip in the header.
 **`title`** `string` · optional · default: `undefined` — Custom title displayed at the center of the header.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `BrowserPreview.Props`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/Button.md
+++ b/packages/llms/src/components/Button.md
@@ -98,6 +98,7 @@ These type-only aliases are available for annotations and do not add runtime sta
 - `Button.Props`
 - `Button.StylesNames`
 - `Button.CssVariables`
+- `Button.Factory`
 - `Button.{Primary, Secondary, Tertiary, Quaternary, DestructivePrimary, DestructiveSecondary, DestructiveTertiary, DestructiveQuaternary}.Props`
 
 ## Usage

--- a/packages/llms/src/components/Button.md
+++ b/packages/llms/src/components/Button.md
@@ -91,6 +91,15 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 - `Button.DestructiveTertiary`
 - `Button.DestructiveQuaternary`
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Button.Props`
+- `Button.StylesNames`
+- `Button.CssVariables`
+- `Button.{Primary, Secondary, Tertiary, Quaternary, DestructivePrimary, DestructiveSecondary, DestructiveTertiary, DestructiveQuaternary}.Props`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/ChildForm.md
+++ b/packages/llms/src/components/ChildForm.md
@@ -59,6 +59,13 @@ Do not use `ChildForm` when:
 **`title`** `string` · optional · default: `undefined` — MAY define the title of the child form.
 **`description`** `ReactNode` · optional · default: `undefined` — MAY define the description of the child form.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `ChildForm.Props`
+- `ChildForm.StylesNames`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/ChildForm.md
+++ b/packages/llms/src/components/ChildForm.md
@@ -65,6 +65,7 @@ These type-only aliases are available for annotations and do not add runtime sta
 
 - `ChildForm.Props`
 - `ChildForm.StylesNames`
+- `ChildForm.Factory`
 
 ## Usage
 

--- a/packages/llms/src/components/Collection.md
+++ b/packages/llms/src/components/Collection.md
@@ -95,6 +95,14 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 
 - `Collection.Layouts`
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Collection.Props<T>`
+- `Collection.StylesNames`
+- `Collection.Factory`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/CopyToClipboard.md
+++ b/packages/llms/src/components/CopyToClipboard.md
@@ -59,6 +59,12 @@ Do not use `CopyToClipboard` when:
 **`tooltipLabelCopy`** `string` · optional · default: `Copy to clipboard` — The tooltip displays this text when hovering over the button.
 **`tooltipLabelCopied`** `string` · optional · default: `Copied` — The tooltip displays this text when the value is copied to the clipboard.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `CopyToClipboard.Props`
+
 ## Usage
 
 Use `CopyToClipboard` in the `rightSection` of a read-only input when users need to quickly copy values like API keys, tokens, or IDs.

--- a/packages/llms/src/components/DateRangePicker.md
+++ b/packages/llms/src/components/DateRangePicker.md
@@ -1,0 +1,50 @@
+---
+name: DateRangePicker
+description: Date range picker with an input trigger, inline calendar, presets, and optional URL synchronization.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`DateRangePicker` lets users select a start and end date from a popover calendar while retaining optional presets and controlled or uncontrolled state.
+
+## Props
+
+> Extends: `BoxProps`, selected `DateRangePickerInlineCalendarProps`, selected `PopoverProps`, and `StylesApiProps<DateRangePickerFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+
+**`onClick`** `() => void` · optional · default: `undefined` — Called when the target input is clicked.
+**`onCancel`** `() => void` · optional · default: `undefined` — Called when the cancel button is clicked.
+**`onChange`** `(dates: DatesRangeValue<string>) => void` · optional · default: `undefined` — Called when the date range changes.
+**`onOpenedChange`** `(opened: boolean) => void` · optional · default: `undefined` — Called when the popover open state changes.
+**`formatter`** `(time: dayjs.ConfigType) => string` · optional · default: `(time) => dayjs(time).format('MMM D, YYYY')` — Formats the displayed date values.
+**`placeholder`** `string` · optional · default: `'Select date range'` — Label displayed when no date range is selected.
+**`defaultValue`** `DatesRangeValue<string>` · optional · default: `undefined` — Initial value for uncontrolled usage.
+**`value`** `DatesRangeValue<string>` · optional · default: `undefined` — Controlled date range value.
+**`syncWithUrl`** `boolean` · optional · default: `undefined` — Syncs selected dates to URL query parameters.
+**`error`** `string` · optional · default: `undefined` — Error message displayed with the input.
+
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `DateRangePicker.Props`
+- `DateRangePicker.StylesNames`
+- `DateRangePicker.Factory`
+
+## Usage
+
+```tsx
+import {DateRangePicker} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+export function Example() {
+    const [value, setValue] = useState<[string | null, string | null]>([null, null]);
+
+    return <DateRangePicker value={value} onChange={setValue} />;
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/EllipsisText.md
+++ b/packages/llms/src/components/EllipsisText.md
@@ -56,6 +56,13 @@ Do not use `EllipsisText` when:
 **`lineClamp`** `TextProps['lineClamp']` · optional · default: `undefined` — Consumers MAY set this line clamp for multi-line truncation; when omitted, the component uses single-line ellipsis behavior.
 **`tooltipProps`** `Partial<Omit<TooltipProps, 'label' | 'opened' | 'children'>>` · optional · default: `{}` — Consumers MAY customize the internal Mantine `Tooltip`, but MUST NOT provide `label`, `opened`, or `children`.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `EllipsisText.Props`
+- `EllipsisText.StylesNames`
+
 ## Usage
 
 Use `EllipsisText` to truncate long text inside a constrained container. The most common use case is a single-line label that shows the full value on hover when it overflows.

--- a/packages/llms/src/components/EllipsisText.md
+++ b/packages/llms/src/components/EllipsisText.md
@@ -62,6 +62,7 @@ These type-only aliases are available for annotations and do not add runtime sta
 
 - `EllipsisText.Props`
 - `EllipsisText.StylesNames`
+- `EllipsisText.Factory`
 
 ## Usage
 

--- a/packages/llms/src/components/Facet.md
+++ b/packages/llms/src/components/Facet.md
@@ -86,6 +86,14 @@ Important states include:
 **`limit`** `number` · optional · default: `Infinity` — Limit amount of items showed at a time.
 **`hideSearch`** `boolean` · optional · default: `data.length <= 7` — This prop controls whether the search input is displayed.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Facet.Props`
+- `Facet.StylesNames`
+- `Facet.Factory`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/Header.md
+++ b/packages/llms/src/components/Header.md
@@ -75,6 +75,7 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 These type-only aliases are available for annotations and do not add runtime static properties.
 
 - `Header.Props`
+- `Header.StylesNames`
 - `Header.Factory`
 - `Header.Breadcrumbs.Props`
 - `Header.Right.Props`

--- a/packages/llms/src/components/Header.md
+++ b/packages/llms/src/components/Header.md
@@ -70,6 +70,16 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 - `Header.Right`
 - `Header.DocAnchor`
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Header.Props`
+- `Header.Factory`
+- `Header.Breadcrumbs.Props`
+- `Header.Right.Props`
+- `Header.DocAnchor.Props`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/Input.md
+++ b/packages/llms/src/components/Input.md
@@ -79,6 +79,16 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 
 **`children`** `ReactNode` · required · default: `undefined` — The tooltip content to display.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Input.Props`
+- `Input.Factory`
+- `Input.LabelInfo.Props`
+- `Input.LabelInfo.StylesNames`
+- `Input.LabelInfo.Factory`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/LastUpdated.md
+++ b/packages/llms/src/components/LastUpdated.md
@@ -56,6 +56,14 @@ Do not use `LastUpdated` when:
 **`time`** `dayjs.ConfigType` · optional · default: `dayjs().valueOf()` — The unformatted time to display, parsed by dayjs when possible.
 **`label`** `string` · optional · default: `'Last update:'` — Label that SHOULD contextualize the time.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `LastUpdated.Props`
+- `LastUpdated.StylesNames`
+- `LastUpdated.Factory`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/Modal.md
+++ b/packages/llms/src/components/Modal.md
@@ -70,6 +70,16 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 - `Modal.Stack`
 - `Modal.Footer`
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Modal.Props`
+- `Modal.StylesNames`
+- `Modal.CssVariables`
+- `Modal.Factory`
+- `Modal.Footer.{Props, StylesNames, Factory}`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/Navigation.md
+++ b/packages/llms/src/components/Navigation.md
@@ -59,6 +59,16 @@ The Navigation component uses three CSS custom properties for accent colors. Con
 
 If not defined, the defaults are teal-based (matching the Administration Console theme).
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Navigation.Props`
+- `Navigation.SideBar.Props`
+- `Navigation.Link.Props`
+- `Navigation.Toggle.Props`
+- `Navigation.Badge.Props`
+
 ## Usage
 
 The `Navigation` provider MUST wrap `AppShell` so that the shell can read the collapsed state. Use a component inside `Navigation` that calls `useNavigation()` to pass the collapsed state to `AppShell`.

--- a/packages/llms/src/components/PrerequisitesList.md
+++ b/packages/llms/src/components/PrerequisitesList.md
@@ -19,6 +19,13 @@ description: Displays a list of prerequisites with status indicators (complete, 
 **`label`** `string` · required — The text content of the prerequisite.
 **`description`** `string` · optional · default: `undefined` — Optional description text displayed below the label in a smaller, dimmed font.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `PrerequisitesList.Props`
+- `PrerequisitesList.Factory`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/Prompt.md
+++ b/packages/llms/src/components/Prompt.md
@@ -71,6 +71,22 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 - `Prompt.CancelButton`
 - `Prompt.ConfirmButton`
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Prompt.Props`
+- `Prompt.StylesNames`
+- `Prompt.CssVariables`
+- `Prompt.Factory`
+- `Prompt.Information.Props`
+- `Prompt.Success.Props`
+- `Prompt.Warning.Props`
+- `Prompt.Critical.Props`
+- `Prompt.Footer.Props`
+- `Prompt.CancelButton.Props`
+- `Prompt.ConfirmButton.Props`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/RadioCard.md
+++ b/packages/llms/src/components/RadioCard.md
@@ -66,6 +66,15 @@ Important states include:
 **`readOnly`** `boolean` · optional · default: `undefined` — When `true`, the card appears read-only and prevents users from changing its value through direct interaction.
 **`disabledTooltip`** `string` · optional · default: `undefined` — When the card is disabled, this message can be shown in a tooltip to explain why selection is unavailable.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `RadioCard.Props`
+- `RadioCard.StylesNames`
+- `RadioCard.CssVariables`
+- `RadioCard.Factory`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/StatusToken.md
+++ b/packages/llms/src/components/StatusToken.md
@@ -62,6 +62,14 @@ Do not use `StatusToken` when:
 **`size`** `'sm' | 'lg'` · optional · default: `'lg'` — The size of the token MAY be set to control the rendered icon dimensions.
 **`variant`** `'success' | 'caution' | 'error' | 'disabled' | 'waiting' | 'edited' | 'new'` · required — The variant of the token MUST match the status semantics you need to communicate.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `StatusToken.Props`
+- `StatusToken.CssVariables`
+- `StatusToken.Factory`
+
 ## Usage
 
 Use `success` for healthy or completed states, `caution` for warnings, `error` for failures, `waiting` for in-progress work, and `edited` or `new` for recently changed items.

--- a/packages/llms/src/components/StickyFooter.md
+++ b/packages/llms/src/components/StickyFooter.md
@@ -54,6 +54,14 @@ Do not use `StickyFooter` when:
 **`children`** `ReactNode` · optional · default: `undefined` — Footer children SHOULD usually be buttons.
 **`variant`** `'default' | 'modal-footer'` · optional · default: `undefined` — The `modal-footer` variant SHOULD be used when rendering the `StickyFooter` inside `Modal`. The `modal-footer` variant removes the modal's default padding so that the footer properly hugs the bottom of the modal. It also adds a border on top of the footer. Deprecated: You SHOULD use `Modal.Footer` from `@coveord/plasma-mantine/Modal` for modal footers. For other cases, the `default` variant SHOULD suffice.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `StickyFooter.Props`
+- `StickyFooter.StylesNames`
+- `StickyFooter.Factory`
+
 ## Usage
 
 ```tsx

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -125,6 +125,27 @@ Use `Table.Toolbar` to render `Table.Filter`, `Table.Predicate`, and `Table.Date
 
 You SHOULD use `Table.Toolbar` when filter components need to be rendered outside the table header grid (e.g., in a custom layout above the table). You MUST still render `Table.Toolbar` inside the `<Table>` component because it requires `useTableContext`.
 
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Table.Props<TData>`
+- `Table.StylesNames`
+- `Table.Factory`
+- `Table.ActionItem.{Props, StylesNames, Factory}`
+- `Table.Cell.{Props, StylesNames, Factory}`
+- `Table.DateRangePicker.{Props, StylesNames, Factory}`
+- `Table.Filter.{Props, StylesNames, Factory}`
+- `Table.Footer.Props`
+- `Table.Header.{Props, StylesNames, Factory}`
+- `Table.LastUpdated.{Props, StylesNames, Factory}`
+- `Table.Loading.Props`
+- `Table.NoData.Props`
+- `Table.Pagination.Props`
+- `Table.PerPage.Props`
+- `Table.Predicate.{Props, StylesNames, Factory}`
+- `Table.Toolbar.{Props, StylesNames, Factory}`
+
 ## Usage
 
 ```tsx

--- a/packages/mantine/src/components/ActionIcon/ActionIcon.tsx
+++ b/packages/mantine/src/components/ActionIcon/ActionIcon.tsx
@@ -107,3 +107,40 @@ ActionIcon.Group.displayName = 'ActionIcon.Group';
 (ActionIconDestructiveSecondary as ComponentType).displayName = 'ActionIcon.DestructiveSecondary';
 (ActionIconDestructiveTertiary as ComponentType).displayName = 'ActionIcon.DestructiveTertiary';
 (ActionIconDestructiveQuaternary as ComponentType).displayName = 'ActionIcon.DestructiveQuaternary';
+export namespace ActionIcon {
+    export type Props = ActionIconProps;
+    export type StylesNames = ActionIconStylesNames;
+    export type CssVariables = ActionIconCssVariables;
+
+    export namespace Primary {
+        export type Props = ActionIconProps;
+    }
+
+    export namespace Secondary {
+        export type Props = ActionIconProps;
+    }
+
+    export namespace Tertiary {
+        export type Props = ActionIconProps;
+    }
+
+    export namespace Quaternary {
+        export type Props = ActionIconProps;
+    }
+
+    export namespace DestructivePrimary {
+        export type Props = ActionIconProps;
+    }
+
+    export namespace DestructiveSecondary {
+        export type Props = ActionIconProps;
+    }
+
+    export namespace DestructiveTertiary {
+        export type Props = ActionIconProps;
+    }
+
+    export namespace DestructiveQuaternary {
+        export type Props = ActionIconProps;
+    }
+}

--- a/packages/mantine/src/components/ActionIcon/ActionIcon.tsx
+++ b/packages/mantine/src/components/ActionIcon/ActionIcon.tsx
@@ -111,6 +111,7 @@ export namespace ActionIcon {
     export type Props = ActionIconProps;
     export type StylesNames = ActionIconStylesNames;
     export type CssVariables = ActionIconCssVariables;
+    export type Factory = ActionIconOverloadFactory;
 
     export namespace Primary {
         export type Props = ActionIconProps;

--- a/packages/mantine/src/components/Alert/Alert.tsx
+++ b/packages/mantine/src/components/Alert/Alert.tsx
@@ -101,3 +101,29 @@ Alert.Advice = AlertAdvice;
 Alert.Warning = AlertWarning;
 Alert.Critical = AlertCritical;
 Alert.Success = AlertSuccess;
+
+export namespace Alert {
+    export type Props = AlertProps;
+    export type StylesNames = AlertStylesNames;
+    export type CssVariables = AlertCssVariables;
+
+    export namespace Information {
+        export type Props = AlertProps;
+    }
+
+    export namespace Advice {
+        export type Props = AlertProps;
+    }
+
+    export namespace Warning {
+        export type Props = AlertProps;
+    }
+
+    export namespace Critical {
+        export type Props = AlertProps;
+    }
+
+    export namespace Success {
+        export type Props = AlertProps;
+    }
+}

--- a/packages/mantine/src/components/Alert/Alert.tsx
+++ b/packages/mantine/src/components/Alert/Alert.tsx
@@ -106,6 +106,7 @@ export namespace Alert {
     export type Props = AlertProps;
     export type StylesNames = AlertStylesNames;
     export type CssVariables = AlertCssVariables;
+    export type Factory = AlertOverloadFactory;
 
     export namespace Information {
         export type Props = AlertProps;

--- a/packages/mantine/src/components/Badge/Badge.tsx
+++ b/packages/mantine/src/components/Badge/Badge.tsx
@@ -204,3 +204,33 @@ Badge.Success = BadgeSuccess;
 Badge.Critical = BadgeCritical;
 Badge.Warning = BadgeWarning;
 Badge.Disabled = BadgeDisabled;
+
+export namespace Badge {
+    export type Props = BadgeProps;
+    export type StylesNames = BadgeStylesNames;
+    export type CssVariables = BadgeCssVariables;
+
+    export namespace Primary {
+        export type Props = SemanticBadgeProps;
+    }
+
+    export namespace Secondary {
+        export type Props = SemanticBadgeProps;
+    }
+
+    export namespace Success {
+        export type Props = SemanticBadgeProps;
+    }
+
+    export namespace Critical {
+        export type Props = SemanticBadgeProps;
+    }
+
+    export namespace Warning {
+        export type Props = SemanticBadgeProps;
+    }
+
+    export namespace Disabled {
+        export type Props = SemanticBadgeProps;
+    }
+}

--- a/packages/mantine/src/components/Badge/Badge.tsx
+++ b/packages/mantine/src/components/Badge/Badge.tsx
@@ -209,6 +209,7 @@ export namespace Badge {
     export type Props = BadgeProps;
     export type StylesNames = BadgeStylesNames;
     export type CssVariables = BadgeCssVariables;
+    export type Factory = BadgeOverloadFactory;
 
     export namespace Primary {
         export type Props = SemanticBadgeProps;

--- a/packages/mantine/src/components/BrowserPreview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/BrowserPreview/BrowserPreview.tsx
@@ -47,3 +47,7 @@ export const BrowserPreview = ({
 );
 
 BrowserPreview.displayName = 'BrowserPreview';
+
+export namespace BrowserPreview {
+    export type Props = BrowserPreviewProps;
+}

--- a/packages/mantine/src/components/Button/Button.tsx
+++ b/packages/mantine/src/components/Button/Button.tsx
@@ -132,6 +132,7 @@ export namespace Button {
     export type Props = ButtonProps;
     export type StylesNames = ButtonStylesNames;
     export type CssVariables = ButtonCssVariables;
+    export type Factory = ButtonOverloadFactory;
 
     export namespace Primary {
         export type Props = ButtonProps;

--- a/packages/mantine/src/components/Button/Button.tsx
+++ b/packages/mantine/src/components/Button/Button.tsx
@@ -127,3 +127,41 @@ Button.DestructiveQuaternary = ButtonDestructiveQuaternary;
 (ButtonDestructiveQuaternary as ComponentType).displayName = 'Button.DestructiveQuaternary';
 
 Button.displayName = 'Button';
+
+export namespace Button {
+    export type Props = ButtonProps;
+    export type StylesNames = ButtonStylesNames;
+    export type CssVariables = ButtonCssVariables;
+
+    export namespace Primary {
+        export type Props = ButtonProps;
+    }
+
+    export namespace Secondary {
+        export type Props = ButtonProps;
+    }
+
+    export namespace Tertiary {
+        export type Props = ButtonProps;
+    }
+
+    export namespace Quaternary {
+        export type Props = ButtonProps;
+    }
+
+    export namespace DestructivePrimary {
+        export type Props = ButtonProps;
+    }
+
+    export namespace DestructiveSecondary {
+        export type Props = ButtonProps;
+    }
+
+    export namespace DestructiveTertiary {
+        export type Props = ButtonProps;
+    }
+
+    export namespace DestructiveQuaternary {
+        export type Props = ButtonProps;
+    }
+}

--- a/packages/mantine/src/components/ChildForm/ChildForm.tsx
+++ b/packages/mantine/src/components/ChildForm/ChildForm.tsx
@@ -78,4 +78,5 @@ ChildForm.displayName = 'ChildForm';
 export namespace ChildForm {
     export type Props = ChildFormProps;
     export type StylesNames = ChildFormStylesNames;
+    export type Factory = ChildFormFactory;
 }

--- a/packages/mantine/src/components/ChildForm/ChildForm.tsx
+++ b/packages/mantine/src/components/ChildForm/ChildForm.tsx
@@ -74,3 +74,8 @@ export const ChildForm = polymorphicFactory<ChildFormFactory>((props) => {
 });
 
 ChildForm.displayName = 'ChildForm';
+
+export namespace ChildForm {
+    export type Props = ChildFormProps;
+    export type StylesNames = ChildFormStylesNames;
+}

--- a/packages/mantine/src/components/Collection/Collection.tsx
+++ b/packages/mantine/src/components/Collection/Collection.tsx
@@ -406,3 +406,9 @@ Collection.displayName = 'Collection';
 Collection.extend = identity as CustomComponentThemeExtend<CollectionFactory>;
 
 Collection.Layouts = CollectionLayouts;
+
+export namespace Collection {
+    export type Props<T> = CollectionProps<T>;
+    export type StylesNames = CollectionStylesNames;
+    export type Factory = CollectionFactory;
+}

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -79,3 +79,7 @@ export const CopyToClipboard: FunctionComponent<CopyToClipboardProps> = ({withLa
     );
 
 CopyToClipboard.displayName = 'CopyToClipboard';
+
+export namespace CopyToClipboard {
+    export type Props = CopyToClipboardProps;
+}

--- a/packages/mantine/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/mantine/src/components/DateRangePicker/DateRangePicker.tsx
@@ -200,3 +200,9 @@ export const DateRangePicker = factory<DateRangePickerFactory>(({ref, ...props})
         </Popover>
     );
 });
+
+export namespace DateRangePicker {
+    export type Props = DateRangePickerProps;
+    export type StylesNames = DateRangePickerStylesNames;
+    export type Factory = DateRangePickerFactory;
+}

--- a/packages/mantine/src/components/DateRangePicker/DateRangePickerInlineCalendar.tsx
+++ b/packages/mantine/src/components/DateRangePicker/DateRangePickerInlineCalendar.tsx
@@ -132,3 +132,7 @@ export const DateRangePickerInlineCalendar = ({
         </>
     );
 };
+
+export namespace DateRangePickerInlineCalendar {
+    export type Props = DateRangePickerInlineCalendarProps;
+}

--- a/packages/mantine/src/components/EllipsisText/EllipsisText.tsx
+++ b/packages/mantine/src/components/EllipsisText/EllipsisText.tsx
@@ -86,3 +86,8 @@ export const EllipsisText = polymorphicFactory<EllipsisTextFactory>((props) => {
 });
 
 const isOverflowing = (h: HTMLDivElement) => h.scrollWidth > h.clientWidth || h.scrollHeight > h.clientHeight;
+
+export namespace EllipsisText {
+    export type Props = EllipsisTextProps;
+    export type StylesNames = EllipsisTextStylesNames;
+}

--- a/packages/mantine/src/components/EllipsisText/EllipsisText.tsx
+++ b/packages/mantine/src/components/EllipsisText/EllipsisText.tsx
@@ -90,4 +90,5 @@ const isOverflowing = (h: HTMLDivElement) => h.scrollWidth > h.clientWidth || h.
 export namespace EllipsisText {
     export type Props = EllipsisTextProps;
     export type StylesNames = EllipsisTextStylesNames;
+    export type Factory = EllipsisTextFactory;
 }

--- a/packages/mantine/src/components/Facet/Facet.tsx
+++ b/packages/mantine/src/components/Facet/Facet.tsx
@@ -353,3 +353,9 @@ Facet.displayName = 'Facet';
 const defaultFilter = (query: string, item: FacetItem) =>
     item.label.toLowerCase().trim().includes(query.toLowerCase().trim()) ||
     item.value.toLowerCase().trim().includes(query.toLowerCase().trim());
+
+export namespace Facet {
+    export type Props = FacetProps;
+    export type StylesNames = FacetStylesNames;
+    export type Factory = FacetFactory;
+}

--- a/packages/mantine/src/components/Header/Header.tsx
+++ b/packages/mantine/src/components/Header/Header.tsx
@@ -18,10 +18,14 @@ import {
     HeaderBreadcrumbAnchor,
     type HeaderBreadcrumbAnchorStyleNames,
 } from './HeaderBreadcrumbs/HeaderBreadcrumbAnchor.js';
-import {HeaderBreadcrumbs, HeaderBreadcrumbsStyleNames} from './HeaderBreadcrumbs/HeaderBreadcrumbs.js';
+import {
+    HeaderBreadcrumbs,
+    HeaderBreadcrumbsProps,
+    HeaderBreadcrumbsStyleNames,
+} from './HeaderBreadcrumbs/HeaderBreadcrumbs.js';
 import {HeaderBreadcrumbText, HeaderBreadcrumbTextStyleNames} from './HeaderBreadcrumbs/HeaderBreadcrumbText.js';
-import {HeaderDocAnchor, HeaderDocAnchorStyleNames} from './HeaderDocAnchor/HeaderDocAnchor.js';
-import {HeaderRight, HeaderRightStyleNames} from './HeaderRight/HeaderRight.js';
+import {HeaderDocAnchor, HeaderDocAnchorProps, HeaderDocAnchorStyleNames} from './HeaderDocAnchor/HeaderDocAnchor.js';
+import {HeaderRight, HeaderRightProps, HeaderRightStyleNames} from './HeaderRight/HeaderRight.js';
 
 export type {HeaderBreadcrumbsProps} from './HeaderBreadcrumbs/HeaderBreadcrumbs.js';
 export type {HeaderDocAnchorProps} from './HeaderDocAnchor/HeaderDocAnchor.js';
@@ -165,3 +169,20 @@ Header.BreadcrumbAnchor = HeaderBreadcrumbAnchor;
 Header.BreadcrumbText = HeaderBreadcrumbText;
 Header.Right = HeaderRight;
 Header.DocAnchor = HeaderDocAnchor;
+
+export namespace Header {
+    export type Props = HeaderProps;
+    export type Factory = HeaderFactory;
+
+    export namespace Breadcrumbs {
+        export type Props = HeaderBreadcrumbsProps;
+    }
+
+    export namespace Right {
+        export type Props = HeaderRightProps;
+    }
+
+    export namespace DocAnchor {
+        export type Props = HeaderDocAnchorProps;
+    }
+}

--- a/packages/mantine/src/components/Header/Header.tsx
+++ b/packages/mantine/src/components/Header/Header.tsx
@@ -1,13 +1,13 @@
 import {
     Divider,
     Factory,
+    factory,
     Group,
     GroupProps,
     Stack,
     StylesApiProps,
     Text,
     Title,
-    factory,
     useProps,
     useStyles,
 } from '@mantine/core';
@@ -32,7 +32,7 @@ export type {HeaderDocAnchorProps} from './HeaderDocAnchor/HeaderDocAnchor.js';
 export type {HeaderRightProps} from './HeaderRight/HeaderRight.js';
 
 export type HeaderVariant = 'primary' | 'secondary';
-export type HeaderStyleNames =
+export type HeaderStylesNames =
     | 'root'
     | 'title'
     | 'description'
@@ -43,6 +43,10 @@ export type HeaderStyleNames =
     | HeaderBreadcrumbAnchorStyleNames
     | HeaderBreadcrumbTextStyleNames
     | HeaderRightStyleNames;
+/**
+ * @deprecated use HeaderStylesNames instead. Will be removed in the next major version
+ */
+export type HeaderStyleNames = HeaderStylesNames;
 
 export interface HeaderProps
     extends
@@ -79,7 +83,7 @@ export type HeaderFactory = Factory<{
     props: HeaderProps;
     ref: HTMLDivElement;
     variant: HeaderVariant;
-    stylesNames: HeaderStyleNames;
+    stylesNames: HeaderStylesNames;
     staticComponents: {
         Breadcrumbs: typeof HeaderBreadcrumbs;
         BreadcrumbAnchor: typeof HeaderBreadcrumbAnchor;
@@ -173,6 +177,7 @@ Header.DocAnchor = HeaderDocAnchor;
 export namespace Header {
     export type Props = HeaderProps;
     export type Factory = HeaderFactory;
+    export type StylesNames = HeaderStylesNames;
 
     export namespace Breadcrumbs {
         export type Props = HeaderBreadcrumbsProps;

--- a/packages/mantine/src/components/InlineConfirm/InlineConfirm.tsx
+++ b/packages/mantine/src/components/InlineConfirm/InlineConfirm.tsx
@@ -53,3 +53,8 @@ export const InlineConfirm = ((_props) => {
 
 InlineConfirm.Prompt = InlineConfirmPrompt;
 InlineConfirm.Target = InlineConfirmTarget;
+
+export namespace InlineConfirm {
+    export type Props = InlineConfirmProps;
+    export type Factory = InlineConfirmFactory;
+}

--- a/packages/mantine/src/components/Input/Input.ts
+++ b/packages/mantine/src/components/Input/Input.ts
@@ -25,3 +25,14 @@ export {Input};
 export type InputFactory = PlasmaInputFactory;
 export type {InputProps, InputLabelInfoFactory, InputLabelInfoProps, InputLabelInfoStylesNames};
 export {InputLabelInfo};
+
+export namespace Input {
+    export type Props = InputProps;
+    export type Factory = InputFactory;
+
+    export namespace LabelInfo {
+        export type Props = InputLabelInfoProps;
+        export type StylesNames = InputLabelInfoStylesNames;
+        export type Factory = InputLabelInfoFactory;
+    }
+}

--- a/packages/mantine/src/components/LastUpdated/LastUpdated.tsx
+++ b/packages/mantine/src/components/LastUpdated/LastUpdated.tsx
@@ -66,3 +66,9 @@ export const LastUpdated = factory<LastUpdatedFactory>(({ref, ...props}) => {
 });
 
 LastUpdated.displayName = 'LastUpdated';
+
+export namespace LastUpdated {
+    export type Props = LastUpdatedProps;
+    export type StylesNames = LastUpdatedStylesNames;
+    export type Factory = LastUpdatedFactory;
+}

--- a/packages/mantine/src/components/Modal/Modal.tsx
+++ b/packages/mantine/src/components/Modal/Modal.tsx
@@ -1,11 +1,18 @@
 import {
     factory,
     Modal as MantineModal,
+    ModalCssVariables,
     ModalFactory as MantineModalFactory,
     ModalProps as MantineModalProps,
+    ModalStylesNames,
 } from '@mantine/core';
 import {Header, type HeaderDocAnchorProps, type HeaderProps} from '../Header/Header.js';
-import {ModalFooter as PlasmaModalFooter} from './ModalFooter.js';
+import {
+    ModalFooter as PlasmaModalFooter,
+    type ModalFooterFactory,
+    type ModalFooterProps,
+    type ModalFooterStylesNames,
+} from './ModalFooter.js';
 
 interface PlasmaModalProps extends MantineModalProps {
     /**
@@ -56,3 +63,16 @@ export type ModalProps = PlasmaModalProps;
 
 export type ModalFactory = PlasmaModalFactory;
 export type {ModalRootProps, ModalCssVariables, ModalStylesNames} from '@mantine/core';
+
+export namespace Modal {
+    export type Props = ModalProps;
+    export type StylesNames = ModalStylesNames;
+    export type CssVariables = ModalCssVariables;
+    export type Factory = ModalFactory;
+
+    export namespace Footer {
+        export type Props = ModalFooterProps;
+        export type StylesNames = ModalFooterStylesNames;
+        export type Factory = ModalFooterFactory;
+    }
+}

--- a/packages/mantine/src/components/Navigation/Navigation.tsx
+++ b/packages/mantine/src/components/Navigation/Navigation.tsx
@@ -1,11 +1,11 @@
 import {useToggle} from '@mantine/hooks';
 import {ReactElement, ReactNode} from 'react';
 import {NavigationContext} from './Navigation.context.js';
-import {NavigationBadge} from './NavigationBadge.js';
-import {NavigationLink} from './NavigationLink.js';
+import {NavigationBadge, NavigationBadgeProps} from './NavigationBadge.js';
+import {NavigationLink, NavigationLinkProps} from './NavigationLink.js';
 import {NavigationSection} from './NavigationSection.js';
-import {NavigationSideBar} from './NavigationSideBar.js';
-import {NavigationToggle} from './NavigationToggle.js';
+import {NavigationSideBar, NavigationSideBarProps} from './NavigationSideBar.js';
+import {NavigationToggle, NavigationToggleProps} from './NavigationToggle.js';
 
 interface NavigationType {
     (props: NavigationProps): ReactElement;
@@ -45,3 +45,23 @@ export {NavigationLink, type NavigationLinkProps} from './NavigationLink.js';
 export {NavigationToggle, type NavigationToggleProps} from './NavigationToggle.js';
 export {NavigationBadge, type NavigationBadgeProps, type NavigationBadgeVariant} from './NavigationBadge.js';
 export {useNavigation, type NavigationContextType} from './Navigation.context.js';
+
+export namespace Navigation {
+    export type Props = NavigationProps;
+
+    export namespace SideBar {
+        export type Props = NavigationSideBarProps;
+    }
+
+    export namespace Link {
+        export type Props = NavigationLinkProps;
+    }
+
+    export namespace Toggle {
+        export type Props = NavigationToggleProps;
+    }
+
+    export namespace Badge {
+        export type Props = NavigationBadgeProps;
+    }
+}

--- a/packages/mantine/src/components/PrerequisitesList/PrerequisitesList.tsx
+++ b/packages/mantine/src/components/PrerequisitesList/PrerequisitesList.tsx
@@ -58,3 +58,8 @@ export const PrerequisitesList = factory<PrerequisitesListFactory>((_props) => {
 
 PrerequisitesList.displayName = 'PrerequisitesList';
 PrerequisitesList.Item = PrerequisitesListItem;
+
+export namespace PrerequisitesList {
+    export type Props = PrerequisitesListProps;
+    export type Factory = PrerequisitesListFactory;
+}

--- a/packages/mantine/src/components/Prompt/Prompt.tsx
+++ b/packages/mantine/src/components/Prompt/Prompt.tsx
@@ -23,8 +23,18 @@ import {InfoToken} from '../InfoToken/InfoToken.js';
 import {Modal} from '../Modal/Modal.js';
 import {PromptContextProvider} from './Prompt.context.js';
 import classes from './Prompt.module.css';
-import {PromptCancelButton, PromptCancelButtonStylesNamesVariant} from './PromptCancelButton.js';
-import {PromptConfirmButton, PromptConfirmButtonStylesNamesVariant} from './PromptConfirmButton.js';
+import {
+    PromptCancelButton,
+    type PromptCancelButtonProps,
+    type PromptCancelButtonStylesNamesVariant,
+} from './PromptCancelButton.js';
+import {
+    PromptConfirmButton,
+    type PromptConfirmButtonProps,
+    type PromptConfirmButtonStylesNamesVariant,
+} from './PromptConfirmButton.js';
+
+export type {PromptCancelButtonProps, PromptConfirmButtonProps};
 
 export type PromptVariant = 'success' | 'warning' | 'critical' | 'information';
 export type PromptVars = {root: '--prompt-icon-size'};
@@ -162,3 +172,38 @@ export const Prompt = {
     ConfirmButton: PromptConfirmButton,
     Footer: PromptFooter,
 } as const;
+
+export namespace Prompt {
+    export type Props = PromptProps;
+    export type StylesNames = PromptStylesNames;
+    export type CssVariables = PromptVars;
+    export type Factory = PromptFactory;
+
+    export namespace Information {
+        export type Props = PromptProps;
+    }
+
+    export namespace Success {
+        export type Props = PromptProps;
+    }
+
+    export namespace Warning {
+        export type Props = PromptProps;
+    }
+
+    export namespace Critical {
+        export type Props = PromptProps;
+    }
+
+    export namespace Footer {
+        export type Props = Modal.Footer.Props;
+    }
+
+    export namespace CancelButton {
+        export type Props = PromptCancelButtonProps;
+    }
+
+    export namespace ConfirmButton {
+        export type Props = PromptConfirmButtonProps;
+    }
+}

--- a/packages/mantine/src/components/RadioCard/RadioCard.tsx
+++ b/packages/mantine/src/components/RadioCard/RadioCard.tsx
@@ -96,3 +96,10 @@ export const RadioCard = factory<RadioCardFactory>((_props) => {
     );
 });
 RadioCard.displayName = 'RadioCard';
+
+export namespace RadioCard {
+    export type Props = RadioCardProps;
+    export type StylesNames = RadioCardStylesNames;
+    export type CssVariables = RadioCardCssVariables;
+    export type Factory = RadioCardFactory;
+}

--- a/packages/mantine/src/components/StatusToken/StatusToken.tsx
+++ b/packages/mantine/src/components/StatusToken/StatusToken.tsx
@@ -143,3 +143,9 @@ export const StatusToken: ReturnType<typeof polymorphicFactory<StatusTokenFactor
     });
 
 StatusToken.displayName = 'StatusToken';
+
+export namespace StatusToken {
+    export type Props = StatusTokenProps;
+    export type CssVariables = StatusTokenCssVariables;
+    export type Factory = StatusTokenFactory;
+}

--- a/packages/mantine/src/components/StickyFooter/StickyFooter.tsx
+++ b/packages/mantine/src/components/StickyFooter/StickyFooter.tsx
@@ -68,3 +68,9 @@ export const StickyFooter = factory<StickyFooterFactory>((props) => {
 });
 
 StickyFooter.displayName = 'StickyFooter';
+
+export namespace StickyFooter {
+    export type Props = StickyFooterProps;
+    export type StylesNames = StickyFooterStylesNames;
+    export type Factory = StickyFooterFactory;
+}

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -214,7 +214,8 @@ export {
     type HeaderFactory,
     type HeaderProps,
     type HeaderRightProps,
-    type HeaderStyleNames,
+    type HeaderStyleNames, // deprecated, remove in next major version
+    type HeaderStylesNames,
     type HeaderVariant,
 } from './components/Header/Header.js';
 


### PR DESCRIPTION
### Proposed Changes

Add namespace exports to custom components to follow Mantine conventions

### Potential Breaking Changes

None, only new exports

