### PR TITLE
fix(mantine, RadioCard): add missing error style

### DIFF
--- a/.changeset/lucky-comets-jump.md
+++ b/.changeset/lucky-comets-jump.md
@@ -1,0 +1,8 @@
+---
+'@coveord/plasma-mantine': minor
+'@coveord/plasma-llms': patch
+---
+
+Display validation feedback with `RadioCard.error`
+
+`RadioCard` now accepts an `error` prop that renders validation feedback below the card, marks it invalid, and adds an error outline when it is unselected. Pass an actionable validation message to `error` when a radio option needs attention.

--- a/packages/llms/src/components/RadioCard.md
+++ b/packages/llms/src/components/RadioCard.md
@@ -1,6 +1,6 @@
 ---
 name: RadioCard
-description: Selectable card control that presents a radio option with a label and can include supporting text.
+description: Selectable card control that presents a radio option with a label, supporting text, and validation feedback.
 ---
 
 # Usage guidance
@@ -42,12 +42,14 @@ Important states include:
 - unselected
 - disabled with optional tooltip
 - read-only
+- error, with validation feedback below the card and an error outline when unselected
 
 ## Content guidance
 
 - Labels SHOULD name the option directly.
 - Descriptions SHOULD explain impact, eligibility, or key differences.
 - Keep descriptions parallel across cards so comparison is fair.
+- Error messages SHOULD explain what needs attention and how to resolve it.
 
 ## Common anti-patterns
 
@@ -63,6 +65,7 @@ Important states include:
 
 **`label`** `ReactNode` · required · default: `undefined` — Content rendered as the primary label next to the radio indicator.
 **`description`** `ReactNode` · optional · default: `undefined` — Content rendered below the label as supporting text.
+**`error`** `ReactNode` · optional · default: `undefined` — Renders validation feedback below the card, marks the card invalid, and applies an error outline when the card is unselected.
 **`readOnly`** `boolean` · optional · default: `undefined` — When `true`, the card appears read-only and prevents users from changing its value through direct interaction.
 **`disabledTooltip`** `string` · optional · default: `undefined` — When the card is disabled, this message can be shown in a tooltip to explain why selection is unavailable.
 

--- a/packages/mantine/src/components/RadioCard/RadioCard.tsx
+++ b/packages/mantine/src/components/RadioCard/RadioCard.tsx
@@ -34,6 +34,10 @@ export type RadioCardProps = MantineRadioCardProps &
          */
         description?: ReactNode;
         /**
+         * The error message of the card. Appears at the bottom.
+         */
+        error?: ReactNode;
+        /**
          * If true, the radio card will be displayed in a read-only state.
          */
         readOnly?: boolean;
@@ -57,6 +61,7 @@ export const RadioCard = factory<RadioCardFactory>((_props) => {
         label,
         description,
         disabledTooltip,
+        error,
         readOnly,
         ref,
         ...others
@@ -80,8 +85,14 @@ export const RadioCard = factory<RadioCardFactory>((_props) => {
                 {...getStyles('card', {className, style, classNames, styles})}
                 {...others}
                 aria-readonly={readOnly}
+                aria-invalid={error ? true : undefined}
+                mod={{error: !!error}}
             >
-                <Radio.Indicator disabled={disabled} {...getStyles('indicator', {classNames, styles})} />
+                <Radio.Indicator
+                    aria-invalid={error ? true : undefined}
+                    disabled={disabled}
+                    {...getStyles('indicator', {classNames, styles})}
+                />
                 <Stack {...getStyles('container', {classNames, styles})}>
                     <Input.Label {...getStyles('title', {classNames, styles})}>{label}</Input.Label>
                     {description && (
@@ -90,6 +101,7 @@ export const RadioCard = factory<RadioCardFactory>((_props) => {
                         </Input.Description>
                     )}
                     {children}
+                    {error ? <Input.Error>{error}</Input.Error> : null}
                 </Stack>
             </Radio.Card>
         </Tooltip>

--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -47,10 +47,14 @@
             }
         }
     }
+
+    &[data-error='true']:not([data-checked]) {
+        --radio-card-outline-color: var(--mantine-color-error);
+    }
 }
 
 .container {
-    gap: var(--mantine-spacing-xs);
+    gap: calc(var(--mantine-spacing-xs) / 2);
     width: 100%;
 }
 


### PR DESCRIPTION
### Proposed Changes

Add missing error prop (and style) to the RadioCard component

Error
<img width="306" height="131" alt="image" src="https://github.com/user-attachments/assets/69cc4324-247b-4a8b-b27b-2918b6045452" />

### Potential Breaking Changes

None, new feature