### PR TITLE
fix(date-picker): fix date input with time having leading 0

### DIFF
--- a/packages/react/src/utils/DateUtils.spec.tsx
+++ b/packages/react/src/utils/DateUtils.spec.tsx
@@ -70,6 +70,18 @@ describe('DateUtils', () => {
 
             expect(DateUtils.getValidDate(date).toString()).toBe(moment().toDate().toString());
         });
+
+        it('should parse a time with a leading zero on the hour when parsing strictly (fromTime)', () => {
+            const date = 'Jan 02, 2010, 04:00';
+
+            expect(DateUtils.getValidDate(date, true).toString()).toContain('Sat Jan 02 2010 04:00:00 GMT');
+        });
+
+        it('should parse a time without a leading zero on the hour when parsing strictly (fromTime)', () => {
+            const date = 'Jan 02, 2010, 4:00';
+
+            expect(DateUtils.getValidDate(date, true).toString()).toContain('Sat Jan 02 2010 04:00:00 GMT');
+        });
     });
 
     describe('isDifferent', () => {

--- a/packages/react/src/utils/DateUtils.ts
+++ b/packages/react/src/utils/DateUtils.ts
@@ -16,6 +16,12 @@ export interface IDateComponents {
 
 export const SIMPLE_DATE_FORMAT: string = 'MMM DD, YYYY';
 export const LONG_DATE_FORMAT: string = SIMPLE_DATE_FORMAT + ', H:mm';
+/**
+ * Formats accepted when parsing a date string that includes a time. Both the leading-zero
+ * (`HH:mm`, e.g. `04:00`) and the non-leading-zero (`H:mm`, e.g. `4:00`) variants are supported
+ * so that user input is not rejected because of a leading zero.
+ */
+export const LONG_DATE_PARSE_FORMATS: string[] = [LONG_DATE_FORMAT, SIMPLE_DATE_FORMAT + ', HH:mm'];
 export const DATES_SEPARATOR: string = '%';
 
 export class DateUtils {
@@ -78,7 +84,7 @@ export class DateUtils {
     }
 
     static getValidDate(date: string, fromTime: boolean = false): Date {
-        const momentDate: moment.Moment = moment(date, LONG_DATE_FORMAT, fromTime);
+        const momentDate: moment.Moment = moment(date, LONG_DATE_PARSE_FORMATS, fromTime);
         if (momentDate.isValid()) {
             return momentDate.toDate();
         }

--- a/packages/website/src/examples/legacy/layout/Table/withDatePicker.demo.tsx
+++ b/packages/website/src/examples/legacy/layout/Table/withDatePicker.demo.tsx
@@ -39,14 +39,14 @@ const selectionOptions: IDatesSelectionBox[] = [
             },
         ],
         isRange: true,
-        withTime: false,
+        withTime: true,
         hasSetToNowButton: true,
     },
 ];
 
 const tableDatePickerConfig: ConfigSupplier<ITableWithDatePickerConfig> = () => ({
     datesSelectionBoxes: selectionOptions,
-    initialDateRange: [moment().subtract(75, 'years').toDate(), moment().toDate()],
+    initialDateRange: [moment().subtract(10, 'years').toDate(), moment().toDate()],
 });
 
 const TableComposed = compose<any>(tableWithDatePicker(tableDatePickerConfig))(TableHOC);


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/PSE-1607

**Summary**

Typing a time with a leading zero on the hour (e.g. `04:00` instead of `4:00`) reset the `DatePicker` value to the current date/time and left the calendar out of sync.

The cause was in `DateUtils.getValidDate`, which parsed time strings strictly against `MMM DD, YYYY, H:mm'`. The `H` token rejects leading-zero hours in strict mode, so `04:00` failed to parse and the code fell back to `moment().toDate()` (now). `4:00` and `14:00` parsed fine, which is why the bug only showed up with single-digit hours written with a leading zero.

**Changes**

Added `LONG_DATE_PARSE_FORMATS`, accepting both `H:mm` and `HH:mm`.
`getValidDate` now parses against that format list instead of the single format. Display formatting is unchanged (still `H:mm`).

**Testing**

Added unit tests in `DateUtils.spec.tsx` for leading-zero (`04:00`) and non-leading-zero (`4:00`) hours under strict parsing. 🧪 

>[!WARNING] 
>The demos seem broken in the legacy `v53` branch. I didn't investigate much since it's outstanding to my fix. On my end I tested locally from `v53` to confirm I could reproduce the issue and then locally again on my branch to confirm the fix.

🎬 Before

https://github.com/user-attachments/assets/447e9a0c-93b2-4128-92fb-3832a8efb262

🎬 After

https://github.com/user-attachments/assets/ce03871c-64ed-4d42-b432-8b69e0e68933


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [ ] The potential breaking changes are clearly identified
- [ ] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
