### PR TITLE
DS-426: Add Storybook component docs for C components

### DIFF
--- a/packages/storybook/src/components/call-to-action/CloseButton.mdx
+++ b/packages/storybook/src/components/call-to-action/CloseButton.mdx
@@ -1,0 +1,75 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+import * as stories from './CloseButton.stories';
+
+<Meta of={stories} title="@components/Call to action/CloseButton" />
+
+{/* For the agent-friendly version of this documentation, see packages/llms/src/components/CloseButton.md */}
+
+# CloseButton
+
+Icon-only button for dismissing or closing an overlaying element such as a modal, drawer, or tag.
+
+# Usage guidance
+
+## What problem does it solve?
+
+`CloseButton` provides a standardised dismiss affordance — a small × icon button — for components that can be closed or removed by the user, keeping the action visually lightweight and consistent across the product.
+
+## When to use it
+
+- Dismissing modals, drawers, popovers, or notifications.
+- Removing a tag, chip, or filter pill from a selection.
+- Closing an inline alert or banner that the user can opt out of.
+
+## When not to use it
+
+- When the dismissal action needs a text label for clarity — use a `Button.Tertiary` with a "Close" or "Dismiss" label instead.
+- As a primary or destructive action — `CloseButton` communicates cancellation and closure, not data deletion.
+- When a full-width or prominent cancel action is needed in a form footer — use `Button.Secondary` labelled "Cancel".
+
+## Decision-making guidance
+
+- Use `size="md"` (default) for standalone overlays such as modals and drawers.
+- Use `size="sm"` for compact contexts such as chips, tags, and inline alerts where a full-size button would overpower the surrounding element.
+- Do not use `CloseButton` as the sole means of closing a modal — always pair it with an alternative (a "Cancel" button, pressing Escape, or clicking the backdrop) to ensure keyboard and assistive technology users can close the overlay.
+
+## Accessibility expectations
+
+- `CloseButton` renders a `<button>` element and is keyboard-accessible by default.
+- The default icon provides an `aria-label` of "close". Override it with a more specific `aria-label` when the context needs one (e.g. "Close notification" or "Remove tag: Sales").
+- When used to close a modal, the focus SHOULD return to the element that triggered the modal after dismissal.
+
+## Common anti-patterns
+
+- Using `CloseButton` without an associated overlay or dismissible element — if nothing is being closed, use `ActionIcon` with an appropriate icon and label.
+- Placing `CloseButton` inside interactive elements that already have click handlers without stopping event propagation.
+- Relying solely on `CloseButton` to close a modal without also handling the Escape key.
+
+# API reference
+
+## Props
+
+> Extends: `CloseButtonProps` from `@mantine/core`. No additional Plasma-specific props beyond the Mantine base component.
+
+**`size`** `'sm' | 'md'` · optional · default: `'md'` — Controls the icon size. `sm` renders a 12 px icon; `md` renders a 16 px icon.
+
+## Usage
+
+```tsx
+import {CloseButton, TextInput} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+// Clear button inside an input
+function ClearableInput() {
+    const [value, setValue] = useState('');
+    return (
+        <TextInput
+            value={value}
+            onChange={(event) => setValue(event.currentTarget.value)}
+            rightSection={
+                value ? <CloseButton size="sm" aria-label="Clear value" onClick={() => setValue('')} /> : null
+            }
+        />
+    );
+}
+```

--- a/packages/storybook/src/components/call-to-action/CloseButton.mdx
+++ b/packages/storybook/src/components/call-to-action/CloseButton.mdx
@@ -9,11 +9,11 @@ import * as stories from './CloseButton.stories';
 
 Icon-only button for dismissing or closing an overlaying element such as a modal, drawer, or tag.
 
-# Usage guidance
+## Overview
 
-## What problem does it solve?
-
-`CloseButton` provides a standardised dismiss affordance — a small × icon button — for components that can be closed or removed by the user, keeping the action visually lightweight and consistent across the product.
+CloseButton gives a standardized dismiss affordance, a small × icon button.
+Reach for it on components that the user can close or remove.
+It keeps the action visually lightweight and consistent across the product.
 
 ## When to use it
 
@@ -23,53 +23,35 @@ Icon-only button for dismissing or closing an overlaying element such as a modal
 
 ## When not to use it
 
-- When the dismissal action needs a text label for clarity — use a `Button.Tertiary` with a "Close" or "Dismiss" label instead.
-- As a primary or destructive action — `CloseButton` communicates cancellation and closure, not data deletion.
-- When a full-width or prominent cancel action is needed in a form footer — use `Button.Secondary` labelled "Cancel".
+- When the dismissal needs a text label for clarity, use a `Button.Tertiary` with a "Close" or "Dismiss" label instead.
+- As a primary or destructive action. `CloseButton` communicates cancellation and closure, not data deletion.
+- When a form footer needs a full-width or prominent cancel action, use `Button.Secondary` labeled "Cancel".
 
-## Decision-making guidance
+## Choosing a size
 
-- Use `size="md"` (default) for standalone overlays such as modals and drawers.
-- Use `size="sm"` for compact contexts such as chips, tags, and inline alerts where a full-size button would overpower the surrounding element.
-- Do not use `CloseButton` as the sole means of closing a modal — always pair it with an alternative (a "Cancel" button, pressing Escape, or clicking the backdrop) to ensure keyboard and assistive technology users can close the overlay.
+- Use `size="md"`, the default, for standalone overlays such as modals and drawers.
+- Use `size="sm"` for compact contexts such as chips, tags, and inline alerts. A full-size button would overpower the surrounding element there.
+- Don't use `CloseButton` as the only way to close a modal. Always pair it with an alternative like a "Cancel" button, the Escape key, or a backdrop click. That lets keyboard and assistive technology users close the overlay.
 
-## Accessibility expectations
+## Accessibility
 
 - `CloseButton` renders a `<button>` element and is keyboard-accessible by default.
-- The default icon provides an `aria-label` of "close". Override it with a more specific `aria-label` when the context needs one (e.g. "Close notification" or "Remove tag: Sales").
-- When used to close a modal, the focus SHOULD return to the element that triggered the modal after dismissal.
+- The default icon has an `aria-label` of "close". Override it with a more specific label when the context needs one, such as "Close notification" or "Remove tag: Sales".
+- When the button closes a modal, return focus to the element that triggered the modal after dismissal.
 
 ## Common anti-patterns
 
-- Using `CloseButton` without an associated overlay or dismissible element — if nothing is being closed, use `ActionIcon` with an appropriate icon and label.
-- Placing `CloseButton` inside interactive elements that already have click handlers without stopping event propagation.
-- Relying solely on `CloseButton` to close a modal without also handling the Escape key.
+- Don't use `CloseButton` without an associated overlay or dismissible element. If nothing is being closed, use `ActionIcon` with an appropriate icon and label.
+- Don't place `CloseButton` inside interactive elements that already have click handlers without stopping event propagation.
+- Don't rely only on `CloseButton` to close a modal without also handling the Escape key.
 
-# API reference
+## Content guidance
 
-## Props
+**Default label (`aria-label`):**
 
-> Extends: `CloseButtonProps` from `@mantine/core`. No additional Plasma-specific props beyond the Mantine base component.
+- Keep the default "close" for a generic dismiss action.
 
-**`size`** `'sm' | 'md'` · optional · default: `'md'` — Controls the icon size. `sm` renders a 12 px icon; `md` renders a 16 px icon.
+**Contextual label (`aria-label`):**
 
-## Usage
-
-```tsx
-import {CloseButton, TextInput} from '@coveord/plasma-mantine';
-import {useState} from 'react';
-
-// Clear button inside an input
-function ClearableInput() {
-    const [value, setValue] = useState('');
-    return (
-        <TextInput
-            value={value}
-            onChange={(event) => setValue(event.currentTarget.value)}
-            rightSection={
-                value ? <CloseButton size="sm" aria-label="Clear value" onClick={() => setValue('')} /> : null
-            }
-        />
-    );
-}
-```
+- Write a specific label when several close actions share a screen: `"Close notification" not "close"`.
+- Name the item being removed for a removal action, such as "Remove tag: Sales".

--- a/packages/storybook/src/components/call-to-action/CopyToClipboard.mdx
+++ b/packages/storybook/src/components/call-to-action/CopyToClipboard.mdx
@@ -1,0 +1,86 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+import * as stories from './CopyToClipboard.stories';
+
+<Meta of={stories} title="@components/Call to action/CopyToClipboard" />
+
+{/* For the agent-friendly version of this documentation, see packages/llms/src/components/CopyToClipboard.md */}
+
+# CopyToClipboard
+
+Action icon that copies a string value to the clipboard and shows tooltip feedback.
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `CopyToClipboard` gives users a fast, low-friction way to copy exact values that are difficult or error-prone to select manually.
+
+It is useful for technical identifiers, API keys, tokens, URLs, generated IDs, and other read-only values that users need elsewhere.
+
+## When to use it
+
+Use `CopyToClipboard` when:
+
+- users need to copy an exact string value
+- the value is displayed as read-only or otherwise not meant to be edited in place
+- copying is a secondary utility action attached to a field or value
+- tooltip feedback should confirm the copy action
+
+## When not to use it
+
+Do not use `CopyToClipboard` when:
+
+- the user needs to edit the value before using it
+- the value is short and copying is not a meaningful task
+- the copied value is sensitive and should not be exposed without confirmation
+
+## Decision-making guidance
+
+- When showing a read-only value like an API key or URL in a text field, place the copy icon inside the field on the right side — this is the most common and expected placement.
+- If copying is the main action on the screen (for example, "Copy invite link"), use a full button with a text label instead of the small icon — the icon alone doesn't communicate enough weight.
+- Always make sure it's obvious what the user is copying. The field label, nearby text, or context should tell them exactly what value they'll get in their clipboard.
+
+## Accessibility expectations
+
+- The copied value MUST be clear from the surrounding label or context.
+- Tooltip copy feedback SHOULD be concise.
+- Do not rely on the icon alone when several copy actions appear near each other.
+
+## Common anti-patterns
+
+- Showing copy actions for every minor label on a page.
+- Copying hidden or ambiguous values.
+- Using the deprecated label mode instead of placing the action near the value.
+
+# API reference
+
+## Props
+
+> Extends: `ActionIconProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+
+**`value`** `string` · required · default: `undefined` — The value copied to the clipboard.
+**`withLabel`** `boolean` · optional · default: `false` — Deprecated. You SHOULD place the `CopyToClipboard` component inside the `rightSection` of input components instead. When used, this prop displays the string to be copied alongside the button.
+**`onCopy`** `MouseEventHandler<HTMLButtonElement>` · optional · default: `undefined` — If provided, this callback is called each time the value is copied to the clipboard.
+**`color`** `MantineColor | (string & {})` · optional · default: `gray` — The icon uses this color when idle.
+**`tooltipLabelCopy`** `string` · optional · default: `Copy to clipboard` — The tooltip displays this text when hovering over the button.
+**`tooltipLabelCopied`** `string` · optional · default: `Copied` — The tooltip displays this text when the value is copied to the clipboard.
+
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `CopyToClipboard.Props`
+
+## Usage
+
+Use `CopyToClipboard` in the `rightSection` of a read-only input when users need to quickly copy values like API keys, tokens, or IDs.
+
+```tsx
+import {CopyToClipboard, TextInput} from '@coveord/plasma-mantine';
+
+export function ApiKeyField() {
+    const apiKey = 'sk_live_1234567890abcdef';
+
+    return <TextInput label="API key" value={apiKey} readOnly rightSection={<CopyToClipboard value={apiKey} />} />;
+}
+```

--- a/packages/storybook/src/components/call-to-action/CopyToClipboard.mdx
+++ b/packages/storybook/src/components/call-to-action/CopyToClipboard.mdx
@@ -9,78 +9,53 @@ import * as stories from './CopyToClipboard.stories';
 
 Action icon that copies a string value to the clipboard and shows tooltip feedback.
 
-# Usage guidance
+## Overview
 
-## What problem does it solve?
-
-The `CopyToClipboard` gives users a fast, low-friction way to copy exact values that are difficult or error-prone to select manually.
-
-It is useful for technical identifiers, API keys, tokens, URLs, generated IDs, and other read-only values that users need elsewhere.
+The CopyToClipboard gives users a fast, low-friction way to copy exact values.
+Reach for it when values are hard or error-prone to select by hand.
+It suits technical identifiers, API keys, tokens, URLs, and other read-only values.
 
 ## When to use it
 
 Use `CopyToClipboard` when:
 
-- users need to copy an exact string value
-- the value is displayed as read-only or otherwise not meant to be edited in place
-- copying is a secondary utility action attached to a field or value
-- tooltip feedback should confirm the copy action
+- Users need to copy an exact string value.
+- The value is read-only or not meant to be edited in place.
+- Copying is a secondary utility action attached to a field or value.
+- Tooltip feedback should confirm the copy action.
 
 ## When not to use it
 
-Do not use `CopyToClipboard` when:
+Don't use `CopyToClipboard` when:
 
-- the user needs to edit the value before using it
-- the value is short and copying is not a meaningful task
-- the copied value is sensitive and should not be exposed without confirmation
+- The user needs to edit the value before using it.
+- The value is short and copying isn't a meaningful task.
+- The copied value is sensitive and shouldn't be exposed without confirmation.
 
-## Decision-making guidance
+## Placement
 
-- When showing a read-only value like an API key or URL in a text field, place the copy icon inside the field on the right side — this is the most common and expected placement.
-- If copying is the main action on the screen (for example, "Copy invite link"), use a full button with a text label instead of the small icon — the icon alone doesn't communicate enough weight.
-- Always make sure it's obvious what the user is copying. The field label, nearby text, or context should tell them exactly what value they'll get in their clipboard.
+- Place the copy icon inside a read-only text field, on the right side. This is the most common and expected placement for values like an API key or URL.
+- Use a full button with a text label when copying is the main action, such as "Copy invite link". The small icon alone doesn't carry enough weight.
+- Make it obvious what the user is copying. The field label, nearby text, or context should name the exact value.
 
-## Accessibility expectations
+## Accessibility
 
-- The copied value MUST be clear from the surrounding label or context.
-- Tooltip copy feedback SHOULD be concise.
-- Do not rely on the icon alone when several copy actions appear near each other.
+- Make the copied value clear from the surrounding label or context.
+- Keep tooltip copy feedback concise.
+- Don't rely on the icon alone when several copy actions appear near each other.
 
 ## Common anti-patterns
 
-- Showing copy actions for every minor label on a page.
-- Copying hidden or ambiguous values.
-- Using the deprecated label mode instead of placing the action near the value.
+- Don't show copy actions for every minor label on a page.
+- Don't copy hidden or ambiguous values.
+- Don't use the deprecated label mode. Place the action near the value instead.
 
-# API reference
+## Content guidance
 
-## Props
+**Tooltip labels (`tooltipLabelCopy`, `tooltipLabelCopied`):**
 
-> Extends: `ActionIconProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+- Keep the copy feedback concise, such as "Copy to clipboard" and "Copied".
 
-**`value`** `string` · required · default: `undefined` — The value copied to the clipboard.
-**`withLabel`** `boolean` · optional · default: `false` — Deprecated. You SHOULD place the `CopyToClipboard` component inside the `rightSection` of input components instead. When used, this prop displays the string to be copied alongside the button.
-**`onCopy`** `MouseEventHandler<HTMLButtonElement>` · optional · default: `undefined` — If provided, this callback is called each time the value is copied to the clipboard.
-**`color`** `MantineColor | (string & {})` · optional · default: `gray` — The icon uses this color when idle.
-**`tooltipLabelCopy`** `string` · optional · default: `Copy to clipboard` — The tooltip displays this text when hovering over the button.
-**`tooltipLabelCopied`** `string` · optional · default: `Copied` — The tooltip displays this text when the value is copied to the clipboard.
+**Surrounding context:**
 
-## TypeScript namespace aliases
-
-These type-only aliases are available for annotations and do not add runtime static properties.
-
-- `CopyToClipboard.Props`
-
-## Usage
-
-Use `CopyToClipboard` in the `rightSection` of a read-only input when users need to quickly copy values like API keys, tokens, or IDs.
-
-```tsx
-import {CopyToClipboard, TextInput} from '@coveord/plasma-mantine';
-
-export function ApiKeyField() {
-    const apiKey = 'sk_live_1234567890abcdef';
-
-    return <TextInput label="API key" value={apiKey} readOnly rightSection={<CopyToClipboard value={apiKey} />} />;
-}
-```
+- Make the label or nearby text name the exact value being copied.

--- a/packages/storybook/src/components/data-display/Card.mdx
+++ b/packages/storybook/src/components/data-display/Card.mdx
@@ -9,101 +9,80 @@ import * as stories from './Card.stories';
 
 Container that groups related content into a visually distinct surface, optionally interactive with hover and selection states.
 
-# Usage guidance
+## Overview
 
-## What problem does it solve?
-
-`Card` lets users scan a collection of related items at a glance — each card summarises one subject and gives enough information to identify it without reading everything. It also works as a static container when content needs visual separation from the rest of the page.
+Card groups related content into one visually distinct surface.
+Reach for it when users need to scan a collection of related items at a glance, where each card summarizes one subject.
+It also works as a static container when a block of content needs separation from the rest of the page.
 
 ## When to use it
 
-- Showing a collection of related items users need to browse and compare — results, resources, options, or feature summaries.
+- Showing a collection of related items users browse and compare, like results, resources, options, or feature summaries.
 - Building a grid or list of selectable tiles where the user clicks to choose one.
-- Wrapping a self-contained block of content — like an onboarding step or a settings panel — that should feel visually distinct from surrounding content.
+- Wrapping a self-contained block of content, such as an onboarding step or a settings panel, that should feel visually distinct.
 
 ## When not to use it
 
-- When the content is part of a large structured dataset — use `Table` instead; cards don't scale to many rows of comparable data.
-- When the content is an in-page message or notification — use `Alert` instead; cards group content, they do not convey alerts or status messages.
-- When selection carries form semantics — use `RadioCard` or `Checkbox`, which have the correct native behaviour.
-- When the content is meant to be read sequentially as continuous text — cards imply independent, scannable units.
-- When the content does not need visual grouping — use layout primitives like `Stack`, `Flex`, or `Grid` without a card shell.
+- When the content belongs to a large structured dataset, use `Table` instead. Cards don't scale to many rows of comparable data.
+- When the content is an in-page message or notification, use `Alert` instead. Cards group content, they don't convey alerts or status messages.
+- When selection carries form semantics, use `RadioCard` or `Checkbox`, which have the correct native behavior.
+- When the content is meant to be read sequentially as continuous text. Cards imply independent, scannable units.
+- When the content doesn't need visual grouping, use layout primitives like `Stack`, `Flex`, or `Grid` without a card shell.
 
-## Decision-making guidance
+## Choosing a variant
 
-- Use the default variant for static, non-interactive content containers.
-- Use `variant="hover"` only when the entire card is a clickable target — for example, a results tile that navigates or toggles a selection.
-- When `variant="hover"` is combined with `mod={{selected: true}}`, the card gains a primary-colour border indicating the active selection. Manage this state externally via `mod`.
-- When `variant="hover"` is combined with `mod={{disabled: true}}`, `pointer-events` are suppressed and the card becomes non-interactive.
+Use the default variant for static, non-interactive content containers.
+Use `variant="hover"` only when the entire card is a clickable target, such as a results tile that navigates or toggles a selection.
+
+Combine `variant="hover"` with `mod={{selected: true}}` to give the card a primary color border that marks the active selection.
+Manage this state externally through `mod`.
+
+Combine `variant="hover"` with `mod={{disabled: true}}` to suppress pointer events and make the card non-interactive.
 
 ## Variants
 
-- **`undefined`** (default) — static bordered surface with no hover behaviour. Use for informational containers.
-- **`hover`** — adds a box-shadow on hover, a selection border when `data-selected` is set, and pointer-cursor. Use for clickable tiles.
+- **Default (`undefined`)** is a static bordered surface with no hover behavior. Use it for informational containers.
+- **`hover`** adds a box-shadow on hover, a selection border when `data-selected` is set, and a pointer cursor. Use it for clickable tiles.
 
 ## States
 
-Relevant to `variant="hover"` only:
+These states apply to `variant="hover"` only.
 
-- **Normal** — no shadow.
-- **Hover** — elevated box-shadow signals interactivity.
-- **Selected** — primary-colour border communicates active selection.
-- **Disabled** — pointer events removed; visually inert.
+- **Normal** has no shadow.
+- **Hover** shows an elevated box-shadow to signal interactivity.
+- **Selected** shows a primary color border to communicate the active selection.
+- **Disabled** removes pointer events and looks visually inert.
 
-## Interaction notes
+## Interaction
 
-When `variant="hover"`, attach an `onClick` handler to toggle selection. Plasma does not manage the selected state internally — pass the current value through `mod={{selected: boolean}}`.
+When you use `variant="hover"`, attach an `onClick` handler to toggle selection.
+The selected state isn't tracked for you, so pass the current value through `mod={{selected: boolean}}`.
 
-## Accessibility expectations
+## Accessibility
 
-- When `variant="hover"` is used as a selectable tile, the `Card` SHOULD carry an appropriate ARIA role (e.g. `role="radio"` within a `role="radiogroup"`, or `role="option"`) and `aria-selected` so that its state is communicated to assistive technology.
-- Keyboard users MUST be able to activate the card with the Enter or Space key when it is interactive; add `tabIndex={0}` and a `onKeyDown` handler if needed alongside `onClick`.
-- Disabled cards SHOULD communicate their state via `aria-disabled="true"` rather than relying solely on visual styling.
-
-## Content guidance
-
-- Each card should represent a single subject — avoid mixing unrelated content in one card.
-- Keep card content concise; users should be able to identify the item at a glance without reading everything.
-- Cards within the same collection SHOULD follow a consistent content structure — the same types of information in the same positions.
-- Avoid more than one or two actions per card; if more are needed, reconsider the layout.
+- When you use `variant="hover"` as a selectable tile, give the card a suitable ARIA role, such as `role="radio"` inside a `role="radiogroup"`, or `role="option"`. Add `aria-selected` so assistive technology can read its state.
+- Keyboard users need to activate an interactive card with the Enter or Space key. Add `tabIndex={0}` and an `onKeyDown` handler alongside `onClick`.
+- Give disabled cards `aria-disabled="true"` instead of relying on visual styling alone.
 
 ## Common anti-patterns
 
-- Using `variant="hover"` without an `onClick` handler — the pointer cursor implies interactivity that is not present.
-- Passing `selected` and `disabled` as top-level props — these are not direct `CardProps`; they MUST be passed through the `mod` prop as `mod={{selected: true, disabled: true}}`.
-- Nesting interactive elements (buttons, links) inside a `variant="hover"` card without careful event management — clicks on inner elements will also trigger the card's `onClick`.
-- Nesting a `Card` inside another `Card` — flatten the hierarchy or use layout primitives instead.
+- Don't use `variant="hover"` without an `onClick` handler. The pointer cursor implies interactivity that isn't there.
+- Don't pass `selected` and `disabled` as top-level props. They aren't direct `CardProps`, so pass them through the `mod` prop as `mod={{selected: true, disabled: true}}`.
+- Don't nest interactive elements like buttons or links inside a `variant="hover"` card without careful event management. Clicks on inner elements also trigger the `onClick` of the card.
+- Don't nest a `Card` inside another `Card`. Flatten the hierarchy or use layout primitives instead.
 
-# API reference
+## Content guidance
 
-## Props
+**Card content:**
 
-> Extends: `CardProps` from `@mantine/core`. No additional Plasma-specific props beyond the Mantine base component; interactive behaviour is controlled via `variant` and `mod`.
+- Represent a single subject per card. Don't mix unrelated content in one card.
+- Keep the content concise so users identify the item at a glance.
 
-**`variant`** `'hover' | undefined` · optional · default: `undefined` — When set to `'hover'`, the card gains hover shadow and supports selected/disabled data attributes.
+**Actions:**
 
-**`mod`** `{selected?: boolean; disabled?: boolean}` · optional — Data attributes used to apply selection border (`data-selected`) and disable pointer events (`data-disabled`). Only meaningful when `variant="hover"`.
+- Limit a card to one or two actions. Reconsider the layout if you need more.
 
-## Usage
+**Cards in a collection:**
 
-```tsx
-import {Card, Text} from '@coveord/plasma-mantine';
-
-// Static content container
-function InfoCard() {
-    return (
-        <Card>
-            <Text>Some grouped content here.</Text>
-        </Card>
-    );
-}
-
-// Disabled tile
-function DisabledTile() {
-    return (
-        <Card variant="hover" mod={{disabled: true}}>
-            <Text>This option is unavailable.</Text>
-        </Card>
-    );
-}
-```
+- Follow a consistent content structure across cards in the same collection.
+- Place the same types of information in the same positions.

--- a/packages/storybook/src/components/data-display/Card.mdx
+++ b/packages/storybook/src/components/data-display/Card.mdx
@@ -1,0 +1,109 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+import * as stories from './Card.stories';
+
+<Meta of={stories} title="@components/Data display/Card" />
+
+{/* For the agent-friendly version of this documentation, see packages/llms/src/components/Card.md */}
+
+# Card
+
+Container that groups related content into a visually distinct surface, optionally interactive with hover and selection states.
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Card` lets users scan a collection of related items at a glance — each card summarises one subject and gives enough information to identify it without reading everything. It also works as a static container when content needs visual separation from the rest of the page.
+
+## When to use it
+
+- Showing a collection of related items users need to browse and compare — results, resources, options, or feature summaries.
+- Building a grid or list of selectable tiles where the user clicks to choose one.
+- Wrapping a self-contained block of content — like an onboarding step or a settings panel — that should feel visually distinct from surrounding content.
+
+## When not to use it
+
+- When the content is part of a large structured dataset — use `Table` instead; cards don't scale to many rows of comparable data.
+- When the content is an in-page message or notification — use `Alert` instead; cards group content, they do not convey alerts or status messages.
+- When selection carries form semantics — use `RadioCard` or `Checkbox`, which have the correct native behaviour.
+- When the content is meant to be read sequentially as continuous text — cards imply independent, scannable units.
+- When the content does not need visual grouping — use layout primitives like `Stack`, `Flex`, or `Grid` without a card shell.
+
+## Decision-making guidance
+
+- Use the default variant for static, non-interactive content containers.
+- Use `variant="hover"` only when the entire card is a clickable target — for example, a results tile that navigates or toggles a selection.
+- When `variant="hover"` is combined with `mod={{selected: true}}`, the card gains a primary-colour border indicating the active selection. Manage this state externally via `mod`.
+- When `variant="hover"` is combined with `mod={{disabled: true}}`, `pointer-events` are suppressed and the card becomes non-interactive.
+
+## Variants
+
+- **`undefined`** (default) — static bordered surface with no hover behaviour. Use for informational containers.
+- **`hover`** — adds a box-shadow on hover, a selection border when `data-selected` is set, and pointer-cursor. Use for clickable tiles.
+
+## States
+
+Relevant to `variant="hover"` only:
+
+- **Normal** — no shadow.
+- **Hover** — elevated box-shadow signals interactivity.
+- **Selected** — primary-colour border communicates active selection.
+- **Disabled** — pointer events removed; visually inert.
+
+## Interaction notes
+
+When `variant="hover"`, attach an `onClick` handler to toggle selection. Plasma does not manage the selected state internally — pass the current value through `mod={{selected: boolean}}`.
+
+## Accessibility expectations
+
+- When `variant="hover"` is used as a selectable tile, the `Card` SHOULD carry an appropriate ARIA role (e.g. `role="radio"` within a `role="radiogroup"`, or `role="option"`) and `aria-selected` so that its state is communicated to assistive technology.
+- Keyboard users MUST be able to activate the card with the Enter or Space key when it is interactive; add `tabIndex={0}` and a `onKeyDown` handler if needed alongside `onClick`.
+- Disabled cards SHOULD communicate their state via `aria-disabled="true"` rather than relying solely on visual styling.
+
+## Content guidance
+
+- Each card should represent a single subject — avoid mixing unrelated content in one card.
+- Keep card content concise; users should be able to identify the item at a glance without reading everything.
+- Cards within the same collection SHOULD follow a consistent content structure — the same types of information in the same positions.
+- Avoid more than one or two actions per card; if more are needed, reconsider the layout.
+
+## Common anti-patterns
+
+- Using `variant="hover"` without an `onClick` handler — the pointer cursor implies interactivity that is not present.
+- Passing `selected` and `disabled` as top-level props — these are not direct `CardProps`; they MUST be passed through the `mod` prop as `mod={{selected: true, disabled: true}}`.
+- Nesting interactive elements (buttons, links) inside a `variant="hover"` card without careful event management — clicks on inner elements will also trigger the card's `onClick`.
+- Nesting a `Card` inside another `Card` — flatten the hierarchy or use layout primitives instead.
+
+# API reference
+
+## Props
+
+> Extends: `CardProps` from `@mantine/core`. No additional Plasma-specific props beyond the Mantine base component; interactive behaviour is controlled via `variant` and `mod`.
+
+**`variant`** `'hover' | undefined` · optional · default: `undefined` — When set to `'hover'`, the card gains hover shadow and supports selected/disabled data attributes.
+
+**`mod`** `{selected?: boolean; disabled?: boolean}` · optional — Data attributes used to apply selection border (`data-selected`) and disable pointer events (`data-disabled`). Only meaningful when `variant="hover"`.
+
+## Usage
+
+```tsx
+import {Card, Text} from '@coveord/plasma-mantine';
+
+// Static content container
+function InfoCard() {
+    return (
+        <Card>
+            <Text>Some grouped content here.</Text>
+        </Card>
+    );
+}
+
+// Disabled tile
+function DisabledTile() {
+    return (
+        <Card variant="hover" mod={{disabled: true}}>
+            <Text>This option is unavailable.</Text>
+        </Card>
+    );
+}
+```

--- a/packages/storybook/src/components/forms-and-inputs/array/Chip.mdx
+++ b/packages/storybook/src/components/forms-and-inputs/array/Chip.mdx
@@ -1,0 +1,93 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+import * as stories from './Chip.stories';
+
+<Meta of={stories} title="@components/Forms and inputs/array/Chip" />
+
+{/* For the agent-friendly version of this documentation, see packages/llms/src/components/Chip.md */}
+
+# Chip
+
+Selectable pill-shaped control that strips the Mantine variant prop to enforce Plasma styling.
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `Chip` lets users select compact options in a pill-shaped control when the choices are short and benefit from being visible together.
+
+## When to use it
+
+Use `Chip` when:
+
+- users choose from a small set of short options
+- the choices can fit comfortably in the available space
+- the selection should feel lighter than a full form field
+- single or multiple selection can be represented as selectable pills
+
+`Chip.Group` SHOULD be used when related chips form a single choice set.
+
+## When not to use it
+
+Do not use `Chip` when:
+
+- choices are long, numerous, or need search
+- the option descriptions are important to the decision
+- the control is only displaying metadata; use `Badge`
+- the choice is a primary form field that needs stronger labeling or validation
+
+## Decision-making guidance
+
+- Use `Chip` for compact selectable options.
+- Use `Checkbox` for visible multi-select choices that need labels, descriptions, or standard form behavior.
+- Use `Select` when only one option can be chosen from a larger list.
+- Use `MultiSelect` when users pick several options from a longer list that benefits from search.
+- Use `Badge` for non-interactive labels.
+
+## States
+
+Important states include:
+
+- selected
+- unselected
+- disabled
+- grouped single-selection or multiple-selection
+
+## Content guidance
+
+- Chip labels SHOULD be short and parallel.
+- Do not use chips when labels wrap or require explanation.
+- Group labels SHOULD explain what the chip set controls.
+
+## Common anti-patterns
+
+- Using chips for long lists that need search.
+- Using chips as decorative tags when the user cannot select them.
+- Mixing unrelated choices in one chip group.
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component. The `variant` prop is stripped and has no effect._
+
+## Sub-components
+
+Plasma provides pre-configured sub-components as convenience wrappers. You SHOULD use these over setting props manually.
+
+- `Chip.Group`
+
+## Usage
+
+```tsx
+import {Chip} from '@coveord/plasma-mantine';
+
+function Example() {
+    return (
+        <Chip.Group multiple defaultValue={['react']}>
+            <Chip value="react">React</Chip>
+            <Chip value="vue">Vue</Chip>
+            <Chip value="angular">Angular</Chip>
+        </Chip.Group>
+    );
+}
+```

--- a/packages/storybook/src/components/forms-and-inputs/array/Chip.mdx
+++ b/packages/storybook/src/components/forms-and-inputs/array/Chip.mdx
@@ -9,33 +9,32 @@ import * as stories from './Chip.stories';
 
 Selectable pill-shaped control that strips the Mantine variant prop to enforce Plasma styling.
 
-# Usage guidance
+## Overview
 
-## What problem does it solve?
-
-The `Chip` lets users select compact options in a pill-shaped control when the choices are short and benefit from being visible together.
+The Chip lets users select compact options in a pill-shaped control.
+Reach for it when the choices are short and benefit from being visible together.
 
 ## When to use it
 
 Use `Chip` when:
 
-- users choose from a small set of short options
-- the choices can fit comfortably in the available space
-- the selection should feel lighter than a full form field
-- single or multiple selection can be represented as selectable pills
+- Users choose from a small set of short options.
+- The choices fit comfortably in the available space.
+- The selection should feel lighter than a full form field.
+- Single or multiple selection can be shown as selectable pills.
 
-`Chip.Group` SHOULD be used when related chips form a single choice set.
+Use `Chip.Group` when related chips form a single choice set.
 
 ## When not to use it
 
-Do not use `Chip` when:
+Don't use `Chip` when:
 
-- choices are long, numerous, or need search
-- the option descriptions are important to the decision
-- the control is only displaying metadata; use `Badge`
-- the choice is a primary form field that needs stronger labeling or validation
+- Choices are long, numerous, or need search.
+- The option descriptions are important to the decision.
+- The control only displays metadata. Use `Badge` instead.
+- The choice is a primary form field that needs stronger labeling or validation.
 
-## Decision-making guidance
+## Choosing a control
 
 - Use `Chip` for compact selectable options.
 - Use `Checkbox` for visible multi-select choices that need labels, descriptions, or standard form behavior.
@@ -45,49 +44,24 @@ Do not use `Chip` when:
 
 ## States
 
-Important states include:
-
-- selected
-- unselected
-- disabled
-- grouped single-selection or multiple-selection
-
-## Content guidance
-
-- Chip labels SHOULD be short and parallel.
-- Do not use chips when labels wrap or require explanation.
-- Group labels SHOULD explain what the chip set controls.
+- **Selected** marks the chip as chosen.
+- **Unselected** is the default state.
+- **Disabled** prevents interaction.
+- **Grouped** supports single-selection or multiple-selection sets.
 
 ## Common anti-patterns
 
-- Using chips for long lists that need search.
-- Using chips as decorative tags when the user cannot select them.
-- Mixing unrelated choices in one chip group.
+- Don't use chips for long lists that need search.
+- Don't use chips as decorative tags when the user can't select them.
+- Don't mix unrelated choices in one chip group.
 
-# API reference
+## Content guidance
 
-## Props
+**Chip labels:**
 
-_No additional props beyond the Mantine base component. The `variant` prop is stripped and has no effect._
+- Keep labels short and parallel.
+- Don't use chips when a label wraps or needs explanation.
 
-## Sub-components
+**Group labels (`Chip.Group`):**
 
-Plasma provides pre-configured sub-components as convenience wrappers. You SHOULD use these over setting props manually.
-
-- `Chip.Group`
-
-## Usage
-
-```tsx
-import {Chip} from '@coveord/plasma-mantine';
-
-function Example() {
-    return (
-        <Chip.Group multiple defaultValue={['react']}>
-            <Chip value="react">React</Chip>
-            <Chip value="vue">Vue</Chip>
-            <Chip value="angular">Angular</Chip>
-        </Chip.Group>
-    );
-}
-```
+- Explain what the chip set controls.

--- a/packages/storybook/src/components/forms-and-inputs/array/Collection.mdx
+++ b/packages/storybook/src/components/forms-and-inputs/array/Collection.mdx
@@ -1,0 +1,170 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+import * as stories from './Collection.stories';
+
+<Meta of={stories} title="@components/Forms and inputs/array/Collection" />
+
+{/* For the agent-friendly version of this documentation, see packages/llms/src/components/Collection.md */}
+
+# Collection
+
+Dynamic list input that can render items with column-based layouts or a legacy children render prop.
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `Collection` lets users add, remove, edit, and optionally reorder repeated form items as one structured field.
+
+It is useful for editable lists such as contacts, recipients, rules, conditions, mappings, or repeated configuration blocks.
+
+## When to use it
+
+Use `Collection` when:
+
+- users manage a repeatable set of structured items
+- each item has one or more editable fields
+- users need add/remove behavior in the same form context
+- stable item identity matters for updates, validation, or form state
+
+## When not to use it
+
+Do not use `Collection` when:
+
+- the list is read-only data; use `Table`, cards, or a list
+- users are selecting from existing options rather than creating repeated items
+- each item is complex enough to need its own page or dedicated editor
+- the repeated fields are unrelated and should not be grouped as one form field
+
+## Decision-making guidance
+
+- Use `Table` for read-only or data-heavy tabular display.
+- Use `ChildForm` for one optional nested section, not a repeatable list.
+
+## States
+
+Important states include:
+
+- empty collection
+- one or more items
+- disabled or read-only collection
+- add disabled because the current state does not allow insertion
+- draggable reorder mode
+
+## Interaction notes
+
+- `newItem` MUST create a valid starting item.
+- `required` SHOULD be used when at least one item must remain.
+- `addDisabledTooltip` SHOULD explain why adding is currently unavailable.
+- Reordering SHOULD preserve item values and validation state.
+
+## Content guidance
+
+- Labels SHOULD describe the repeated item type.
+- Add button labels SHOULD name the item being added, such as "Add contact."
+- Column headers SHOULD be short and describe the fields inside each item.
+
+## Common anti-patterns
+
+- Using `Collection` for static read-only data.
+- Omitting stable item IDs when items can be reordered.
+- Letting users add many empty repeated items without clear validation.
+
+# API reference
+
+## Props
+
+> Extends: `__InputWrapperProps`, `BoxProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+
+**`columns`** `Array<CollectionColumnDef<T>>` · optional · default: `undefined` — MAY provide column definitions for the collection. This prop is REQUIRED when using the column-based pattern.
+**`layout`** `CollectionLayout` · optional · default: `CollectionLayouts.Horizontal` — MAY define the layout component to use for rendering. This prop MUST only be used with `columns`.
+**`children`** `(item: T, index: number) => ReactNode` · optional · default: `undefined` — MAY provide a render function called for each item passed in the `value` prop. `columns` and `layout` MUST NOT be used with this pattern.
+**`newItem`** `T | (() => T)` · required · default: `undefined` — REQUIRED. MUST define the default value each new item SHOULD have.
+**`value`** `T[]` · optional · default: `[]` — MAY provide the list of items to display inside the collection.
+**`getItemId`** `(originalItem: T, itemIndex: number) => string` · optional · default: `({id}) => id` — MAY define how each item is uniquely identified. It is RECOMMENDED that you specify this prop to an ID that makes sense. This method is REQUIRED when using this component with ReactHookForm.
+**`onFocus`** `() => void` · optional · default: `undefined` — Optional. Unused and has no effect.
+**`onChange`** `(value: T[]) => void` · optional · default: `undefined` — MAY be used to receive the whole list of items after the change whenever the value needs to be updated.
+**`onRemoveItem`** `(itemIndex: number) => void` · optional · default: `undefined` — MAY be used to receive the index of the item removed from the collection using the remove button.
+**`onReorderItem`** `(payload: {from: number; to: number}) => void` · optional · default: `undefined` — MAY be used to receive the origin and destination index whenever a collection item needs to be reordered.
+**`onInsertItem`** `(value: T, index: number) => void` · optional · default: `undefined` — MAY be used to receive the value of the item to insert and the index of the new item to insert when a new item needs to be added to the collection.
+**`draggable`** `boolean` · optional · default: `false` — MAY enable drag and drop behavior for the collection.
+**`disabled`** `boolean` · optional · default: `false` — Can disable the collection; in other words, it can put the collection in read-only mode.
+**`readOnly`** `boolean` · optional · default: `false` — MAY mark the collection as readOnly. If true, the collection prevents adding or removing items.
+**`allowAdd`** `boolean | ((values: T[]) => boolean)` · optional · default: `undefined` — MAY determine if the add item button SHOULD be enabled given the current items of the collection. The button remains enabled if this prop is undefined.
+**`addLabel`** `ReactNode` · optional · default: `"Add item"` — MAY define the label of the add item button.
+**`addDisabledTooltip`** `string` · optional · default: `'There is already an empty item'` — MAY define the tooltip text displayed when hovering over the disabled add item button.
+**`gap`** `MantineSpacing` · optional · default: `'md'` — MAY define the gap between the collection items.
+**`required`** `boolean` · optional · default: `false` — MAY mark the collection as required. When true, the collection hides the remove button if there is only one item.
+
+## Sub-components
+
+Plasma provides pre-configured sub-components as convenience wrappers. You SHOULD use these over setting props manually.
+
+- `Collection.Layouts`
+
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `Collection.Props<T>`
+- `Collection.StylesNames`
+- `Collection.Factory`
+
+## Usage
+
+```tsx
+import {useState} from 'react';
+import {Collection, TextInput} from '@coveord/plasma-mantine';
+
+interface Contact {
+    id: string;
+    name: string;
+    email: string;
+}
+
+function Example() {
+    const [contacts, setContacts] = useState<Contact[]>([{id: '1', name: 'Alice Smith', email: 'alice@example.com'}]);
+
+    return (
+        <Collection<Contact>
+            label="Contacts"
+            value={contacts}
+            onChange={setContacts}
+            getItemId={(contact) => contact.id}
+            newItem={() => ({id: crypto.randomUUID(), name: '', email: ''})}
+            columns={[
+                {
+                    header: 'Name',
+                    cell: (contact, index) => (
+                        <TextInput
+                            value={contact.name}
+                            onChange={(event) => {
+                                const nextContacts = [...contacts];
+                                nextContacts[index] = {...contact, name: event.currentTarget.value};
+                                setContacts(nextContacts);
+                            }}
+                        />
+                    ),
+                    maxSize: 200,
+                },
+                {
+                    header: 'Email',
+                    cell: (contact, index) => (
+                        <TextInput
+                            value={contact.email}
+                            onChange={(event) => {
+                                const nextContacts = [...contacts];
+                                nextContacts[index] = {...contact, email: event.currentTarget.value};
+                                setContacts(nextContacts);
+                            }}
+                        />
+                    ),
+                },
+            ]}
+        />
+    );
+}
+```
+
+- The column-based pattern is the RECOMMENDED option for editable lists such as contacts, recipients, or rules.
+- Import `Collection` and related inputs from `@coveord/plasma-mantine`.
+- Pass `getItemId` when items have stable IDs, especially when the list is updated from form state.

--- a/packages/storybook/src/components/forms-and-inputs/array/Collection.mdx
+++ b/packages/storybook/src/components/forms-and-inputs/array/Collection.mdx
@@ -9,162 +9,66 @@ import * as stories from './Collection.stories';
 
 Dynamic list input that can render items with column-based layouts or a legacy children render prop.
 
-# Usage guidance
+## Overview
 
-## What problem does it solve?
-
-The `Collection` lets users add, remove, edit, and optionally reorder repeated form items as one structured field.
-
-It is useful for editable lists such as contacts, recipients, rules, conditions, mappings, or repeated configuration blocks.
+The Collection lets users add, remove, edit, and optionally reorder repeated form items as one structured field.
+Reach for it for editable lists such as contacts, recipients, rules, conditions, or configuration blocks.
 
 ## When to use it
 
 Use `Collection` when:
 
-- users manage a repeatable set of structured items
-- each item has one or more editable fields
-- users need add/remove behavior in the same form context
-- stable item identity matters for updates, validation, or form state
+- Users manage a repeatable set of structured items.
+- Each item has one or more editable fields.
+- Users need add and remove behavior in the same form context.
+- Stable item identity matters for updates, validation, or form state.
 
 ## When not to use it
 
-Do not use `Collection` when:
+Don't use `Collection` when:
 
-- the list is read-only data; use `Table`, cards, or a list
-- users are selecting from existing options rather than creating repeated items
-- each item is complex enough to need its own page or dedicated editor
-- the repeated fields are unrelated and should not be grouped as one form field
+- The list is read-only data. Use `Table`, cards, or a list instead.
+- Users select from existing options rather than creating repeated items.
+- Each item is complex enough to need its own page or dedicated editor.
+- The repeated fields are unrelated and shouldn't be grouped as one form field.
 
-## Decision-making guidance
+## Choosing a control
 
 - Use `Table` for read-only or data-heavy tabular display.
 - Use `ChildForm` for one optional nested section, not a repeatable list.
 
 ## States
 
-Important states include:
+- **Empty** shows no items yet.
+- **One or more items** shows the editable rows.
+- **Disabled or read-only** prevents changes.
+- **Add disabled** blocks insertion when the current state doesn't allow it.
+- **Draggable reorder** lets users reorder items.
 
-- empty collection
-- one or more items
-- disabled or read-only collection
-- add disabled because the current state does not allow insertion
-- draggable reorder mode
+## Interaction
 
-## Interaction notes
-
-- `newItem` MUST create a valid starting item.
-- `required` SHOULD be used when at least one item must remain.
-- `addDisabledTooltip` SHOULD explain why adding is currently unavailable.
-- Reordering SHOULD preserve item values and validation state.
-
-## Content guidance
-
-- Labels SHOULD describe the repeated item type.
-- Add button labels SHOULD name the item being added, such as "Add contact."
-- Column headers SHOULD be short and describe the fields inside each item.
+- Make `newItem` create a valid starting item.
+- Use `required` when at least one item must remain.
+- Use `addDisabledTooltip` to explain why adding is currently unavailable.
+- Preserve item values and validation state when reordering.
 
 ## Common anti-patterns
 
-- Using `Collection` for static read-only data.
-- Omitting stable item IDs when items can be reordered.
-- Letting users add many empty repeated items without clear validation.
+- Don't use `Collection` for static read-only data.
+- Don't omit stable item IDs when items can be reordered.
+- Don't let users add many empty repeated items without clear validation.
 
-# API reference
+## Content guidance
 
-## Props
+**Field label (`label`):**
 
-> Extends: `__InputWrapperProps`, `BoxProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+- Describe the repeated item type: `"Contacts" not "List"`.
 
-**`columns`** `Array<CollectionColumnDef<T>>` · optional · default: `undefined` — MAY provide column definitions for the collection. This prop is REQUIRED when using the column-based pattern.
-**`layout`** `CollectionLayout` · optional · default: `CollectionLayouts.Horizontal` — MAY define the layout component to use for rendering. This prop MUST only be used with `columns`.
-**`children`** `(item: T, index: number) => ReactNode` · optional · default: `undefined` — MAY provide a render function called for each item passed in the `value` prop. `columns` and `layout` MUST NOT be used with this pattern.
-**`newItem`** `T | (() => T)` · required · default: `undefined` — REQUIRED. MUST define the default value each new item SHOULD have.
-**`value`** `T[]` · optional · default: `[]` — MAY provide the list of items to display inside the collection.
-**`getItemId`** `(originalItem: T, itemIndex: number) => string` · optional · default: `({id}) => id` — MAY define how each item is uniquely identified. It is RECOMMENDED that you specify this prop to an ID that makes sense. This method is REQUIRED when using this component with ReactHookForm.
-**`onFocus`** `() => void` · optional · default: `undefined` — Optional. Unused and has no effect.
-**`onChange`** `(value: T[]) => void` · optional · default: `undefined` — MAY be used to receive the whole list of items after the change whenever the value needs to be updated.
-**`onRemoveItem`** `(itemIndex: number) => void` · optional · default: `undefined` — MAY be used to receive the index of the item removed from the collection using the remove button.
-**`onReorderItem`** `(payload: {from: number; to: number}) => void` · optional · default: `undefined` — MAY be used to receive the origin and destination index whenever a collection item needs to be reordered.
-**`onInsertItem`** `(value: T, index: number) => void` · optional · default: `undefined` — MAY be used to receive the value of the item to insert and the index of the new item to insert when a new item needs to be added to the collection.
-**`draggable`** `boolean` · optional · default: `false` — MAY enable drag and drop behavior for the collection.
-**`disabled`** `boolean` · optional · default: `false` — Can disable the collection; in other words, it can put the collection in read-only mode.
-**`readOnly`** `boolean` · optional · default: `false` — MAY mark the collection as readOnly. If true, the collection prevents adding or removing items.
-**`allowAdd`** `boolean | ((values: T[]) => boolean)` · optional · default: `undefined` — MAY determine if the add item button SHOULD be enabled given the current items of the collection. The button remains enabled if this prop is undefined.
-**`addLabel`** `ReactNode` · optional · default: `"Add item"` — MAY define the label of the add item button.
-**`addDisabledTooltip`** `string` · optional · default: `'There is already an empty item'` — MAY define the tooltip text displayed when hovering over the disabled add item button.
-**`gap`** `MantineSpacing` · optional · default: `'md'` — MAY define the gap between the collection items.
-**`required`** `boolean` · optional · default: `false` — MAY mark the collection as required. When true, the collection hides the remove button if there is only one item.
+**Add button (`addLabel`):**
 
-## Sub-components
+- Name the item being added: `"Add contact" not "Add item"`.
 
-Plasma provides pre-configured sub-components as convenience wrappers. You SHOULD use these over setting props manually.
+**Column headers (`columns`):**
 
-- `Collection.Layouts`
-
-## TypeScript namespace aliases
-
-These type-only aliases are available for annotations and do not add runtime static properties.
-
-- `Collection.Props<T>`
-- `Collection.StylesNames`
-- `Collection.Factory`
-
-## Usage
-
-```tsx
-import {useState} from 'react';
-import {Collection, TextInput} from '@coveord/plasma-mantine';
-
-interface Contact {
-    id: string;
-    name: string;
-    email: string;
-}
-
-function Example() {
-    const [contacts, setContacts] = useState<Contact[]>([{id: '1', name: 'Alice Smith', email: 'alice@example.com'}]);
-
-    return (
-        <Collection<Contact>
-            label="Contacts"
-            value={contacts}
-            onChange={setContacts}
-            getItemId={(contact) => contact.id}
-            newItem={() => ({id: crypto.randomUUID(), name: '', email: ''})}
-            columns={[
-                {
-                    header: 'Name',
-                    cell: (contact, index) => (
-                        <TextInput
-                            value={contact.name}
-                            onChange={(event) => {
-                                const nextContacts = [...contacts];
-                                nextContacts[index] = {...contact, name: event.currentTarget.value};
-                                setContacts(nextContacts);
-                            }}
-                        />
-                    ),
-                    maxSize: 200,
-                },
-                {
-                    header: 'Email',
-                    cell: (contact, index) => (
-                        <TextInput
-                            value={contact.email}
-                            onChange={(event) => {
-                                const nextContacts = [...contacts];
-                                nextContacts[index] = {...contact, email: event.currentTarget.value};
-                                setContacts(nextContacts);
-                            }}
-                        />
-                    ),
-                },
-            ]}
-        />
-    );
-}
-```
-
-- The column-based pattern is the RECOMMENDED option for editable lists such as contacts, recipients, or rules.
-- Import `Collection` and related inputs from `@coveord/plasma-mantine`.
-- Pass `getItemId` when items have stable IDs, especially when the list is updated from form state.
+- Keep headers short.
+- Describe the fields inside each item.

--- a/packages/storybook/src/components/forms-and-inputs/boolean/Checkbox.mdx
+++ b/packages/storybook/src/components/forms-and-inputs/boolean/Checkbox.mdx
@@ -1,0 +1,112 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+import * as stories from './Checkbox.stories';
+
+<Meta of={stories} title="@components/Forms and inputs/boolean/Checkbox" />
+
+{/* For the agent-friendly version of this documentation, see packages/llms/src/components/Checkbox.md */}
+
+# Checkbox
+
+Boolean selection control for choosing zero, one, or many visible options, including stand-alone opt-in choices.
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `Checkbox` lets users select zero, one, or many options from a visible set.
+
+It is useful when users need to compare options directly and the list remains short enough to scan comfortably.
+
+## When to use it
+
+Use `Checkbox` when:
+
+- users can choose any number of options, from none to many
+- options SHOULD remain visible for comparison
+- a stand-alone optional commitment or confirmation is needed
+
+`Checkbox.Group` SHOULD be used when multiple related checkboxes form a single field or choice set.
+
+## When not to use it
+
+Do not use `Checkbox` when:
+
+- only one option can be selected
+- the user is choosing between immediate view modes or display states
+- the list is so long that scanning individual options becomes inefficient
+
+## Decision-making guidance
+
+- Use `Checkbox` when direct visibility of options matters
+- Prefer a stand-alone checkbox for an optional commitment or confirmation
+- If the result applies immediately, another control such as a toggle-like option MAY be more appropriate
+- If the list grows too long, a searchable multi-select pattern is often a better fit than simply adding more checkboxes
+- As a starting product guideline, forms SHOULD avoid showing more than about 8 checkboxes together unless there is a strong reason to keep the full list visible
+
+## States
+
+Important states include:
+
+- unchecked
+- checked
+- indeterminate
+- disabled
+- read-only, when provided by the consumer
+
+## Interaction notes
+
+- When presenting multiple related checkboxes, group them together so they behave and read as a set.
+- The indeterminate state (a dash instead of a checkmark) should only appear when it genuinely reflects a partial selection — for example, when some but not all items in a group are checked.
+- Grouped checkboxes can be arranged in a single row or stacked vertically — choose based on how many there are and how much space is available.
+
+## Accessibility expectations
+
+- Each checkbox MUST have a clear, programmatically associated label
+- Related checkbox groups SHOULD have a group label or legend
+- Indeterminate state SHOULD only be used when it has a real parent-child meaning
+- Keyboard users MUST be able to move through and toggle options predictably
+
+## Content guidance
+
+- Labels SHOULD be short, self-explanatory, and consistent across a group
+- For a stand-alone checkbox, the label SHOULD describe what happens if the checkbox is selected
+- Group titles SHOULD describe the type of options available rather than instructing the user with an action phrase
+
+## Common anti-patterns
+
+- Using checkboxes for mutually exclusive choices
+- Showing long checkbox lists that are hard to scan
+- Using an indeterminate state without a real parent-child relationship
+
+# API reference
+
+## Props
+
+_No additional props beyond the Mantine base component._
+
+## Sub-components
+
+Plasma re-exports Mantine's grouped checkbox API.
+
+- `Checkbox.Group`
+
+## Usage
+
+```tsx
+import {Checkbox, Group} from '@coveord/plasma-mantine';
+
+// Stand-alone checkbox
+<Checkbox label="Send me a text notification" />;
+
+// Grouped options
+<Checkbox.Group label="Options">
+    <Group mt="xs">
+        <Checkbox value="1" label="Option 1" />
+        <Checkbox value="2" label="Option 2" />
+        <Checkbox value="3" label="Option 3" />
+    </Group>
+</Checkbox.Group>;
+
+// Indeterminate state when a parent option is only partially selected
+<Checkbox label="Select all" indeterminate />;
+```

--- a/packages/storybook/src/components/forms-and-inputs/boolean/Checkbox.mdx
+++ b/packages/storybook/src/components/forms-and-inputs/boolean/Checkbox.mdx
@@ -9,104 +9,72 @@ import * as stories from './Checkbox.stories';
 
 Boolean selection control for choosing zero, one, or many visible options, including stand-alone opt-in choices.
 
-# Usage guidance
+## Overview
 
-## What problem does it solve?
-
-The `Checkbox` lets users select zero, one, or many options from a visible set.
-
-It is useful when users need to compare options directly and the list remains short enough to scan comfortably.
+The Checkbox lets users pick zero, one, or many options from a visible set.
+Reach for it when users compare options directly and the list stays short enough to scan.
+It also covers a stand-alone opt-in choice, such as a single confirmation.
 
 ## When to use it
 
 Use `Checkbox` when:
 
-- users can choose any number of options, from none to many
-- options SHOULD remain visible for comparison
-- a stand-alone optional commitment or confirmation is needed
+- Users can choose any number of options, from none to many.
+- Options stay visible for comparison.
+- You need a stand-alone optional commitment or confirmation.
 
-`Checkbox.Group` SHOULD be used when multiple related checkboxes form a single field or choice set.
+Use `Checkbox.Group` when related checkboxes form a single field or choice set.
 
 ## When not to use it
 
-Do not use `Checkbox` when:
+Don't use `Checkbox` when:
 
-- only one option can be selected
-- the user is choosing between immediate view modes or display states
-- the list is so long that scanning individual options becomes inefficient
+- Only one option can be selected.
+- The user is choosing between immediate view modes or display states.
+- The list is so long that scanning options becomes inefficient.
 
-## Decision-making guidance
+## Choosing a control
 
-- Use `Checkbox` when direct visibility of options matters
-- Prefer a stand-alone checkbox for an optional commitment or confirmation
-- If the result applies immediately, another control such as a toggle-like option MAY be more appropriate
-- If the list grows too long, a searchable multi-select pattern is often a better fit than simply adding more checkboxes
-- As a starting product guideline, forms SHOULD avoid showing more than about 8 checkboxes together unless there is a strong reason to keep the full list visible
+- Use `Checkbox` when direct visibility of the options matters.
+- Prefer a stand-alone checkbox for an optional commitment or confirmation.
+- Consider a toggle-like option when the result applies immediately.
+- Choose a searchable multi-select pattern when the list grows too long, instead of adding more checkboxes.
+- As a starting guideline, avoid showing more than about eight checkboxes together without a strong reason.
 
 ## States
 
-Important states include:
+- **Unchecked** is the default, empty state.
+- **Checked** shows a checkmark.
+- **Indeterminate** shows a dash for a partial selection.
+- **Disabled** prevents interaction.
+- **Read-only** applies when the consumer provides it.
 
-- unchecked
-- checked
-- indeterminate
-- disabled
-- read-only, when provided by the consumer
+## Interaction
 
-## Interaction notes
+- Group related checkboxes together so they read and behave as a set.
+- Show the indeterminate state, a dash instead of a checkmark, only when it reflects a partial selection. For example, when some but not all items in a group are checked.
+- Arrange grouped checkboxes in a single row or stacked vertically, based on how many there are and the space available.
 
-- When presenting multiple related checkboxes, group them together so they behave and read as a set.
-- The indeterminate state (a dash instead of a checkmark) should only appear when it genuinely reflects a partial selection — for example, when some but not all items in a group are checked.
-- Grouped checkboxes can be arranged in a single row or stacked vertically — choose based on how many there are and how much space is available.
+## Accessibility
 
-## Accessibility expectations
-
-- Each checkbox MUST have a clear, programmatically associated label
-- Related checkbox groups SHOULD have a group label or legend
-- Indeterminate state SHOULD only be used when it has a real parent-child meaning
-- Keyboard users MUST be able to move through and toggle options predictably
-
-## Content guidance
-
-- Labels SHOULD be short, self-explanatory, and consistent across a group
-- For a stand-alone checkbox, the label SHOULD describe what happens if the checkbox is selected
-- Group titles SHOULD describe the type of options available rather than instructing the user with an action phrase
+- Give each checkbox a clear, programmatically associated label.
+- Give related checkbox groups a group label or legend.
+- Use the indeterminate state only when it has a real parent-child meaning.
+- Make sure keyboard users can move through and toggle options predictably.
 
 ## Common anti-patterns
 
-- Using checkboxes for mutually exclusive choices
-- Showing long checkbox lists that are hard to scan
-- Using an indeterminate state without a real parent-child relationship
+- Don't use checkboxes for mutually exclusive choices.
+- Don't show long checkbox lists that are hard to scan.
+- Don't use an indeterminate state without a real parent-child relationship.
 
-# API reference
+## Content guidance
 
-## Props
+**Checkbox labels (`label`):**
 
-_No additional props beyond the Mantine base component._
+- Keep labels short, self-explanatory, and consistent across a group.
+- For a stand-alone checkbox, describe what happens when it's selected: `"Send me a text notification" not "Text notification"`.
 
-## Sub-components
+**Group titles (`Checkbox.Group`):**
 
-Plasma re-exports Mantine's grouped checkbox API.
-
-- `Checkbox.Group`
-
-## Usage
-
-```tsx
-import {Checkbox, Group} from '@coveord/plasma-mantine';
-
-// Stand-alone checkbox
-<Checkbox label="Send me a text notification" />;
-
-// Grouped options
-<Checkbox.Group label="Options">
-    <Group mt="xs">
-        <Checkbox value="1" label="Option 1" />
-        <Checkbox value="2" label="Option 2" />
-        <Checkbox value="3" label="Option 3" />
-    </Group>
-</Checkbox.Group>;
-
-// Indeterminate state when a parent option is only partially selected
-<Checkbox label="Select all" indeterminate />;
-```
+- Describe the type of options available, not an action to take: `"Notifications" not "Choose your notifications"`.

--- a/packages/storybook/src/components/forms-and-inputs/string/CodeEditor.mdx
+++ b/packages/storybook/src/components/forms-and-inputs/string/CodeEditor.mdx
@@ -9,92 +9,58 @@ import * as stories from './CodeEditor.stories';
 
 Monaco-based code editor that supports syntax highlighting, validation, search, and copy actions.
 
-# Usage guidance
+## Overview
 
-## What problem does it solve?
-
-The `CodeEditor` gives users a structured editing surface for code-like, syntax-sensitive, or multi-line technical content.
-
-It is useful when plain text entry is not enough because users need syntax highlighting, code formatting expectations, search, copy, or editor-level behavior.
+The CodeEditor gives users a structured surface for editing code-like content.
+Reach for it when plain text entry isn't enough for syntax-sensitive or multi-line technical values.
+It adds syntax highlighting, formatting expectations, search, and copy actions.
 
 ## When to use it
 
 Use `CodeEditor` when:
 
-- users edit JSON, XML, Python, Markdown, or other code-like content
-- syntax highlighting helps users understand or validate the value
-- the content is multi-line and technical
-- search or copy actions are useful inside the editor
+- Users edit JSON, XML, Python, Markdown, or other code-like content.
+- Syntax highlighting helps users understand or validate the value.
+- The content is multi-line and technical.
+- Search or copy actions are useful inside the editor.
 
 ## When not to use it
 
-Do not use `CodeEditor` when:
+Don't use `CodeEditor` when:
 
-- users enter ordinary short text; use `TextInput`
-- users enter long prose; use `Textarea`
-- syntax support would add complexity without helping the task
+- Users enter ordinary short text. Use `TextInput` instead.
+- Users enter long prose. Use `Textarea` instead.
+- Syntax support would add complexity without helping the task.
 
-## Decision-making guidance
+## Choosing a control
 
 - Use `CodeEditor` for technical text where structure matters.
 - Use `Textarea` for freeform prose or comments.
 - Use `TextInput` for short single-line values.
 - Use `disabled` when the editor should be readable but not editable.
 
-## Accessibility expectations
+## Accessibility
 
-- Labels and descriptions SHOULD explain what kind of content is expected.
-- Validation feedback SHOULD identify the problem and location when possible.
-- The editor height SHOULD leave enough room for users to understand the content.
+- Use labels and descriptions to explain what kind of content is expected.
+- Make validation feedback identify the problem and its location when possible.
+- Give the editor enough height for users to understand the content.
 
 ## Common anti-patterns
 
-- Using a code editor for ordinary text fields.
-- Making users edit large structured payloads without examples or validation.
-- Setting a very small height for multi-line technical content.
+- Don't use a code editor for ordinary text fields.
+- Don't make users edit large structured payloads without examples or validation.
+- Don't set a very small height for multi-line technical content.
 
-# API reference
+## Content guidance
 
-## Props
+**Field label (`label`):**
 
-> Extends: `InputWrapperProps`, `StackProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+- Name the kind of content the editor expects: `"Payload" not "Input"`.
 
-**`language`** `'plaintext' | 'json' | 'markdown' | 'python' | 'xml' | (string & unknown)` · optional · default: `plaintext` — Defines the language syntax of the editor.
-**`defaultValue`** `string` · optional · default: `''` — For uncontrolled input, this prop MAY provide the default value.
-**`value`** `string` · optional · default: `undefined` — For controlled input, this prop MUST provide the value.
-**`onChange`** `(value: string) => void` · optional · default: `undefined` — For controlled input, this callback receives the updated value.
-**`onSearch`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the search icon is clicked.
-**`onCopy`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the copy icon is clicked.
-**`onFocus`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the code editor gets focus.
-**`editorHandle`** `React.MutableRefObject<monacoEditor.IStandaloneCodeEditor | null>` · optional · default: `undefined` — This ref MAY provide access to the editor's functionality.
-**`minHeight`** `number` · optional · default: `300` — The CodeEditor height, including label and description, is never smaller than this value. By default, the CodeEditor adjusts to fill its parent height. If the parent height is too short, the component uses this value as its minimum height.
-**`maxHeight`** `number` · optional · default: `undefined` — The CodeEditor height, including label and description, is never larger than this value. By default, the CodeEditor adjusts to fill its parent height. This prop can set the maximum height when the parent height would otherwise be too high.
-**`disabled`** `boolean` · optional · default: `undefined` — When set, the editor is read-only and uses disabled styling.
-**`monacoLoader`** `'cdn' | 'local'` · optional · default: `local` — Defines how the Monaco editor files are loaded. When `local` is used, the required [additional configuration](https://github.com/suren-atoyan/monaco-react#use-monaco-editor-as-an-npm-package) MUST be provided.
-**`options`** `Pick<monacoEditor.IStandaloneEditorConstructionOptions, 'tabSize'>` · optional · default: `undefined` — This prop MAY pass options to the Monaco editor. It currently supports only [`tabSize`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html#tabSize).
+**Description (`description`):**
 
-## Usage
+- Explain what to enter and any format expectations.
 
-```tsx
-import {useState} from 'react';
-import {CodeEditor} from '@coveord/plasma-mantine';
+**Validation messages:**
 
-export function JsonEditor() {
-    const [value, setValue] = useState(`{
-  "name": "Plasma",
-  "enabled": true
-}`);
-
-    return (
-        <CodeEditor
-            label="Payload"
-            description="Edit the JSON payload before saving."
-            language="json"
-            value={value}
-            onChange={setValue}
-            monacoLoader="cdn"
-            minHeight={320}
-        />
-    );
-}
-```
+- Identify the problem and its location when possible.

--- a/packages/storybook/src/components/forms-and-inputs/string/CodeEditor.mdx
+++ b/packages/storybook/src/components/forms-and-inputs/string/CodeEditor.mdx
@@ -1,0 +1,100 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+import * as stories from './CodeEditor.stories';
+
+<Meta of={stories} title="@components/Forms and inputs/string/CodeEditor" />
+
+{/* For the agent-friendly version of this documentation, see packages/llms/src/components/CodeEditor.md */}
+
+# CodeEditor
+
+Monaco-based code editor that supports syntax highlighting, validation, search, and copy actions.
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `CodeEditor` gives users a structured editing surface for code-like, syntax-sensitive, or multi-line technical content.
+
+It is useful when plain text entry is not enough because users need syntax highlighting, code formatting expectations, search, copy, or editor-level behavior.
+
+## When to use it
+
+Use `CodeEditor` when:
+
+- users edit JSON, XML, Python, Markdown, or other code-like content
+- syntax highlighting helps users understand or validate the value
+- the content is multi-line and technical
+- search or copy actions are useful inside the editor
+
+## When not to use it
+
+Do not use `CodeEditor` when:
+
+- users enter ordinary short text; use `TextInput`
+- users enter long prose; use `Textarea`
+- syntax support would add complexity without helping the task
+
+## Decision-making guidance
+
+- Use `CodeEditor` for technical text where structure matters.
+- Use `Textarea` for freeform prose or comments.
+- Use `TextInput` for short single-line values.
+- Use `disabled` when the editor should be readable but not editable.
+
+## Accessibility expectations
+
+- Labels and descriptions SHOULD explain what kind of content is expected.
+- Validation feedback SHOULD identify the problem and location when possible.
+- The editor height SHOULD leave enough room for users to understand the content.
+
+## Common anti-patterns
+
+- Using a code editor for ordinary text fields.
+- Making users edit large structured payloads without examples or validation.
+- Setting a very small height for multi-line technical content.
+
+# API reference
+
+## Props
+
+> Extends: `InputWrapperProps`, `StackProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+
+**`language`** `'plaintext' | 'json' | 'markdown' | 'python' | 'xml' | (string & unknown)` · optional · default: `plaintext` — Defines the language syntax of the editor.
+**`defaultValue`** `string` · optional · default: `''` — For uncontrolled input, this prop MAY provide the default value.
+**`value`** `string` · optional · default: `undefined` — For controlled input, this prop MUST provide the value.
+**`onChange`** `(value: string) => void` · optional · default: `undefined` — For controlled input, this callback receives the updated value.
+**`onSearch`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the search icon is clicked.
+**`onCopy`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the copy icon is clicked.
+**`onFocus`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the code editor gets focus.
+**`editorHandle`** `React.MutableRefObject<monacoEditor.IStandaloneCodeEditor | null>` · optional · default: `undefined` — This ref MAY provide access to the editor's functionality.
+**`minHeight`** `number` · optional · default: `300` — The CodeEditor height, including label and description, is never smaller than this value. By default, the CodeEditor adjusts to fill its parent height. If the parent height is too short, the component uses this value as its minimum height.
+**`maxHeight`** `number` · optional · default: `undefined` — The CodeEditor height, including label and description, is never larger than this value. By default, the CodeEditor adjusts to fill its parent height. This prop can set the maximum height when the parent height would otherwise be too high.
+**`disabled`** `boolean` · optional · default: `undefined` — When set, the editor is read-only and uses disabled styling.
+**`monacoLoader`** `'cdn' | 'local'` · optional · default: `local` — Defines how the Monaco editor files are loaded. When `local` is used, the required [additional configuration](https://github.com/suren-atoyan/monaco-react#use-monaco-editor-as-an-npm-package) MUST be provided.
+**`options`** `Pick<monacoEditor.IStandaloneEditorConstructionOptions, 'tabSize'>` · optional · default: `undefined` — This prop MAY pass options to the Monaco editor. It currently supports only [`tabSize`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html#tabSize).
+
+## Usage
+
+```tsx
+import {useState} from 'react';
+import {CodeEditor} from '@coveord/plasma-mantine';
+
+export function JsonEditor() {
+    const [value, setValue] = useState(`{
+  "name": "Plasma",
+  "enabled": true
+}`);
+
+    return (
+        <CodeEditor
+            label="Payload"
+            description="Edit the JSON payload before saving."
+            language="json"
+            value={value}
+            onChange={setValue}
+            monacoLoader="cdn"
+            minHeight={320}
+        />
+    );
+}
+```

--- a/packages/storybook/src/components/layout/ChildForm.mdx
+++ b/packages/storybook/src/components/layout/ChildForm.mdx
@@ -1,0 +1,105 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+import * as stories from './ChildForm.stories';
+
+<Meta of={stories} title="@components/Layout/ChildForm" />
+
+{/* For the agent-friendly version of this documentation, see packages/llms/src/components/ChildForm.md */}
+
+# ChildForm
+
+Expandable nested sub-form within a parent form context.
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `ChildForm` reveals optional nested fields inside a larger form while keeping those related fields visually grouped.
+
+## When to use it
+
+Use `ChildForm` when:
+
+- a parent form has optional or conditional fields
+- fields should appear only after a user opts into a related configuration
+- nested fields belong to the same parent entity
+- title and description help explain the conditional section
+
+## When not to use it
+
+Do not use `ChildForm` when:
+
+- the section is always required and should be visible
+- the nested flow is large enough to need a separate step or page
+- the relationship between parent and child fields is unclear
+- hiding fields would make validation errors hard to understand
+
+## Decision-making guidance
+
+- Use `ChildForm` for conditional nested form sections.
+- Use a separate page, step, or modal when the child workflow is complex.
+- Pair it with the control that reveals the section, such as a checkbox or switch.
+
+## Interaction notes
+
+- The opening control SHOULD make it clear what fields will appear.
+- Collapsing a child form SHOULD NOT silently discard user-entered data unless the product explicitly confirms that behavior.
+- Validation errors inside a collapsed child form SHOULD remain discoverable.
+
+## Content guidance
+
+- Titles SHOULD name the nested object or configuration.
+- Descriptions SHOULD explain why the extra fields are needed.
+
+## Common anti-patterns
+
+- Hiding required fields behind an optional-looking control.
+- Nesting several child forms deeply.
+- Using `ChildForm` as a general layout card.
+
+# API reference
+
+## Props
+
+> Extends: `CollapseProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+
+**`title`** `string` · optional · default: `undefined` — MAY define the title of the child form.
+**`description`** `ReactNode` · optional · default: `undefined` — MAY define the description of the child form.
+
+## TypeScript namespace aliases
+
+These type-only aliases are available for annotations and do not add runtime static properties.
+
+- `ChildForm.Props`
+- `ChildForm.StylesNames`
+- `ChildForm.Factory`
+
+## Usage
+
+```tsx
+import {Checkbox, ChildForm, Stack, TextInput} from '@coveord/plasma-mantine';
+import {useState} from 'react';
+
+function Example() {
+    const [hasSecondaryContact, setHasSecondaryContact] = useState(false);
+
+    return (
+        <Stack>
+            <Checkbox
+                label="Add a secondary contact"
+                checked={hasSecondaryContact}
+                onChange={(event) => setHasSecondaryContact(event.currentTarget.checked)}
+            />
+            <ChildForm
+                in={hasSecondaryContact}
+                title="Secondary contact"
+                description="Collect backup contact details only when they are needed."
+            >
+                <TextInput label="Full name" placeholder="Taylor Smith" />
+                <TextInput label="Email" placeholder="taylor@example.com" />
+            </ChildForm>
+        </Stack>
+    );
+}
+```
+
+`ChildForm` SHOULD be used to reveal optional nested fields within a larger parent form while keeping related inputs visually grouped.

--- a/packages/storybook/src/components/layout/ChildForm.mdx
+++ b/packages/storybook/src/components/layout/ChildForm.mdx
@@ -9,97 +9,54 @@ import * as stories from './ChildForm.stories';
 
 Expandable nested sub-form within a parent form context.
 
-# Usage guidance
+## Overview
 
-## What problem does it solve?
-
-The `ChildForm` reveals optional nested fields inside a larger form while keeping those related fields visually grouped.
+ChildForm reveals optional nested fields inside a larger form.
+It keeps those related fields visually grouped so the section reads as one unit.
+Reach for it when a parent form has conditional fields that appear after the user opts in.
 
 ## When to use it
 
 Use `ChildForm` when:
 
-- a parent form has optional or conditional fields
-- fields should appear only after a user opts into a related configuration
-- nested fields belong to the same parent entity
-- title and description help explain the conditional section
+- A parent form has optional or conditional fields.
+- Fields should appear only after a user opts into a related configuration.
+- Nested fields belong to the same parent entity.
+- A title and description help explain the conditional section.
 
 ## When not to use it
 
-Do not use `ChildForm` when:
+Don't use `ChildForm` when:
 
-- the section is always required and should be visible
-- the nested flow is large enough to need a separate step or page
-- the relationship between parent and child fields is unclear
-- hiding fields would make validation errors hard to understand
+- The section is always required and should stay visible.
+- The nested flow is large enough to need a separate step or page.
+- The relationship between parent and child fields is unclear.
+- Hiding fields would make validation errors hard to understand.
 
-## Decision-making guidance
+## Choosing an approach
 
 - Use `ChildForm` for conditional nested form sections.
 - Use a separate page, step, or modal when the child workflow is complex.
 - Pair it with the control that reveals the section, such as a checkbox or switch.
 
-## Interaction notes
+## Interaction
 
-- The opening control SHOULD make it clear what fields will appear.
-- Collapsing a child form SHOULD NOT silently discard user-entered data unless the product explicitly confirms that behavior.
-- Validation errors inside a collapsed child form SHOULD remain discoverable.
-
-## Content guidance
-
-- Titles SHOULD name the nested object or configuration.
-- Descriptions SHOULD explain why the extra fields are needed.
+- Make the opening control clear about what fields will appear.
+- Don't silently discard user-entered data when a child form collapses, unless the product confirms that behavior.
+- Keep validation errors inside a collapsed child form discoverable.
 
 ## Common anti-patterns
 
-- Hiding required fields behind an optional-looking control.
-- Nesting several child forms deeply.
-- Using `ChildForm` as a general layout card.
+- Don't hide required fields behind an optional-looking control.
+- Don't nest several child forms deeply.
+- Don't use `ChildForm` as a general layout card.
 
-# API reference
+## Content guidance
 
-## Props
+**Title (`title`):**
 
-> Extends: `CollapseProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
+- Name the nested object or configuration: `"Secondary contact" not "More options"`.
 
-**`title`** `string` · optional · default: `undefined` — MAY define the title of the child form.
-**`description`** `ReactNode` · optional · default: `undefined` — MAY define the description of the child form.
+**Description (`description`):**
 
-## TypeScript namespace aliases
-
-These type-only aliases are available for annotations and do not add runtime static properties.
-
-- `ChildForm.Props`
-- `ChildForm.StylesNames`
-- `ChildForm.Factory`
-
-## Usage
-
-```tsx
-import {Checkbox, ChildForm, Stack, TextInput} from '@coveord/plasma-mantine';
-import {useState} from 'react';
-
-function Example() {
-    const [hasSecondaryContact, setHasSecondaryContact] = useState(false);
-
-    return (
-        <Stack>
-            <Checkbox
-                label="Add a secondary contact"
-                checked={hasSecondaryContact}
-                onChange={(event) => setHasSecondaryContact(event.currentTarget.checked)}
-            />
-            <ChildForm
-                in={hasSecondaryContact}
-                title="Secondary contact"
-                description="Collect backup contact details only when they are needed."
-            >
-                <TextInput label="Full name" placeholder="Taylor Smith" />
-                <TextInput label="Email" placeholder="taylor@example.com" />
-            </ChildForm>
-        </Stack>
-    );
-}
-```
-
-`ChildForm` SHOULD be used to reveal optional nested fields within a larger parent form while keeping related inputs visually grouped.
+- Explain why the extra fields are needed.


### PR DESCRIPTION
## Summary

Adds Storybook component documentation for the `C` component group.

## Components completed

- [x] Card
- [x] Checkbox
- [x] ChildForm
- [x] Chip
- [x] CloseButton
- [x] CodeEditor
- [x] Collection
- [x] CopyToClipboard

## Validation

For each component above:

- MDX file is under `packages/storybook/src/`
- `<Meta ... />` is unchanged after rewrite
- H1 and description are unchanged after rewrite
- Original `.md` source file was not modified
- Fenced code blocks are unchanged after rewrite
- Storybook build passed

## Build result

Passing.

## Demos
[Storybook](https://ds-426-c-components--69e1126f9e24a5e560359ac2.chromatic.com/?path=/docs/guidance-glossary--docs)
