### PR TITLE
docs(llms): refine Button.Secondary guidance wording

### DIFF
--- a/packages/llms/src/components/Button.md
+++ b/packages/llms/src/components/Button.md
@@ -31,7 +31,7 @@ Do not use `Button` when:
 ## Decision-making guidance
 
 - Use one primary button per decision area when possible.
-- Use `Button.Secondary` for important supporting actions such as cancel; use `Button.Tertiary` or `Button.Quaternary` for low-emphasis actions such as preview or back.
+- Use `Button.Secondary` for important supporting actions; use `Button.Tertiary` or `Button.Quaternary` for low-emphasis actions such as preview or back.
 - Use destructive variants only when the action can delete, revoke, archive, or otherwise negatively affect data.
 
 ## Variants


### PR DESCRIPTION
Small wording tweak to the `Button` usage guidance: drop the "such as cancel" example from the `Button.Secondary` line.

```diff
- Use `Button.Secondary` for important supporting actions such as cancel; use `Button.Tertiary` or `Button.Quaternary` for low-emphasis actions such as preview or back.
+ Use `Button.Secondary` for important supporting actions; use `Button.Tertiary` or `Button.Quaternary` for low-emphasis actions such as preview or back.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)