### PR TITLE
fix(radio): fix spacing styling between inputWrapper and radioGroup

### DIFF
--- a/packages/mantine/src/styles/Radio.module.css
+++ b/packages/mantine/src/styles/Radio.module.css
@@ -35,3 +35,8 @@
         }
     }
 }
+
+div[role='radiogroup'] {
+    padding-top: var(--mantine-spacing-xs);
+    padding-bottom: var(--mantine-spacing-xs);
+}

--- a/packages/storybook/src/components/forms-and-inputs/string/Radio.stories.tsx
+++ b/packages/storybook/src/components/forms-and-inputs/string/Radio.stories.tsx
@@ -47,7 +47,7 @@ export const RadioGroup: StoryObj<RadioGroupStoryArgs> = {
     },
     render: (props) => (
         <Radio.Group {...withLabelInfoProps(props)}>
-            <Group mt="xs">
+            <Group>
                 <Radio value="1" label="Option 1" readOnly={props.readOnly} />
                 <Radio value="2" label="Option 2" readOnly={props.readOnly} />
                 <Radio value="3" label="Option 3" readOnly={props.readOnly} />


### PR DESCRIPTION
This PR handles the spacing needed for the Radio.Group component to reflect figma mock ups. No need to explicitly set it when developping.