### PR TITLE
ADUI-11538 Clear Table selection with Escape

### DIFF
--- a/.changeset/calm-lions-jump.md
+++ b/.changeset/calm-lions-jump.md
@@ -1,0 +1,8 @@
+---
+'@coveord/plasma-mantine': minor
+'@coveord/plasma-llms': patch
+---
+
+Clear `Table` row selections with Escape
+
+Press Escape to clear selected rows when row selection is enabled. Tables with `forceSelection` enabled preserve their selection.

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -52,6 +52,7 @@ Important states include:
 ## Interaction notes
 
 - Expandable row content SHOULD add detail without replacing the row's core scannable information.
+- When row selection is enabled, pressing Escape clears the selection unless `forceSelection` is enabled.
 
 ## Content guidance
 

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -283,6 +283,16 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
         null,
         [containerRef.current, ...additionalRootNodes],
     );
+    useEffect(() => {
+        const clearRowSelection = (event: KeyboardEvent) => {
+            if (event.key === 'Escape' && store.rowSelectionEnabled && !store.rowSelectionForced) {
+                store.clearRowSelection();
+            }
+        };
+
+        document.addEventListener('keydown', clearRowSelection, true);
+        return () => document.removeEventListener('keydown', clearRowSelection, true);
+    }, [store.clearRowSelection, store.rowSelectionEnabled, store.rowSelectionForced]);
     const mergedRef = useMergedRef(containerRef, ref);
 
     if (!data) {

--- a/packages/mantine/src/components/Table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/Table.spec.tsx
@@ -226,6 +226,28 @@ describe('Table', () => {
         expect(screen.getByRole('row', {name: /John Doe/i, selected: false})).toBeInTheDocument();
     });
 
+    it('clears a selected row when pressing Escape', async () => {
+        const user = userEvent.setup();
+        const Fixture = () => {
+            const store = useTable<RowData>();
+            return (
+                <Table
+                    store={store}
+                    getRowId={({id}) => id}
+                    data={[{id: '🆔-1', firstName: 'John', lastName: 'Smith'}]}
+                    columns={columns}
+                />
+            );
+        };
+        render(<Fixture />);
+
+        const row = screen.getByRole('row', {name: /John Smith/i});
+        await user.click(row);
+        await user.keyboard('{Escape}');
+
+        expect(row).toHaveAttribute('aria-selected', 'false');
+    });
+
     describe('with multiple layouts', () => {
         const Layout1: TableLayout = ({children}) => <>{children}</>;
         Layout1.displayName = 'Layout 1';
@@ -300,6 +322,62 @@ describe('Table', () => {
     });
 
     describe('when multi row selection is enabled', () => {
+        const data: RowData[] = [
+            {id: '🆔-1', firstName: 'John', lastName: 'Smith'},
+            {id: '🆔-2', firstName: 'Jane', lastName: 'Doe'},
+        ];
+
+        const Fixture = ({
+            enableRowSelection = true,
+            forceSelection = false,
+            initialRowSelection = {},
+        }: {
+            enableRowSelection?: boolean;
+            forceSelection?: boolean;
+            initialRowSelection?: Record<string, RowData>;
+        }) => {
+            const store = useTable<RowData>({
+                enableMultiRowSelection: true,
+                enableRowSelection,
+                forceSelection,
+                initialState: {rowSelection: initialRowSelection},
+            });
+
+            return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} />;
+        };
+
+        it('clears multiple selected rows when pressing Escape', async () => {
+            const user = userEvent.setup();
+            render(<Fixture />);
+
+            await user.click(screen.getByRole('checkbox', {name: /select all/i}));
+            expect(screen.getAllByRole('row', {selected: true})).toHaveLength(2);
+
+            await user.keyboard('{Escape}');
+
+            expect(screen.queryAllByRole('row', {selected: true})).toEqual([]);
+        });
+
+        it('keeps multiple selected rows when row selection is disabled', async () => {
+            const user = userEvent.setup();
+            const initialRowSelection = {'🆔-1': data[0], '🆔-2': data[1]};
+            render(<Fixture enableRowSelection={false} initialRowSelection={initialRowSelection} />);
+
+            await user.keyboard('{Escape}');
+
+            expect(screen.getAllByRole('row', {selected: true})).toHaveLength(2);
+        });
+
+        it('keeps multiple selected rows when row selection is forced', async () => {
+            const user = userEvent.setup();
+            render(<Fixture forceSelection />);
+
+            await user.click(screen.getByRole('checkbox', {name: /select all/i}));
+            await user.keyboard('{Escape}');
+
+            expect(screen.getAllByRole('row', {selected: true})).toHaveLength(2);
+        });
+
         it('does not clear the row selection when clicking outside the table', async () => {
             const user = userEvent.setup();
             const Fixture = () => {

--- a/packages/storybook/src/components/data-display/Table.stories.tsx
+++ b/packages/storybook/src/components/data-display/Table.stories.tsx
@@ -51,6 +51,12 @@ const meta: Meta<StoryArgs> = {
     component: Table,
     parameters: {
         layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'When row selection is enabled, press Escape to clear the selection. Escape does not clear forced selections.',
+            },
+        },
     },
 };
 export default meta;


### PR DESCRIPTION
<!-- This notice will be removed when you mark your PR as "Ready for review" -->

### Proposed Changes

This PR adds the feature to the table component: pressing the ESC button on the keyboard will now clear the row selection (if row selection is enabled).

[Jira ticket](https://coveord.atlassian.net/browse/ADUI-11538)

### How to test

1. Go in the table demo page and enable row actions and multi row selection.
2. Make a selection of rows
3. Press escape on your keyboard, it should unselect all rows you have selected

### Potential Breaking Changes

None.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (not relevant for this interaction change)