### PR TITLE
Add value columns to foundations documentation pages

### DIFF
--- a/.changeset/fix-table-column-value-types.md
+++ b/.changeset/fix-table-column-value-types.md
@@ -1,0 +1,5 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Fix `Table` column types for inferred cell values

--- a/packages/mantine/src/components/Table/Table.types.ts
+++ b/packages/mantine/src/components/Table/Table.types.ts
@@ -71,7 +71,7 @@ export interface TableProps<TData> extends BoxProps, StylesApiProps<PlasmaTableF
      *
      * @see https://tanstack.com/table/v8/docs/guide/column-defs
      */
-    columns: Array<ColumnDef<TData>>;
+    columns: Array<ColumnDef<TData, any>>;
     /**
      * Available layouts
      *

--- a/packages/storybook/src/components/foundation/CSSVariableValue.tsx
+++ b/packages/storybook/src/components/foundation/CSSVariableValue.tsx
@@ -1,0 +1,6 @@
+import {Code} from '@coveord/plasma-mantine';
+
+export const CSSVariableValue = ({name}: {name: string}) => {
+    const rootStyles = window.getComputedStyle(document.documentElement);
+    return <Code>{rootStyles.getPropertyValue(name).trim()}</Code>;
+};

--- a/packages/storybook/src/components/foundation/radii/Radii.stories.tsx
+++ b/packages/storybook/src/components/foundation/radii/Radii.stories.tsx
@@ -1,6 +1,6 @@
-import {createColumnHelper, Table, useTable, type ColumnDef} from '@coveord/plasma-mantine';
-import {Box, Text} from '@mantine/core';
+import {Box, Code, createColumnHelper, Table, useTable} from '@coveord/plasma-mantine';
 import type {Meta, StoryObj} from '@storybook/react-vite';
+import {CSSVariableValue} from '../CSSVariableValue.js';
 import {FoundationWrapper} from '../FoundationWrapper.js';
 
 const meta: Meta = {
@@ -19,51 +19,50 @@ export default meta;
 type Story = StoryObj;
 
 type RadiusRowData = {
-    name: string;
-    value: string;
-    variable: string;
+    size: string;
 };
 
 const radiiValues: RadiusRowData[] = [
-    {name: 'none', value: '0px', variable: '--mantine-radius-none'},
-    {name: 'xs', value: '2px', variable: '--mantine-radius-xs'},
-    {name: 'sm', value: '4px', variable: '--mantine-radius-sm'},
-    {name: 'md', value: '8px', variable: '--mantine-radius-md'},
-    {name: 'lg', value: '16px', variable: '--mantine-radius-lg'},
-    {name: 'xl', value: '24px', variable: '--mantine-radius-xl'},
-    {name: 'xxl', value: '32px', variable: '--mantine-radius-xxl'},
+    {size: 'default'},
+    {size: 'none'},
+    {size: 'xs'},
+    {size: 'sm'},
+    {size: 'md'},
+    {size: 'lg'},
+    {size: 'xl'},
+    {size: 'xxl'},
 ];
+
+const getVariableName = (size: string): string => `--mantine-radius-${size}`;
 
 const columnHelper = createColumnHelper<RadiusRowData>();
 const columns = [
-    columnHelper.accessor('name', {
-        header: 'Name',
-        cell: ({getValue}) => (
-            <Text fw={600} ff="monospace" size="sm">
-                {getValue()}
-            </Text>
-        ),
+    columnHelper.accessor('size', {
+        header: 'Size',
+        cell: ({getValue}) => <Code fw={600}>{getValue()}</Code>,
         enableSorting: false,
     }),
-    columnHelper.accessor('variable', {
+    columnHelper.accessor('size', {
         header: 'Variable',
-        cell: ({getValue}) => (
-            <Text size="xs" c="dimmed" ff="monospace">
-                {getValue()}
-            </Text>
-        ),
+        cell: ({getValue}) => <Code>{getVariableName(getValue())}</Code>,
         enableSorting: false,
     }),
-    columnHelper.display({
+    columnHelper.accessor('size', {
+        header: 'Value',
+        cell: ({getValue}) => <CSSVariableValue name={getVariableName(getValue())} />,
+        enableSorting: false,
+    }),
+    columnHelper.accessor('size', {
         id: 'preview',
         header: '',
-        cell: ({row}) => (
+        enableSorting: false,
+        cell: ({getValue}) => (
             <Box
                 style={{
                     width: 64,
                     height: 64,
                     backgroundColor: 'var(--mantine-color-blue-6)',
-                    borderRadius: row.original.value,
+                    borderRadius: `var(${getVariableName(getValue())})`,
                 }}
             />
         ),
@@ -84,12 +83,7 @@ export const Radii: Story = {
                 title="Radii"
                 description="The Plasma theme defines the following border radius values. Each radius maps to a CSS variable --mantine-radius-{size}."
             >
-                <Table<RadiusRowData>
-                    store={table}
-                    columns={columns as Array<ColumnDef<RadiusRowData, unknown>>}
-                    data={radiiValues}
-                    getRowId={({name}) => name}
-                />
+                <Table<RadiusRowData> store={table} columns={columns} data={radiiValues} getRowId={({size}) => size} />
             </FoundationWrapper>
         );
     },

--- a/packages/storybook/src/components/foundation/shadows/Shadows.stories.tsx
+++ b/packages/storybook/src/components/foundation/shadows/Shadows.stories.tsx
@@ -1,6 +1,6 @@
-import {createColumnHelper, Table, useTable, type ColumnDef} from '@coveord/plasma-mantine';
-import {Box, Text} from '@mantine/core';
+import {Box, Code, createColumnHelper, Table, useTable} from '@coveord/plasma-mantine';
 import type {Meta, StoryObj} from '@storybook/react-vite';
+import {CSSVariableValue} from '../CSSVariableValue.js';
 import {FoundationWrapper} from '../FoundationWrapper.js';
 import classes from './ShadowsTable.module.css';
 
@@ -20,63 +20,36 @@ export default meta;
 type Story = StoryObj;
 
 type ShadowRowData = {
-    name: string;
-    value: string;
-    variable: string;
+    size: string;
 };
 
-const shadows: ShadowRowData[] = [
-    {
-        name: 'xs',
-        value: '0px 1px 2px 0px rgba(0, 0, 0, 0.10), 0px 1px 3px 0px rgba(0, 0, 0, 0.05), 0px -0.5px 1px 0px rgba(0, 0, 0, 0.02)',
-        variable: '--mantine-shadow-xs',
-    },
-    {
-        name: 'sm',
-        value: '0px 7px 7px -5px rgba(0, 0, 0, 0.04), 0px 10px 15px -5px rgba(0, 0, 0, 0.10), 0px 1px 3px 0px rgba(0, 0, 0, 0.05)',
-        variable: '--mantine-shadow-sm',
-    },
-    {
-        name: 'md',
-        value: '0px 10px 10px -5px rgba(0, 0, 0, 0.04), 0px 20px 25px -5px rgba(0, 0, 0, 0.10), 0px 1px 3px 0px rgba(0, 0, 0, 0.05)',
-        variable: '--mantine-shadow-md',
-    },
-    {
-        name: 'lg',
-        value: '0px 12px 12px -7px rgba(0, 0, 0, 0.04), 0px 28px 23px -7px rgba(0, 0, 0, 0.10), 0px 1px 3px 0px rgba(0, 0, 0, 0.05)',
-        variable: '--mantine-shadow-lg',
-    },
-    {
-        name: 'xl',
-        value: '0px 17px 17px -7px rgba(0, 0, 0, 0.04), 0px 36px 28px -7px rgba(0, 0, 0, 0.10), 0px 1px 3px 0px rgba(0, 0, 0, 0.05)',
-        variable: '--mantine-shadow-xl',
-    },
-];
+const shadows: ShadowRowData[] = [{size: 'xs'}, {size: 'sm'}, {size: 'md'}, {size: 'lg'}, {size: 'xl'}];
+
+const getVariableName = (size: string): string => `--mantine-shadow-${size}`;
 
 const columnHelper = createColumnHelper<ShadowRowData>();
 const columns = [
-    columnHelper.accessor('name', {
-        header: 'Name',
-        cell: ({getValue}) => (
-            <Text fw={600} ff="monospace" size="sm">
-                {getValue()}
-            </Text>
-        ),
+    columnHelper.accessor('size', {
+        header: 'Size',
+        cell: ({getValue}) => <Code fw={600}>{getValue()}</Code>,
         enableSorting: false,
     }),
-    columnHelper.accessor('variable', {
+    columnHelper.accessor('size', {
         header: 'Variable',
-        cell: ({getValue}) => (
-            <Text size="xs" c="dimmed" ff="monospace">
-                {getValue()}
-            </Text>
-        ),
+        cell: ({getValue}) => <Code>{getVariableName(getValue())}</Code>,
         enableSorting: false,
     }),
-    columnHelper.display({
+    columnHelper.accessor('size', {
+        header: 'Value',
+        cell: ({getValue}) => <CSSVariableValue name={getVariableName(getValue())} />,
+        enableSorting: false,
+        size: 320,
+    }),
+    columnHelper.accessor('size', {
         id: 'preview',
         header: '',
-        cell: ({row}) => (
+        enableSorting: false,
+        cell: ({getValue}) => (
             <Box
                 style={{
                     width: 120,
@@ -84,7 +57,7 @@ const columns = [
                     margin: 10,
                     backgroundColor: 'var(--mantine-color-white)',
                     borderRadius: 8,
-                    boxShadow: row.original.value,
+                    boxShadow: `var(${getVariableName(getValue())})`,
                 }}
             />
         ),
@@ -107,9 +80,9 @@ export const Shadows: Story = {
             >
                 <Table<ShadowRowData>
                     store={table}
-                    columns={columns as Array<ColumnDef<ShadowRowData, unknown>>}
+                    columns={columns}
                     data={shadows}
-                    getRowId={({name}) => name}
+                    getRowId={({size}) => size}
                     layoutProps={{
                         classNames: {
                             row: classes.shadowRow,

--- a/packages/storybook/src/components/foundation/spacings/Spacings.stories.tsx
+++ b/packages/storybook/src/components/foundation/spacings/Spacings.stories.tsx
@@ -1,6 +1,6 @@
-import {createColumnHelper, Table, useTable, type ColumnDef} from '@coveord/plasma-mantine';
-import {Box, Text} from '@mantine/core';
+import {Box, Code, createColumnHelper, Table, useTable} from '@coveord/plasma-mantine';
 import type {Meta, StoryObj} from '@storybook/react-vite';
+import {CSSVariableValue} from '../CSSVariableValue.js';
 import {FoundationWrapper} from '../FoundationWrapper.js';
 
 const meta: Meta = {
@@ -19,49 +19,46 @@ export default meta;
 type Story = StoryObj;
 
 type SpacingRowData = {
-    name: string;
-    value: string;
-    variable: string;
+    size: string;
 };
 
 const spacings: SpacingRowData[] = [
-    {name: 'xxs', value: '4px', variable: '--mantine-spacing-xxs'},
-    {name: 'xs', value: '8px', variable: '--mantine-spacing-xs'},
-    {name: 'sm', value: '16px', variable: '--mantine-spacing-sm'},
-    {name: 'md', value: '24px', variable: '--mantine-spacing-md'},
-    {name: 'lg', value: '32px', variable: '--mantine-spacing-lg'},
-    {name: 'xl', value: '40px', variable: '--mantine-spacing-xl'},
+    {size: 'xxs'},
+    {size: 'xs'},
+    {size: 'sm'},
+    {size: 'md'},
+    {size: 'lg'},
+    {size: 'xl'},
 ];
+
+const getVariableName = (size: string): string => `--mantine-spacing-${size}`;
 
 const columnHelper = createColumnHelper<SpacingRowData>();
 const columns = [
-    columnHelper.accessor('name', {
-        header: 'Name',
-        cell: ({getValue}) => (
-            <Text fw={600} ff="monospace" size="sm">
-                {getValue()}
-            </Text>
-        ),
+    columnHelper.accessor('size', {
+        header: 'Size',
+        cell: ({getValue}) => <Code fw={600}>{getValue()}</Code>,
         enableSorting: false,
     }),
-    columnHelper.accessor('variable', {
+    columnHelper.accessor('size', {
         header: 'Variable',
-        cell: ({getValue}) => (
-            <Text size="xs" c="dimmed" ff="monospace">
-                {getValue()}
-            </Text>
-        ),
+        cell: ({getValue}) => <Code>{getVariableName(getValue())}</Code>,
         enableSorting: false,
     }),
-    columnHelper.display({
+    columnHelper.accessor('size', {
+        header: 'Value',
+        cell: ({getValue}) => <CSSVariableValue name={getVariableName(getValue())} />,
+        enableSorting: false,
+    }),
+    columnHelper.accessor('size', {
         id: 'preview',
         header: '',
-        cell: ({row}) => (
+        enableSorting: false,
+        cell: ({getValue}) => (
             <Box
                 style={{
-                    width: `var(${row.original.variable})`,
-                    height: `var(${row.original.variable})`,
-                    width: `var(${row.original.variable})`,
+                    width: `var(${getVariableName(getValue())})`,
+                    height: `var(${getVariableName(getValue())})`,
                     backgroundColor: 'var(--mantine-color-blue-6)',
                     minWidth: 4,
                 }}
@@ -84,12 +81,7 @@ export const Spacings: Story = {
                 title="Spacings"
                 description="The Plasma theme defines the following spacing values. Each spacing maps to a CSS variable --mantine-spacing-{size}."
             >
-                <Table<SpacingRowData>
-                    store={table}
-                    columns={columns as Array<ColumnDef<SpacingRowData, unknown>>}
-                    data={spacings}
-                    getRowId={({name}) => name}
-                />
+                <Table<SpacingRowData> store={table} columns={columns} data={spacings} getRowId={({size}) => size} />
             </FoundationWrapper>
         );
     },

--- a/packages/storybook/src/getting started/Glossary.mdx
+++ b/packages/storybook/src/getting started/Glossary.mdx
@@ -1,7 +1,7 @@
 import {Meta, Unstyled} from '@storybook/addon-docs/blocks';
 import {Alert} from '@coveord/plasma-mantine';
 
-<Meta title="@getting started/Glossary" id="guidance-glossary" />
+<Meta title="@content/Glossary" id="guidance-glossary" />
 
 {/* For the agent-friendly version of this documentation, see packages/llms/src/content/Glossary.md */}
 


### PR DESCRIPTION
### Proposed Changes

Display the resolved CSS variable values and variable-based previews for radius, spacing, and shadow tokens in their respective foundation stories. The Radii story also includes the default radius token.

Extract a shared `CSSVariableValue` component for the foundation stories.

Correct the `Table` column type so inferred cell values work without a consumer-side cast.

Move the Glossary into the Content Storybook section.

### Potential Breaking Changes

None.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)