### PR TITLE
Improve AI agent documentation

### DIFF
--- a/.changeset/eager-comets-wander.md
+++ b/.changeset/eager-comets-wander.md
@@ -1,0 +1,6 @@
+---
+'@coveord/plasma-llms': patch
+'@coveord/plasma-mcp-server': patch
+---
+
+Prefer MCP tools in Plasma agent guidance

--- a/.github/skills/plasma-component-docs/SKILL.md
+++ b/.github/skills/plasma-component-docs/SKILL.md
@@ -45,4 +45,4 @@ Follow the format in [references/format.md](references/format.md) exactly. Key r
 pnpm turbo run build --filter=@coveord/plasma-llms
 ```
 
-This rebuilds `dist/llms/`, `dist/llms.txt`, `dist/llms-full.txt`, and `dist/plasma-skill.md` from all specs.
+This rebuilds `packages/llms/dist/llms/`, `packages/llms/dist/llms.txt`, and `packages/llms/dist/llms-full.txt` from the component and content specs. It also regenerates `packages/llms/dist/plasma-skill.md` from `packages/llms/src/skill.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ This repo ships agent **skills** in `.github/skills/`. Use them when the task ma
 - **`storybook-component-guidelines`** — **Step 2**: rewrite the converted `.mdx` into clear, human-readable Storybook documentation. Runs after Step 1.
 - **`changesets-author`** — write or edit a changeset that follows the enforced template. Use when adding or editing a `.changeset/*.md` file. Scaffold with `pnpm changeset:new` and check with `pnpm changeset:validate`.
 
-There is also a public agent skill served at `https://plasma.coveo.com/plasma-skill.md` (source: `packages/llms/src/skill.md`) and an MCP server (`@coveord/plasma-mcp-server`) for looking up Plasma component APIs. When consulting component APIs, read the specs in `packages/llms/src/components/` or use the Plasma/Mantine MCP servers described in the [README](README.md).
+`packages/llms/src/skill.md` is the source for the public Plasma skill served at `https://plasma.coveo.com/plasma-skill.md`. It is intended for agents using Plasma in consumer applications; agents contributing to this repository do not need to install it. Edit the source file, not the generated `packages/llms/dist/plasma-skill.md`, when updating the public skill.
 
 ## Component documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Run all tests from the root with `pnpm test`. From within `packages/{name}` you 
 - **`storybook-component-guidelines`** — Step 2: rewrite the converted `.mdx` into human-readable documentation.
 - **`changesets-author`** — write or edit a changeset that follows the template documented below.
 
-A public agent skill is also served at [`https://plasma.coveo.com/plasma-skill.md`](https://plasma.coveo.com/plasma-skill.md), and the `@coveord/plasma-mcp-server` package exposes Plasma docs to AI agents (see the [README](README.md) for setup).
+`packages/llms/src/skill.md` is the source for the public Plasma skill served at [`https://plasma.coveo.com/plasma-skill.md`](https://plasma.coveo.com/plasma-skill.md). It is intended for agents using Plasma in consumer applications, so contributors do not need to install it. Edit the source file rather than the generated `packages/llms/dist/plasma-skill.md`.
 
 ## Committing your changes
 

--- a/README.md
+++ b/README.md
@@ -46,17 +46,22 @@ Each package documents its own installation and usage in its README:
 
 ## AI Coding Agents
 
-Plasma documents its wrapped components in [`@coveord/plasma-llms`](packages/llms/README.md). The other components are pure Mantine re-exports. For full coverage, configure **both** the Plasma and Mantine MCP servers:
+For the best agent experience, combine the [Plasma skill](https://plasma.coveo.com/plasma-skill.md) with both documentation MCP servers. They serve complementary purposes:
 
-- **Plasma MCP** — authoritative for Plasma-specific props, sub-components, and usage
-- **Mantine MCP** — fallback for re-exported components and inherited props
+- **Plasma skill:** persistent setup, import, and documentation lookup conventions
+- **Plasma MCP:** authoritative on-demand Plasma-specific props, sub-components, usage, and content guidelines
+- **Mantine MCP:** on-demand fallback for re-exported components and inherited props
+
+Use both the skill and MCP servers when the client supports them. The skill uses static [`@coveord/plasma-llms`](packages/llms/README.md) files only as a fallback when MCP is unavailable.
 
 > **Import invariant:** always import from `@coveord/plasma-mantine`, even when Mantine docs were the reference source.
 
 <details>
 <summary><strong>Claude Code</strong></summary>
 
-Add both MCP servers to a project-scoped `.mcp.json` at your repository root (commit it to share the setup with your team):
+**Step 1: Install the Plasma skill.** Save the [Plasma skill](https://plasma.coveo.com/plasma-skill.md) as `.claude/skills/plasma/SKILL.md` in your project.
+
+**Step 2: Configure the MCP servers.** Add both servers to a project-scoped `.mcp.json` at your repository root (commit it to share the setup with your team):
 
 ```json
 {
@@ -87,7 +92,9 @@ Run `/mcp` inside Claude Code to verify both servers are connected.
 <details>
 <summary><strong>Opencode</strong></summary>
 
-Add both MCP servers to your [Opencode config](https://opencode.ai/docs/mcp-servers/) (`opencode.json` at your repository root, or `~/.config/opencode/opencode.json` for all projects):
+**Step 1: Install the Plasma skill.** Save the [Plasma skill](https://plasma.coveo.com/plasma-skill.md) as `.opencode/skills/plasma/SKILL.md` in your project.
+
+**Step 2: Configure the MCP servers.** Add both servers to your [Opencode config](https://opencode.ai/docs/mcp-servers/) (`opencode.json` at your repository root, or `~/.config/opencode/opencode.json` for all projects):
 
 ```json
 {
@@ -112,18 +119,29 @@ Add both MCP servers to your [Opencode config](https://opencode.ai/docs/mcp-serv
 <details>
 <summary><strong>GitHub Copilot CLI</strong></summary>
 
-Load the Plasma skill in the terminal:
+**Step 1: Install the Plasma skill.** Load it in the terminal:
 
 ```
 /skill https://plasma.coveo.com/plasma-skill.md
 ```
+
+**Step 2: Configure the MCP servers.** Add both servers from the terminal:
+
+```bash
+copilot mcp add plasma -- npx -y @coveord/plasma-mcp-server
+copilot mcp add mantine -- npx -y @mantine/mcp-server
+```
+
+The CLI also reads shared workspace MCP configuration from `.mcp.json`.
 
 </details>
 
 <details>
 <summary><strong>GitHub Copilot in VS Code (agent mode)</strong></summary>
 
-Create `.vscode/mcp.json` in your project:
+**Step 1: Install the Plasma skill.** Save the [Plasma skill](https://plasma.coveo.com/plasma-skill.md) as `.github/skills/plasma/SKILL.md` in your project.
+
+**Step 2: Configure the MCP servers.** Create `.vscode/mcp.json` in your project:
 
 ```json
 {
@@ -147,9 +165,15 @@ Create `.vscode/mcp.json` in your project:
 <details>
 <summary><strong>Kiro</strong></summary>
 
-**Option 1 — MCP servers** (recommended for component API lookups):
+**Step 1: Install the Plasma skill as steering.** Create `.kiro/steering/plasma.md`, paste the contents of [`https://plasma.coveo.com/plasma-skill.md`](https://plasma.coveo.com/plasma-skill.md), and replace its frontmatter with:
 
-Create `.kiro/settings/mcp.json` in your project:
+```markdown
+---
+inclusion: always
+---
+```
+
+**Step 2: Configure the MCP servers.** Create `.kiro/settings/mcp.json` in your project:
 
 ```json
 {
@@ -166,22 +190,14 @@ Create `.kiro/settings/mcp.json` in your project:
 }
 ```
 
-**Option 2 — Steering file** (injects Plasma conventions into every agent session):
-
-Create `.kiro/steering/plasma.md` and paste the contents of [`https://plasma.coveo.com/plasma-skill.md`](https://plasma.coveo.com/plasma-skill.md) into it with this frontmatter:
-
-```markdown
----
-inclusion: always
----
-```
-
 </details>
 
 <details>
 <summary><strong>Codex CLI</strong></summary>
 
-Add to `~/.codex/config.toml` (global) or `.codex/config.toml` (project):
+**Step 1: Install the Plasma skill.** Save the [Plasma skill](https://plasma.coveo.com/plasma-skill.md) as `.agents/skills/plasma/SKILL.md` in your project.
+
+**Step 2: Configure the MCP servers.** Add both servers to `~/.codex/config.toml` (global) or `.codex/config.toml` (project):
 
 ```toml
 [mcp_servers.plasma]

--- a/packages/llms/README.md
+++ b/packages/llms/README.md
@@ -1,17 +1,22 @@
 # @coveord/plasma-llms
 
-LLM-friendly documentation for the [Plasma design system](https://plasma.coveo.com) — Coveo's Mantine-based component library.
+LLM-friendly documentation for the [Plasma design system](https://plasma.coveo.com), Coveo's Mantine-based component library.
 
 Inspired by [Mantine's llms.txt guide](https://mantine.dev/guides/llms/), this package generates static documentation files optimised for consumption by AI tools and large language models.
 
 ## What's included
 
-| File              | URL                                        | Purpose                                                                      |
-| ----------------- | ------------------------------------------ | ---------------------------------------------------------------------------- |
-| `llms.txt`        | `https://plasma.coveo.com/llms.txt`        | Index of all components (compact, [llmstxt.org](https://llmstxt.org) format) |
-| `llms-full.txt`   | `https://plasma.coveo.com/llms-full.txt`   | All component docs concatenated into a single file                           |
-| `llms/Button.md`  | `https://plasma.coveo.com/llms/Button.md`  | Per-component reference (props, sub-components, design guidelines)           |
-| `plasma-skill.md` | `https://plasma.coveo.com/plasma-skill.md` | AI agent skill file for GitHub Copilot CLI / agent workflows                 |
+| File                        | URL                                                  | Purpose                                                                      |
+| --------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `llms.txt`                  | `https://plasma.coveo.com/llms.txt`                  | Index of all components (compact, [llmstxt.org](https://llmstxt.org) format) |
+| `llms-full.txt`             | `https://plasma.coveo.com/llms-full.txt`             | All component docs concatenated into a single file                           |
+| `llms/components/Button.md` | `https://plasma.coveo.com/llms/components/Button.md` | Per-component reference (props, sub-components, design guidelines)           |
+| `llms/content/Voice.md`     | `https://plasma.coveo.com/llms/content/Voice.md`     | Per-guideline reference for user-facing content                              |
+| `plasma-skill.md`           | `https://plasma.coveo.com/plasma-skill.md`           | Portable AI agent skill with Plasma conventions and lookup guidance          |
+
+## Using Plasma with AI coding agents
+
+See the canonical [AI Coding Agents guide](https://github.com/coveo/plasma#ai-coding-agents) for skill installation, MCP server configuration, and the documentation lookup workflow.
 
 ---
 
@@ -23,7 +28,7 @@ Inspired by [Mantine's llms.txt guide](https://mantine.dev/guides/llms/), this p
 pnpm turbo run build --filter=@coveord/plasma-llms
 ```
 
-This reads the hand-maintained `.md` files from `src/components/`, copies them to `dist/llms/` (stripping frontmatter), and assembles the aggregated outputs (`llms.txt`, `llms-full.txt`, `plasma-skill.md`, `descriptions.json`).
+This reads the hand-maintained `.md` files from `src/components/` and `src/content/`, copies them to `dist/llms/` (stripping frontmatter), and assembles `llms.txt`, `llms-full.txt`, and `plasma-skill.md`.
 
 Set `PLASMA_BASE_URL` to override the base URL (default: `https://plasma.coveo.com`):
 
@@ -35,16 +40,18 @@ PLASMA_BASE_URL=http://localhost:6006 pnpm build
 
 Each component has a hand-maintained `src/components/ComponentName.md` file. These are the source of truth for all LLM-facing documentation.
 
-When a component's API changes, use the internal `plasma-component-docs` GitHub Copilot skill to update the spec — it knows the expected format and conventions. You can also edit the files manually.
+When a component's API changes, use the internal `plasma-component-docs` skill to update the spec. It knows the expected format and conventions. You can also edit the files manually.
 
 ### Adding a new component
 
-1. Create `src/components/NewComponent.md` with YAML frontmatter and Markdown content — use the `plasma-component-docs` skill to generate the initial spec
+1. Create `src/components/NewComponent.md` with YAML frontmatter and Markdown content. Use the `plasma-component-docs` skill to generate the initial spec.
 2. Run `pnpm build` to regenerate the dist outputs
 
 ### How it works
 
-1. **`src/build.ts`** reads all `*.md` files from `src/components/`, parses YAML frontmatter, and copies body content to `dist/llms/`
-2. **`src/llms-txt.ts`** builds the index from component names and frontmatter descriptions
-3. **`src/llms-full-txt.ts`** concatenates all component docs into one file
-4. **`src/skill.md`** is the AI agent skill file served as `plasma-skill.md`
+1. **`src/build.ts`** reads all `*.md` files from `src/components/` and `src/content/`, parses YAML frontmatter, and copies body content to `dist/llms/`
+2. **`src/llms-txt.ts`** builds the index from component and content guideline metadata
+3. **`src/llms-full-txt.ts`** concatenates all component and content guideline docs into one file
+4. **`src/skill.md`** is the source for the AI agent skill served as `plasma-skill.md`; the build replaces its `{{BASE_URL}}` placeholders
+
+Do not edit generated files in `dist/` manually.

--- a/packages/llms/src/skill.md
+++ b/packages/llms/src/skill.md
@@ -1,6 +1,6 @@
 ---
 name: plasma
-description: Plasma design system setup, conventions, and component documentation for `@coveord/plasma-mantine` — Coveo's Mantine-based React component library. Use when building or modifying UI in a project that uses Plasma, looking up component props or usage patterns, setting up a new Plasma project, or any task involving `@coveord/plasma-mantine` components.
+description: Plasma design system setup, conventions, and component documentation for `@coveord/plasma-mantine`, Coveo's Mantine-based React component library. Use when building or modifying UI in a project that uses Plasma, looking up component props or usage patterns, setting up a new Plasma project, or any task involving `@coveord/plasma-mantine` components.
 ---
 
 Plasma is Coveo's design system built on top of [Mantine](https://mantine.dev/). It provides React components, a custom theme, design tokens, and icons for Coveo Cloud products.
@@ -33,47 +33,49 @@ function App() {
 
 ## Finding Component Docs
 
-Plasma documents its wrapped components. Query Plasma first; fall back to Mantine for everything else.
+Use the Plasma and Mantine MCP servers for on-demand documentation. MCP clients may prefix the tool names with the server name.
 
-**Step 1 — Plasma (authoritative for Plasma-specific behaviour):**
+**Step 1: Query Plasma first.** Plasma is authoritative for Plasma-specific behaviour, props, sub-components, and usage patterns.
 
-Fetch the component index to see what Plasma documents:
+- Use `list_components` to discover which components Plasma documents.
+- Use `get_component_doc` for complete documentation about a known component.
+- Use `get_component_props` when only the props table is needed.
+- Use `search_docs` to find components or guidance by topic.
+
+**Step 2: Fall back to Mantine.** If Plasma does not document a component or inherited API, use the Mantine MCP server's `list_items`, `get_item_doc`, `get_item_props`, or `search_docs` tool.
+
+Even when Mantine supplies the API reference, import the component from `@coveord/plasma-mantine`.
+
+## Content Guidelines
+
+Plasma provides content guidelines for writing UX copy in Coveo products. Always follow these when writing user-facing text such as labels, errors, tooltips, and descriptions.
+
+- Use `list_content_guidelines` to discover the available guidelines.
+- Use `get_content_guideline` to retrieve `Voice`, `WritingMechanics`, `ProductVocabulary`, or `TargetAudience`.
+- Use `search_docs` to find relevant component or content guidance by topic.
+
+## Fallback When MCP Is Unavailable
+
+If the Plasma or Mantine MCP tools are not configured, use the static LLM documentation instead.
+
+Start with the Plasma index, then fetch only the component or content guideline needed:
 
 ```
 {{BASE_URL}}/llms.txt
-```
-
-Fetch specific component docs (props, sub-components, usage examples):
-
-```
 {{BASE_URL}}/llms/components/ComponentName.md
+{{BASE_URL}}/llms/content/GuidelineName.md
 ```
 
-Fetch full docs for all Plasma-wrapped components (props, sub-components, usage examples):
+Use the full documentation only when a task genuinely requires bulk context:
 
 ```
 {{BASE_URL}}/llms-full.txt
 ```
 
-**Step 2 — Mantine fallback (for re-exported components and inherited props):**
-
-If a component isn't listed in the Plasma index, fetch Mantine's documentation:
+For Mantine fallback documentation, use:
 
 ```
 https://mantine.dev/llms.txt
-```
-
-## Content Guidelines
-
-Plasma provides content guidelines for writing UX copy in Coveo products. Always follow these when writing user-facing text (labels, errors, tooltips, descriptions, etc.).
-
-Fetch a specific content guideline:
-
-```
-{{BASE_URL}}/llms/content/Voice.md
-{{BASE_URL}}/llms/content/WritingMechanics.md
-{{BASE_URL}}/llms/content/ProductVocabulary.md
-{{BASE_URL}}/llms/content/TargetAudience.md
 ```
 
 ## Import invariant

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,107 +1,21 @@
 # @coveord/plasma-mcp-server
 
-MCP (Model Context Protocol) server for the [Plasma design system](https://plasma.coveo.com). Gives AI agents dynamic access to component documentation — no need to load everything upfront.
+MCP (Model Context Protocol) server for the [Plasma design system](https://plasma.coveo.com). It gives AI agents dynamic access to component and content documentation without loading everything upfront.
 
-For full coverage, pair this with [`@mantine/mcp-server`](https://www.npmjs.com/package/@mantine/mcp-server): the Plasma server is authoritative for Plasma-wrapped components; the Mantine server covers the re-exported components and inherited props. Agents should query Plasma first and fall back to Mantine when a component isn't found.
+For installation, client configuration, and guidance on using the Plasma skill with the Plasma and Mantine MCP servers, see the canonical [AI Coding Agents guide](https://github.com/coveo/plasma#ai-coding-agents).
 
 > **Import invariant:** always import from `@coveord/plasma-mantine`, even when Mantine docs were the reference. `@coveord/plasma-mantine` re-exports all Mantine components with Coveo's theme applied.
 
 ## Tools
 
-| Tool                  | Description                                                                              |
-| --------------------- | ---------------------------------------------------------------------------------------- |
-| `list_components`     | Returns all documented Plasma component names                                            |
-| `get_component_doc`   | Returns the full Markdown doc for a component (props, sub-components, design guidelines) |
-| `get_component_props` | Returns just the props table for a component                                             |
-| `search_docs`         | Full-text search across all component docs; returns the top matching excerpts            |
-
-## Setup
-
-### Kiro
-
-**Option 1 — MCP servers** (recommended for on-demand component docs):
-
-Create or edit `.kiro/settings/mcp.json` in your project (or `~/.kiro/settings/mcp.json` for all projects):
-
-```json
-{
-    "mcpServers": {
-        "plasma": {
-            "command": "npx",
-            "args": ["-y", "@coveord/plasma-mcp-server"]
-        },
-        "mantine": {
-            "command": "npx",
-            "args": ["-y", "@mantine/mcp-server"]
-        }
-    }
-}
-```
-
-Restart Kiro after saving the file. Both servers will appear in the MCP panel.
-
-**Option 2 — Steering file** (always-on Plasma conventions, no MCP needed):
-
-Create `.kiro/steering/plasma.md` and paste the contents of [`https://plasma.coveo.com/plasma-skill.md`](https://plasma.coveo.com/plasma-skill.md) into it with this frontmatter:
-
-```markdown
----
-inclusion: always
----
-
-[paste plasma-skill.md contents here]
-```
-
-### GitHub Copilot (VS Code)
-
-Create or edit `.vscode/mcp.json` in your project:
-
-```json
-{
-    "servers": {
-        "plasma": {
-            "type": "stdio",
-            "command": "npx",
-            "args": ["-y", "@coveord/plasma-mcp-server"]
-        },
-        "mantine": {
-            "type": "stdio",
-            "command": "npx",
-            "args": ["-y", "@mantine/mcp-server"]
-        }
-    }
-}
-```
-
-Commit this file to share the MCP setup with your team. Use **MCP: List Servers** in the VS Code command palette to verify the servers are running.
-
-### Codex CLI
-
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.plasma]
-command = "npx"
-args = ["-y", "@coveord/plasma-mcp-server"]
-
-[mcp_servers.mantine]
-command = "npx"
-args = ["-y", "@mantine/mcp-server"]
-```
-
-For a project-specific setup, set `CODEX_HOME=.codex` and create `.codex/config.toml` in your repo instead.
-
-### GitHub Copilot CLI (terminal)
-
-The Copilot CLI uses skill files rather than MCP. Load the Plasma skill with:
-
-```
-/skill https://plasma.coveo.com/plasma-skill.md
-```
-
-Or add it to `.github/copilot-instructions.md` in your project to have it apply automatically.
-
----
+| Tool                      | Description                                                                                    |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `list_components`         | Returns all documented Plasma component names                                                  |
+| `get_component_doc`       | Returns the full Markdown doc for a component (props, sub-components, design guidelines)       |
+| `get_component_props`     | Returns just the props table for a component                                                   |
+| `search_docs`             | Searches component docs and content guidelines; returns the top matching excerpts              |
+| `list_content_guidelines` | Returns all documented content guidelines                                                      |
+| `get_content_guideline`   | Returns the full Markdown doc for a content guideline (voice, mechanics, vocabulary, audience) |
 
 ## Example prompts
 
@@ -119,6 +33,6 @@ Once the MCP server is connected, you can ask your AI agent:
 
 ## How it works
 
-The component documentation is bundled at build time from `@coveord/plasma-llms/dist/` into a `dist/data.json` file. The MCP server loads this file at startup and serves it via the MCP protocol — no runtime network calls or file I/O required.
+The component and content documentation is bundled at build time from `@coveord/plasma-llms/dist/` into a `dist/data.json` file. The MCP server loads this file at startup and serves it via the MCP protocol, with no runtime network calls or file I/O required.
 
 For the underlying static files (useful for tools that fetch URLs directly), see [`@coveord/plasma-llms`](../llms/README.md).

--- a/packages/mcp-server/src/__tests__/server.spec.ts
+++ b/packages/mcp-server/src/__tests__/server.spec.ts
@@ -67,6 +67,15 @@ describe('plasma-mcp-server integration', () => {
                 required: ['component'],
             });
         });
+
+        it('describes search across components and content guidelines', async () => {
+            const response = await server.receive(req(1, 'tools/list'));
+            const tools = (response as {result: {tools: Array<{name: string; description: string}>}}).result.tools;
+            const searchTool = tools.find((t) => t.name === 'search_docs');
+            expect(searchTool?.description).toBe(
+                'Search across all Plasma component documentation and content guidelines',
+            );
+        });
     });
 
     describe('list_components tool', () => {

--- a/packages/mcp-server/src/createServer.ts
+++ b/packages/mcp-server/src/createServer.ts
@@ -89,7 +89,7 @@ export const createServer = (data: LlmsData): McpServer => {
     server.tool(
         {
             name: 'search_docs',
-            description: 'Search across all Plasma component documentation',
+            description: 'Search across all Plasma component documentation and content guidelines',
             schema: querySchema,
         },
         async ({query}) => tool.text(searchDocs(data, query)),


### PR DESCRIPTION
### Purpose

Clarify that the Plasma skill and Plasma and Mantine MCP servers are complementary. Document MCP setup for all supported clients, including GitHub Copilot CLI, and make the published skill prefer MCP tools with static documentation as a fallback.

---

### Jira ticket: [ADUI-11542](https://coveord.atlassian.net/browse/ADUI-11542)

### Target audience

- [x] Developers (DS)
- [ ] Designers (DS)
- [ ] Writers (DS, Docs)
- [ ] Other Coveo teams
- [x] AI agents

### Changes

- Document skill installation and both MCP servers for the supported AI coding agents.
- Add GitHub Copilot CLI MCP configuration instructions.
- Update the public Plasma skill to prefer MCP documentation lookups and retain static LLM files as a fallback.
- Make the MCP search tool description cover content guidelines and add regression coverage.
- Add patch changesets for `@coveord/plasma-llms` and `@coveord/plasma-mcp-server`.

### Demos

Not applicable, documentation and MCP metadata only.

### Self-review checklist

- [x] The content is accurate to the Plasma repository and supported agent integrations.
- [x] The LLM-friendly markdown skill was updated to reflect the changes.
- [x] Spelling and grammar follow the guidelines in WritingMechanics.md.
- [x] Terminology matches the ProductVocabulary.md and Glossary.md lists.
- [ ] The changes render correctly in the Storybook preview (not applicable, no Storybook content changed).
- [x] All added links lead to the intended documentation.

[ADUI-11542]: https://coveord.atlassian.net/browse/ADUI-11542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ