### PR TITLE
feat(mantine): add read-only support to CodeEditor

### DIFF
--- a/.changeset/eager-lions-bake.md
+++ b/.changeset/eager-lions-bake.md
@@ -1,0 +1,8 @@
+---
+'@coveord/plasma-mantine': minor
+'@coveord/plasma-llms': patch
+---
+
+Add `readOnly` support to `CodeEditor`
+
+The `readOnly` prop prevents users from changing the editor content while displaying it with read-only styling.

--- a/packages/llms/src/components/CodeEditor.md
+++ b/packages/llms/src/components/CodeEditor.md
@@ -33,7 +33,8 @@ Do not use `CodeEditor` when:
 - Use `CodeEditor` for technical text where structure matters.
 - Use `Textarea` for freeform prose or comments.
 - Use `TextInput` for short single-line values.
-- Use `disabled` when the editor should be readable but not editable.
+- Use `readOnly` when the editor content should remain readable but not editable.
+- Use `disabled` when the editor is unavailable.
 
 ## Accessibility expectations
 
@@ -63,6 +64,7 @@ Do not use `CodeEditor` when:
 **`editorHandle`** `React.MutableRefObject<monacoEditor.IStandaloneCodeEditor | null>` · optional · default: `undefined` — This ref MAY provide access to the editor's functionality.
 **`minHeight`** `number` · optional · default: `300` — The CodeEditor height, including label and description, is never smaller than this value. By default, the CodeEditor adjusts to fill its parent height. If the parent height is too short, the component uses this value as its minimum height.
 **`maxHeight`** `number` · optional · default: `undefined` — The CodeEditor height, including label and description, is never larger than this value. By default, the CodeEditor adjusts to fill its parent height. This prop can set the maximum height when the parent height would otherwise be too high.
+**`readOnly`** `boolean` · optional · default: `undefined` — When set, the editor prevents content changes and uses read-only styling.
 **`disabled`** `boolean` · optional · default: `undefined` — When set, the editor is read-only and uses disabled styling.
 **`monacoLoader`** `'cdn' | 'local'` · optional · default: `local` — Defines how the Monaco editor files are loaded. When `local` is used, the required [additional configuration](https://github.com/suren-atoyan/monaco-react#use-monaco-editor-as-an-npm-package) MUST be provided.
 **`options`** `Pick<monacoEditor.IStandaloneEditorConstructionOptions, 'tabSize'>` · optional · default: `undefined` — This prop MAY pass options to the Monaco editor. It currently supports only [`tabSize`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html#tabSize).

--- a/packages/mantine/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/mantine/src/components/CodeEditor/CodeEditor.tsx
@@ -64,6 +64,7 @@ interface CodeEditorProps
      * In the case where the parent height would be too high for your liking, you can use this prop to set a maximum.
      */
     maxHeight?: number;
+    readOnly?: boolean;
     disabled?: boolean;
     /**
      * Defines how the monaco editor files will be loaded.
@@ -108,6 +109,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         minHeight,
         maxHeight,
         disabled,
+        readOnly,
         monacoLoader,
         options: {tabSize} = {tabSize: 2},
         editorHandle,
@@ -210,7 +212,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         </Group>
     );
     let editorTheme = colorScheme === 'light' ? 'light' : 'vs-dark';
-    if (disabled) {
+    if (disabled || readOnly) {
         editorTheme += '-disabled';
     }
 
@@ -221,7 +223,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
             className={cx(
                 CodeEditorClasses.root,
                 {[CodeEditorClasses.error]: hasError},
-                {[CodeEditorClasses.disabled]: disabled},
+                {[CodeEditorClasses.disabled]: disabled || readOnly},
             )}
             data-testid="editor-wrapper"
         >
@@ -236,7 +238,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                     scrollBeyondLastLine: false,
                     formatOnPaste: true,
                     fontSize: px(theme.fontSizes.xs) as number,
-                    readOnly: disabled,
+                    readOnly: disabled || readOnly,
                     stickyScroll: {enabled: false},
                     tabSize,
                 }}

--- a/packages/storybook/src/components/forms-and-inputs/string/CodeEditor.stories.tsx
+++ b/packages/storybook/src/components/forms-and-inputs/string/CodeEditor.stories.tsx
@@ -1,8 +1,7 @@
 import {CodeEditor} from '@coveord/plasma-mantine/components/CodeEditor';
 import type {Meta, StoryObj} from '@storybook/react-vite';
-import {Args} from '../../../Args.js';
+import {BaseInputArgs, InputWrapperArgs, type InputWrapperStoryArgs} from '../InputWrapperArgs.js';
 import {withLabelInfoProps} from '../LabelInfoArgs.js';
-import {InputWrapperArgs, type InputWrapperStoryArgs} from '../InputWrapperArgs.js';
 
 interface CodeEditorStoryArgs extends InputWrapperStoryArgs {
     disabled: boolean;
@@ -18,13 +17,13 @@ const meta = {
     },
     args: {
         ...InputWrapperArgs.Args,
-        disabled: Args.disabled.initialValue,
+        ...BaseInputArgs.Args,
         language: 'plaintext',
         defaultValue: '// Write your code here',
     },
     argTypes: {
         ...InputWrapperArgs.ArgsTypes,
-        disabled: Args.disabled.type,
+        ...BaseInputArgs.ArgsTypes,
         language: {
             control: 'select',
             options: ['plaintext', 'json', 'markdown', 'python', 'xml'],


### PR DESCRIPTION
### Proposed Changes

- Add a `readOnly` prop to `CodeEditor` that prevents content changes and applies read-only styling.
- Expose the shared read-only input control in the CodeEditor Storybook story.
- Document the new prop in the LLM specification and add the required changeset.

### Potential Breaking Changes

None.

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)