### PR TITLE
ADUI-11537 Align table row-selection checkboxes

### DIFF
--- a/.changeset/eager-foxes-race.md
+++ b/.changeset/eager-foxes-race.md
@@ -1,0 +1,9 @@
+---
+'@coveord/plasma-mantine': minor
+---
+
+Improve `Table` row-selection controls
+
+`Table` row and card layouts now share consistent row-selection checkbox behavior. Forced selections cannot be
+cleared through a checkbox, row checkboxes remain hidden until their row is hovered, focused, or selected, and the
+row-selection column uses less horizontal space.

--- a/packages/mantine/src/components/Table/Table.module.css
+++ b/packages/mantine/src/components/Table/Table.module.css
@@ -36,6 +36,18 @@
     }
 }
 
+/* Table.SelectRowCheckbox */
+
+.selectRowCheckbox {
+    opacity: 0;
+
+    [aria-selected='true'] &,
+    [aria-selected]:hover &,
+    [aria-selected]:focus-within & {
+        opacity: 1;
+    }
+}
+
 /* Table.Actions */
 
 /* Hide empty menus */

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -27,12 +27,14 @@ import {
     type TableCellProps,
     type TableCellStylesNames,
 } from './table-cell/TableCell.js';
+import {areSelectionCheckboxesVisible} from './table-column/areSelectionCheckboxesVisible.js';
 import {TableActionsColumn} from './table-column/TableActionsColumn.js';
 import {
     TableAccordionColumn,
     TableCollapsibleColumn,
     type TableCollapsibleColumnStylesNames,
 } from './table-column/TableCollapsibleColumn.js';
+import {type TableSelectRowCheckboxStylesNames} from './table-column/TableSelectRowCheckbox.js';
 import {TableSelectableColumn} from './table-column/TableSelectableColumn.js';
 import {
     TableDateRangePicker,
@@ -92,6 +94,7 @@ export type TableStylesNames =
     | TableActionsListStylesNames
     | TableActionItemStylesNames
     | TableCollapsibleColumnStylesNames
+    | TableSelectRowCheckboxStylesNames
     | TableDateRangePickerStylesNames
     | TableFilterStylesNames
     | TableHeaderStylesNames
@@ -180,10 +183,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     const lastUpdated = convertedChildren.find((child) => child.type === TableLastUpdated);
     const noData = convertedChildren.find((child) => child.type === TableNoData);
 
-    // Selection checkboxes only exist in multi-selection mode. They are interactive when row selection is
-    // enabled, and read-only when row selection is disabled but a selection already exists to display.
-    const isSelectionColumnVisible =
-        store.multiRowSelectionEnabled && (store.rowSelectionEnabled || store.getSelectedRows().length > 0);
+    const selectionCheckboxesVisible = areSelectionCheckboxesVisible(store);
 
     const table = useReactTable({
         data: data || [],
@@ -205,7 +205,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
             });
         },
         onColumnVisibilityChange: store.setColumnVisibility,
-        columns: isSelectionColumnVisible ? [TableSelectableColumn as ColumnDef<T>].concat(columns) : columns,
+        columns: selectionCheckboxesVisible ? [TableSelectableColumn as ColumnDef<T>].concat(columns) : columns,
         getCoreRowModel: getCoreRowModel(),
         manualPagination: options.getPaginationRowModel === undefined,
         enableMultiRowSelection: !!store.multiRowSelectionEnabled,
@@ -309,6 +309,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                     table,
                     layouts,
                     containerRef,
+                    selectionCheckboxesVisible,
                 }}
             >
                 <>

--- a/packages/mantine/src/components/Table/TableContext.tsx
+++ b/packages/mantine/src/components/Table/TableContext.tsx
@@ -12,6 +12,7 @@ export interface TableContextValue<TData = unknown> {
     getRowActions: (datum: TData[]) => TableAction[];
     table: Table<TData>;
     containerRef: MutableRefObject<HTMLDivElement | null>;
+    selectionCheckboxesVisible: boolean;
 }
 
 export interface TableProviderProps<T> {

--- a/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
@@ -202,6 +202,35 @@ describe('CardLayout', () => {
             expect(screen.getByTestId('2')).toHaveAttribute('aria-selected', 'false');
         });
 
+        it('keeps selected cards selected through their checkboxes when row selection is forced', async () => {
+            const user = userEvent.setup();
+            const data: RowData[] = [
+                {id: '1', firstName: 'John', lastName: 'Doe'},
+                {id: '2', firstName: 'Jane', lastName: 'Smith'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    forceSelection: true,
+                    initialState: {rowSelection: {'1': data[0]}},
+                });
+                return (
+                    <Table store={store} getRowId={({id}) => id} data={data} columns={columns} layouts={[CardLayout]} />
+                );
+            };
+            render(<Fixture />);
+
+            const firstCard = screen.getByTestId('1');
+            const secondCard = screen.getByTestId('2');
+            await user.click(within(secondCard).getByRole('checkbox', {name: /select row/i}));
+            expect(firstCard).toHaveAttribute('aria-selected', 'true');
+            expect(secondCard).toHaveAttribute('aria-selected', 'true');
+
+            await user.click(within(firstCard).getByRole('checkbox', {name: /select row/i}));
+            expect(firstCard).toHaveAttribute('aria-selected', 'true');
+            expect(secondCard).toHaveAttribute('aria-selected', 'true');
+        });
+
         it('selects multiple cards', async () => {
             const user = userEvent.setup();
             const data: RowData[] = [

--- a/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
@@ -365,6 +365,33 @@ describe('RowLayout', () => {
             expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
         });
 
+        it('keeps selected rows selected through their checkboxes when row selection is forced', async () => {
+            const user = userEvent.setup();
+            const data: RowData[] = [
+                {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+                {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    forceSelection: true,
+                    initialState: {rowSelection: {'🆔-1': data[0]}},
+                });
+                return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} />;
+            };
+            render(<Fixture />);
+
+            const firstRow = screen.getByRole('row', {name: /john smith/i});
+            const secondRow = screen.getByRole('row', {name: /jane doe/i});
+            await user.click(within(secondRow).getByRole('checkbox', {name: /select row/i}));
+            expect(firstRow).toHaveAttribute('aria-selected', 'true');
+            expect(secondRow).toHaveAttribute('aria-selected', 'true');
+
+            await user.click(within(firstRow).getByRole('checkbox', {name: /select row/i}));
+            expect(firstRow).toHaveAttribute('aria-selected', 'true');
+            expect(secondRow).toHaveAttribute('aria-selected', 'true');
+        });
+
         it('selects all rows of the current page when clicking on the checkbox that is in the column header', async () => {
             const user = userEvent.setup();
             const data: RowData[] = [

--- a/packages/mantine/src/components/Table/layouts/card-layout/CardLayout.module.css
+++ b/packages/mantine/src/components/Table/layouts/card-layout/CardLayout.module.css
@@ -2,18 +2,9 @@
     &[data-selectable='true'] {
         cursor: pointer;
     }
-
-    &:hover,
-    &[data-selected='true'] {
-        .cardCheckbox {
-            opacity: 1;
-        }
-    }
 }
 
 .cardCheckbox {
-    transition: opacity var(--coveo-transition-duration) var(--coveo-transition-function);
-    opacity: 0;
     position: absolute;
     top: var(--mantine-spacing-sm);
     right: var(--mantine-spacing-sm);

--- a/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
@@ -2,11 +2,11 @@ import {Box, BoxProps, Card, CompoundStylesApiProps, Factory, SimpleGrid, Stack,
 import {flexRender} from '@tanstack/react-table';
 import {ForwardedRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../../../utils/createFactoryComponent.js';
-import {Checkbox} from '../../../Checkbox/Checkbox.js';
 import {TableLayoutProps} from '../../Table.types.js';
 import {useTableContext} from '../../TableContext.js';
 import {TableCollapsibleColumn} from '../../table-column/TableCollapsibleColumn.js';
 import {TableSelectAllCheckbox} from '../../table-column/TableSelectAllCheckbox.js';
+import {TableSelectRowCheckbox} from '../../table-column/TableSelectRowCheckbox.js';
 import {TableLoading} from '../../table-loading/TableLoading.js';
 import {useCardLayout} from './CardLayoutContext.js';
 
@@ -38,11 +38,6 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
     } = useProps('CardLayoutBody', defaultProps as CardLayoutBodyProps<T>, props);
     const {table, store} = useTableContext<T>();
 
-    // Selection checkboxes only exist in multi-selection mode. They are interactive when row selection is
-    // enabled, and read-only when row selection is disabled but a selection already exists to display.
-    const areSelectionCheckboxesVisible =
-        store.multiRowSelectionEnabled && (store.rowSelectionEnabled || store.getSelectedRows().length > 0);
-
     const headers = table
         .getFlatHeaders()
         .filter((header) => header.column.id !== 'select' && header.column.id !== TableCollapsibleColumn.id)
@@ -57,6 +52,9 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
         .filter((header) => header.column.id !== 'select' && header.column.id !== TableCollapsibleColumn.id)
         .map((header) => header.column.id);
 
+    const cardStyles = ctx.getStyles('card', {classNames, className, styles, style});
+    const checkboxStyles = ctx.getStyles('cardCheckbox', {classNames, styles});
+
     const cards = table.getRowModel().rows.map((row) => {
         const isSelected = !!row.getIsSelected();
         const shouldKeepSelection = store.rowSelectionForced && isSelected;
@@ -67,17 +65,6 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
             }
             row.toggleSelected();
         };
-
-        const cardStyles = ctx.getStyles('card', {
-            classNames,
-            className,
-            styles,
-            style,
-        });
-        const checkboxStyles = ctx.getStyles('cardCheckbox', {
-            classNames,
-            styles,
-        });
 
         return (
             <Card
@@ -92,25 +79,10 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
                     onRowDoubleClick?.(row.original, row.index, row);
                 }}
                 pos="relative"
-                className={cardStyles.className}
-                style={cardStyles.style}
+                {...cardStyles}
                 {...(getRowAttributes?.(row.original, row.index, row) ?? {})}
             >
-                {areSelectionCheckboxesVisible ? (
-                    <Checkbox
-                        checked={isSelected}
-                        onChange={onClick}
-                        readOnly={!store.rowSelectionEnabled}
-                        aria-label="Select row"
-                        onClick={(event) => event.stopPropagation()}
-                        onDoubleClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                        }}
-                        className={checkboxStyles.className}
-                        style={checkboxStyles.style}
-                    />
-                ) : null}
+                <TableSelectRowCheckbox row={row} {...checkboxStyles} />
                 <Stack gap="sm">
                     {row
                         .getVisibleCells()
@@ -135,12 +107,10 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
         <tr>
             <td colSpan={table.getAllColumns().length}>
                 <Stack px="xl" py="md" gap="md">
-                    {areSelectionCheckboxesVisible ? (
-                        <TableSelectAllCheckbox
-                            {...ctx.getStyles('selectAllCheckbox', {classNames, styles})}
-                            label="Select entire page"
-                        />
-                    ) : null}
+                    <TableSelectAllCheckbox
+                        {...ctx.getStyles('selectAllCheckbox', {classNames, styles})}
+                        label="Select entire page"
+                    />
                     <SimpleGrid cols={{base: 1, sm: 2, md: 3, lg: 4}} spacing="md">
                         {cards}
                     </SimpleGrid>

--- a/packages/mantine/src/components/Table/table-column/TableSelectAllCheckbox.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectAllCheckbox.tsx
@@ -10,7 +10,12 @@ export interface TableSelectAllCheckboxProps extends Omit<CheckboxProps, 'checke
  * Shared between the RowLayout column header and the CardLayout header.
  */
 export const TableSelectAllCheckbox = (props: TableSelectAllCheckboxProps) => {
-    const {table, store} = useTableContext();
+    const {table, store, selectionCheckboxesVisible} = useTableContext();
+
+    if (!selectionCheckboxesVisible) {
+        return null;
+    }
+
     const readOnly = !store.rowSelectionEnabled;
     const isAllSelected = table.getIsAllPageRowsSelected();
     const isSomeSelected = table.getIsSomePageRowsSelected();

--- a/packages/mantine/src/components/Table/table-column/TableSelectRowCheckbox.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectRowCheckbox.tsx
@@ -4,21 +4,29 @@ import {ChangeEventHandler} from 'react';
 import {Checkbox} from '../../Checkbox/Checkbox.js';
 import {useTableContext} from '../TableContext.js';
 
-export interface TableSelectRowCheckboxProps extends Omit<CheckboxProps, 'checked' | 'indeterminate' | 'onChange'> {
-    row: Row<unknown>;
+export interface TableSelectRowCheckboxProps<T> extends Omit<CheckboxProps, 'checked' | 'indeterminate' | 'onChange'> {
+    row: Row<T>;
 }
+
+export type TableSelectRowCheckboxStylesNames = 'selectRowCheckbox';
 
 /**
  * A checkbox that toggles the selection of a single row.
  * Read-only when row selection is disabled but a selection is displayed.
  */
-export const TableSelectRowCheckbox = ({row, ...props}: TableSelectRowCheckboxProps) => {
-    const {store} = useTableContext();
+export const TableSelectRowCheckbox = <T,>({row, className, style, ...props}: TableSelectRowCheckboxProps<T>) => {
+    const {store, getStyles, selectionCheckboxesVisible} = useTableContext();
+
+    if (!selectionCheckboxesVisible) {
+        return null;
+    }
+
     const readOnly = !store.rowSelectionEnabled;
+    const shouldKeepSelection = store.rowSelectionForced && row.getIsSelected();
     const toggleSelected = row.getToggleSelectedHandler();
 
     const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-        if (readOnly) {
+        if (readOnly || shouldKeepSelection) {
             return;
         }
         toggleSelected(event);
@@ -32,10 +40,12 @@ export const TableSelectRowCheckbox = ({row, ...props}: TableSelectRowCheckboxPr
             readOnly={readOnly}
             flex={1}
             aria-label="Select row"
+            onClick={(event) => event.stopPropagation()}
             onDoubleClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
             }}
+            {...getStyles('selectRowCheckbox', {className, style})}
             {...props}
         />
     );

--- a/packages/mantine/src/components/Table/table-column/TableSelectableColumn.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectableColumn.tsx
@@ -12,6 +12,7 @@ export const TableSelectableColumn: ColumnDef<unknown> = {
     meta: {
         controlColumn: true,
     },
+    size: 76,
     header: () => <TableSelectAllCheckbox flex={1} />,
     cell: ({row}) => <TableSelectRowCheckbox row={row} />,
 };

--- a/packages/mantine/src/components/Table/table-column/areSelectionCheckboxesVisible.spec.ts
+++ b/packages/mantine/src/components/Table/table-column/areSelectionCheckboxesVisible.spec.ts
@@ -1,0 +1,43 @@
+import {areSelectionCheckboxesVisible} from './areSelectionCheckboxesVisible.js';
+
+describe('areSelectionCheckboxesVisible', () => {
+    it('returns false when multi-row selection is disabled', () => {
+        expect(
+            areSelectionCheckboxesVisible({
+                multiRowSelectionEnabled: false,
+                rowSelectionEnabled: true,
+                getSelectedRows: () => [{}],
+            }),
+        ).toBe(false);
+    });
+
+    it('returns true when multi-row selection and row selection are enabled', () => {
+        expect(
+            areSelectionCheckboxesVisible({
+                multiRowSelectionEnabled: true,
+                rowSelectionEnabled: true,
+                getSelectedRows: () => [],
+            }),
+        ).toBe(true);
+    });
+
+    it('returns true when row selection is disabled and selected rows exist', () => {
+        expect(
+            areSelectionCheckboxesVisible({
+                multiRowSelectionEnabled: true,
+                rowSelectionEnabled: false,
+                getSelectedRows: () => [{}],
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false when row selection is disabled and no selected rows exist', () => {
+        expect(
+            areSelectionCheckboxesVisible({
+                multiRowSelectionEnabled: true,
+                rowSelectionEnabled: false,
+                getSelectedRows: () => [],
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/mantine/src/components/Table/table-column/areSelectionCheckboxesVisible.ts
+++ b/packages/mantine/src/components/Table/table-column/areSelectionCheckboxesVisible.ts
@@ -1,0 +1,9 @@
+import type {TableStore} from '../use-table.js';
+
+type SelectionVisibilityStore<T> = Pick<
+    TableStore<T>,
+    'multiRowSelectionEnabled' | 'rowSelectionEnabled' | 'getSelectedRows'
+>;
+
+export const areSelectionCheckboxesVisible = <T>(store: SelectionVisibilityStore<T>): boolean =>
+    store.multiRowSelectionEnabled && (store.rowSelectionEnabled || store.getSelectedRows().length > 0);

--- a/packages/storybook/src/components/data-display/Table.stories.tsx
+++ b/packages/storybook/src/components/data-display/Table.stories.tsx
@@ -25,7 +25,7 @@ dayjs.extend(LocalizedFormat);
 
 const SEEDED_DATE = new Date(2023, 0, 1);
 
-// Set the seed for faker to avoid mismatch in chromatic
+// Set the seed for faker to avoid mismatch in chromatic.
 faker.seed(42);
 faker.setDefaultRefDate(SEEDED_DATE);
 


### PR DESCRIPTION
### Proposed Changes

- Reuse the shared row-selection checkbox in both row and card layouts.
- Keep forced selections selected when their checkbox is clicked.
- Show row checkboxes when their row is hovered, focused, or selected.
- Centralize selection-checkbox visibility and reduce the selection column width.
- Add unit and layout coverage for the shared behavior.

Jira: [ADUI-11537](https://coveord.atlassian.net/browse/ADUI-11537)

### How to test

Go in the table demo page and activate row actions and row multi selection.

Before

<img width="1869" height="679" alt="image" src="https://github.com/user-attachments/assets/919ccb56-a192-478f-b2f9-82f25be84072" />

After

<img width="1870" height="684" alt="image" src="https://github.com/user-attachments/assets/c8d1eb6c-3387-4599-9d27-e62a8c60513d" />


### Potential Breaking Changes

None.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (not relevant)

[ADUI-11537]: https://coveord.atlassian.net/browse/ADUI-11537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ