### PR TITLE
chore(react): fix modal-wizard unit test

### DIFF
--- a/packages/react/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -195,6 +195,10 @@ describe('ModalWizard', () => {
             {initialState: {modals: [{id: '🧙‍♂️', isOpened: true}]}},
         );
 
+        await waitFor(() => {
+            expect(screen.getByRole('dialog').closest('.modal-container')).toHaveClass('opened');
+        });
+
         await user.click(screen.getByRole('button', {name: 'Next'}));
 
         expect(screen.queryByText(/finish/i)).not.toBeInTheDocument();


### PR DESCRIPTION
The release on V53 fails because this test is flaky. It passes locally. Applied a fix that was already applied on other tests in the same file