### PR TITLE
ADUI-11421 Allow conditional Table row selection

### DIFF
--- a/.changeset/swift-pandas-travel.md
+++ b/.changeset/swift-pandas-travel.md
@@ -1,0 +1,7 @@
+---
+'@coveord/plasma-mantine': minor
+---
+
+Allow conditional row selection with `useTable`
+
+`enableRowSelection` now accepts a predicate in addition to a boolean. Return `false` for rows that users must not be able to select. Rejected rows are skipped by row and card interactions, checkboxes, select-all, and Shift-click range selection.

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -53,6 +53,7 @@ Important states include:
 
 - Expandable row content SHOULD add detail without replacing the row's core scannable information.
 - When row selection is enabled, pressing Escape clears the selection unless `forceSelection` is enabled.
+- `enableRowSelection` MAY be a predicate when only some rows should be selectable. Rows rejected by the predicate cannot be selected through their surface or checkbox and are skipped by select-all and range selection.
 - When multi-row selection is enabled, users MAY click a row, card, or its checkbox and then Shift-click another selection target to select all selectable rows between them on the displayed page. Existing selections outside the range are preserved.
 
 ## Content guidance
@@ -88,6 +89,12 @@ Important states include:
 **`children`** `ReactNode` · optional · default: `undefined` — Children can include sub-components like `Table.Toolbar`, `Table.Header`, `Table.Footer`, `Table.NoData`, and `Table.LastUpdated`. Filter controls (`Table.Filter`, `Table.Predicate`, `Table.DateRangePicker`) MUST be placed inside `Table.Header` or `Table.Toolbar`.
 **`additionalRootNodes`** `HTMLElement[]` · optional · default: `[]` — Nodes that are considered inside the table. Rows normally get unselected when clicking outside the table, but the component can have difficulty guessing what is inside or outside, for example when using modals. You MAY use this prop to force the table to consider some nodes to be inside the table.
 **`options`** `Omit<Partial<TableOptions<TData>>, 'initialState' | 'data' | 'columns' | 'manualPagination' | 'enableMultiRowSelection' | 'getRowId' | 'getRowCanExpand' | 'enableRowSelection' | 'onRowSelectionChange'>` · optional · default: `{}` — Additional options MAY be passed to the table with this prop.
+
+## `useTable` row selection options
+
+**`enableRowSelection`** `boolean | ((row: Row<TData>) => boolean)` · optional · default: `true`: Whether rows can be selected, or a predicate that determines whether each row can be selected. Selection is temporarily disabled while `Table` is loading.
+**`enableMultiRowSelection`** `boolean` · optional · default: `false`: Whether multiple rows can be selected at the same time. Only applies when row selection is enabled.
+**`forceSelection`** `boolean` · optional · default: `false`: Forces the user to always have one row selected. When activating that setting, a good practice is to have a row already selected in the initial state.
 
 ## Sub-components
 
@@ -159,6 +166,7 @@ type TData = {
     firstName: string;
     lastName: string;
     age: number;
+    type: 'Custom' | 'System';
 };
 
 const columnHelper = createColumnHelper<TData>();
@@ -172,8 +180,8 @@ const columns = [
 export function Example() {
     const data = useMemo<TData[]>(
         () => [
-            {id: '1', firstName: 'Ada', lastName: 'Lovelace', age: 36},
-            {id: '2', firstName: 'Grace', lastName: 'Hopper', age: 85},
+            {id: '1', firstName: 'Ada', lastName: 'Lovelace', age: 36, type: 'Custom'},
+            {id: '2', firstName: 'Grace', lastName: 'Hopper', age: 85, type: 'System'},
         ],
         [],
     );
@@ -183,6 +191,7 @@ export function Example() {
             totalEntries: data.length,
             pagination: {page: 0, perPage: 10},
         },
+        enableRowSelection: (row) => row.original.type !== 'System',
     });
 
     return <Table<TData> store={store} columns={columns} data={data} getRowId={({id}) => id} />;

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -218,7 +218,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
         enableMultiRowSelection: !!store.multiRowSelectionEnabled,
         getRowId,
         getRowCanExpand: (row: Row<T>) => !!getRowExpandedContent?.(row.original, row.index, row),
-        enableRowSelection: !loading,
+        enableRowSelection: loading ? false : store.rowSelectionEnabled,
         defaultColumn: {
             size: undefined,
             minSize: defaultColumnSizing.minSize,

--- a/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
@@ -5,7 +5,7 @@ import {useTable} from '../../use-table.js';
 import {CardLayout} from '../card-layout/CardLayout.js';
 
 describe('CardLayout', () => {
-    type RowData = {id: string; firstName: string; lastName?: string};
+    type RowData = {id: string; firstName: string; lastName?: string; disabled?: boolean};
 
     const columnHelper = createColumnHelper<RowData>();
     const columns: Array<ColumnDef<RowData>> = [
@@ -141,6 +141,36 @@ describe('CardLayout', () => {
             const card2 = screen.getByTestId('2');
             expect(within(card1).getByRole('checkbox', {name: /select row/i})).toBeVisible();
             expect(within(card2).getByRole('checkbox', {name: /select row/i})).toBeVisible();
+        });
+
+        it('selects only cards allowed by the row selection predicate', async () => {
+            const user = userEvent.setup();
+            const data: RowData[] = [
+                {id: '1', firstName: 'Selectable'},
+                {id: '2', firstName: 'Disabled', disabled: true},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    enableRowSelection: (row) => !row.original.disabled,
+                });
+                return (
+                    <Table store={store} getRowId={({id}) => id} data={data} columns={columns} layouts={[CardLayout]} />
+                );
+            };
+            render(<Fixture />);
+
+            const selectableCard = screen.getByTestId('1');
+            const disabledCard = screen.getByTestId('2');
+            expect(selectableCard).toHaveAttribute('data-selectable', 'true');
+            expect(disabledCard).not.toHaveAttribute('data-selectable');
+
+            await user.click(disabledCard);
+            await user.click(within(disabledCard).getByRole('checkbox', {name: /select row/i}));
+            expect(disabledCard).toHaveAttribute('aria-selected', 'false');
+
+            await user.click(selectableCard);
+            expect(selectableCard).toHaveAttribute('aria-selected', 'true');
         });
 
         it('does not render selection checkboxes when row selection is disabled and the selection is empty', () => {

--- a/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
@@ -556,7 +556,64 @@ describe('RowLayout', () => {
             expect(screen.queryAllByRole('row', {selected: true})).toEqual([]);
         });
 
-        it('prevents row selection if disableRowSelection is true', async () => {
+        it('selects only rows allowed by the row selection predicate', async () => {
+            const user = userEvent.setup();
+            const data: RowData[] = [
+                {id: '1', firstName: 'Selectable'},
+                {id: '2', firstName: 'Disabled', disabled: true},
+                {id: '3', firstName: 'Also selectable'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    enableRowSelection: (row) => !row.original.disabled,
+                });
+                return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} />;
+            };
+            render(<Fixture />);
+
+            const selectableRow = screen.getByTestId('1');
+            const disabledRow = screen.getByTestId('2');
+            expect(selectableRow).toHaveAttribute('data-selectable', 'true');
+            expect(disabledRow).toHaveAttribute('data-selectable', 'false');
+
+            await user.click(disabledRow);
+            await user.click(within(disabledRow).getByRole('checkbox', {name: /select row/i}));
+            expect(disabledRow).toHaveAttribute('aria-selected', 'false');
+
+            await user.click(screen.getByRole('checkbox', {name: /select all from this page/i}));
+            expect(selectableRow).toHaveAttribute('aria-selected', 'true');
+            expect(disabledRow).toHaveAttribute('aria-selected', 'false');
+            expect(screen.getByTestId('3')).toHaveAttribute('aria-selected', 'true');
+        });
+
+        it('skips rows rejected by the row selection predicate when selecting a range', async () => {
+            const user = userEvent.setup();
+            const data: RowData[] = [
+                {id: '1', firstName: 'One'},
+                {id: '2', firstName: 'Two', disabled: true},
+                {id: '3', firstName: 'Three'},
+            ];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    enableRowSelection: (row) => !row.original.disabled,
+                });
+                return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} />;
+            };
+            render(<Fixture />);
+
+            await user.click(screen.getByTestId('1'));
+            await user.keyboard('{Shift>}');
+            await user.click(screen.getByTestId('3'));
+            await user.keyboard('{/Shift}');
+
+            expect(screen.getByTestId('1')).toHaveAttribute('aria-selected', 'true');
+            expect(screen.getByTestId('2')).toHaveAttribute('aria-selected', 'false');
+            expect(screen.getByTestId('3')).toHaveAttribute('aria-selected', 'true');
+        });
+
+        it('prevents row selection when row selection is disabled', async () => {
             const user = userEvent.setup();
             const data: RowData[] = [
                 {id: '🆔-1', firstName: 'first', lastName: 'last'},

--- a/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
@@ -70,8 +70,8 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
             <Card
                 key={row.id}
                 mod={{selected: isSelected}}
-                variant={store.rowSelectionEnabled ? 'hover' : undefined}
-                data-selectable={store.rowSelectionEnabled || undefined}
+                variant={row.getCanSelect() ? 'hover' : undefined}
+                data-selectable={row.getCanSelect() || undefined}
                 aria-selected={isSelected}
                 data-testid={row.id}
                 onClick={onClick}

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
@@ -59,7 +59,7 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
                     onDoubleClick={() => {
                         onRowDoubleClick?.(row.original, row.index, row);
                     }}
-                    data-selectable={store.rowSelectionEnabled}
+                    data-selectable={row.getCanSelect()}
                     data-selected={isSelected}
                     data-multi-selection={store.multiRowSelectionEnabled}
                     aria-selected={isSelected}
@@ -77,7 +77,7 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
                         };
 
                         const onCollapsibleCellClick = (event: MouseEvent<HTMLTableCellElement>) => {
-                            if (cell.column.id === TableSelectableColumn.id && store.rowSelectionEnabled) {
+                            if (cell.column.id === TableSelectableColumn.id && row.getCanSelect()) {
                                 event.stopPropagation();
                             }
                         };

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutHeader.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutHeader.tsx
@@ -36,11 +36,12 @@ export const RowLayoutHeader = <T,>(props: RowLayoutHeaderProps<T> & {ref?: Forw
         ...others
     } = useProps('RowLayoutHeader', defaultProps, props);
     const {table, store} = useTableContext<T>();
+    const hasSelectableRows = table.getRowModel().rows.some((row) => row.getCanSelect());
 
     const headers = table.getHeaderGroups().map((headerGroup) => (
         <tr
             key={headerGroup.id}
-            data-selectable={store.rowSelectionEnabled}
+            data-selectable={hasSelectableRows}
             data-multi-selection={store.multiRowSelectionEnabled}
             {...ctx.getStyles('headerRow', {className, classNames, styles, style})}
             {...others}

--- a/packages/mantine/src/components/Table/table-column/TableSelectAllCheckbox.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectAllCheckbox.tsx
@@ -16,7 +16,7 @@ export const TableSelectAllCheckbox = (props: TableSelectAllCheckboxProps) => {
         return null;
     }
 
-    const readOnly = !store.rowSelectionEnabled;
+    const readOnly = !store.rowSelectionEnabled || !table.getRowModel().rows.some((row) => row.getCanSelect());
     const isAllSelected = table.getIsAllPageRowsSelected();
     const isSomeSelected = table.getIsSomePageRowsSelected();
     const label = isAllSelected ? 'Unselect all from this page' : 'Select all from this page';

--- a/packages/mantine/src/components/Table/table-column/TableSelectRowCheckbox.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectRowCheckbox.tsx
@@ -23,13 +23,13 @@ export const TableSelectRowCheckbox = <T,>({
     onDoubleClick,
     ...props
 }: TableSelectRowCheckboxProps<T>) => {
-    const {store, getStyles, selectionCheckboxesVisible, handleRowSelection} = useTableContext<T>();
+    const {getStyles, selectionCheckboxesVisible, handleRowSelection} = useTableContext<T>();
 
     if (!selectionCheckboxesVisible) {
         return null;
     }
 
-    const readOnly = !store.rowSelectionEnabled;
+    const readOnly = !row.getCanSelect();
     const handleClick: MouseEventHandler<HTMLInputElement> = (event) => {
         event.stopPropagation();
         handleRowSelection(row, event.shiftKey);

--- a/packages/mantine/src/components/Table/tableSelectionUtils.ts
+++ b/packages/mantine/src/components/Table/tableSelectionUtils.ts
@@ -34,7 +34,7 @@ interface RangeSelectionMouseEvent {
 }
 
 export const areSelectionCheckboxesVisible = <T>(store: SelectionVisibilityStore<T>): boolean =>
-    store.multiRowSelectionEnabled && (store.rowSelectionEnabled || store.getSelectedRows().length > 0);
+    store.multiRowSelectionEnabled && (!!store.rowSelectionEnabled || store.getSelectedRows().length > 0);
 
 export const getSelectableRowsInRange = <TRow extends SelectableRow>(
     rows: TRow[],

--- a/packages/mantine/src/components/Table/use-table.ts
+++ b/packages/mantine/src/components/Table/use-table.ts
@@ -1,6 +1,6 @@
 import type {DatesRangeValue, DateStringValue} from '@mantine/dates';
 import {useDidUpdate} from '@mantine/hooks';
-import {type ExpandedState, type SortingState} from '@tanstack/table-core';
+import {type ExpandedState, type Row, type SortingState} from '@tanstack/table-core';
 import defaultsDeep from 'lodash.defaultsdeep';
 import {Dispatch, SetStateAction, useCallback, useMemo, useState} from 'react';
 import {useUrlSyncedState, UseUrlSyncedStateOptions} from '../../hooks/use-url-synced-state.js';
@@ -21,6 +21,8 @@ export interface PaginationState {
      */
     perPage: number;
 }
+
+export type EnableRowSelection<TData> = boolean | ((row: Row<TData>) => boolean);
 
 export interface TableState<TData = unknown> {
     /**
@@ -164,9 +166,9 @@ export interface TableStore<TData = unknown> {
      */
     multiRowSelectionEnabled: boolean;
     /**
-     * Whether rows can be selected.
+     * Whether rows can be selected, or a predicate that determines whether each row can be selected.
      */
-    rowSelectionEnabled: boolean;
+    rowSelectionEnabled: EnableRowSelection<TData>;
     /**
      * Whether row selection is forced.
      */
@@ -179,15 +181,15 @@ export interface UseTableOptions<TData = unknown> {
      */
     initialState?: DeepPartial<TableState<TData>>;
     /**
-     * Whether rows can be selected.
+     * Whether rows can be selected, or a predicate that determines whether each row can be selected.
      *
      * @default true
      */
-    enableRowSelection?: boolean;
+    enableRowSelection?: EnableRowSelection<TData>;
     /**
      * Whether multiple rows can be selected at the same time.
      *
-     * Only applies when `enableRowSelection` is `true`.
+     * Only applies when row selection is enabled.
      *
      * @default false
      */
@@ -504,7 +506,7 @@ export const useTable = <TData>(userOptions: UseTableOptions<TData> = {}): Table
         clearRowSelection,
         getSelectedRows,
         getSelectedRow,
-        rowSelectionEnabled: !!options.enableRowSelection,
+        rowSelectionEnabled: options.enableRowSelection ?? true,
         rowSelectionForced: !!options.forceSelection,
         multiRowSelectionEnabled: !!options.enableMultiRowSelection,
     };

--- a/packages/mantine/src/components/Table/use-table.ts
+++ b/packages/mantine/src/components/Table/use-table.ts
@@ -22,6 +22,9 @@ export interface PaginationState {
     perPage: number;
 }
 
+/**
+ * Enables or disables row selection globally, or determines whether each row can be selected.
+ */
 export type EnableRowSelection<TData> = boolean | ((row: Row<TData>) => boolean);
 
 export interface TableState<TData = unknown> {
@@ -166,7 +169,9 @@ export interface TableStore<TData = unknown> {
      */
     multiRowSelectionEnabled: boolean;
     /**
-     * Whether rows can be selected, or a predicate that determines whether each row can be selected.
+     * The row selection configuration currently used by the table.
+     *
+     * Reflects the `enableRowSelection` option passed to `useTable`, defaulting to `true` when omitted.
      */
     rowSelectionEnabled: EnableRowSelection<TData>;
     /**
@@ -181,7 +186,10 @@ export interface UseTableOptions<TData = unknown> {
      */
     initialState?: DeepPartial<TableState<TData>>;
     /**
-     * Whether rows can be selected, or a predicate that determines whether each row can be selected.
+     * Configures which rows users can select.
+     *
+     * Set to `true` to allow selecting every row, `false` to disable row selection, or provide a predicate to determine
+     * whether each row can be selected.
      *
      * @default true
      */

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -459,6 +459,7 @@ export {
 } from './components/Table/Table.types.js';
 export {useTableContext} from './components/Table/TableContext.js';
 export {
+    type EnableRowSelection,
     useTable,
     type PaginationState,
     type TableState,

--- a/packages/mantine/src/table.ts
+++ b/packages/mantine/src/table.ts
@@ -8,4 +8,10 @@ export {
     type TableProps,
 } from './components/Table/Table.types.js';
 export {useTableContext} from './components/Table/TableContext.js';
-export {useTable, type TableState, type TableStore, type UseTableOptions} from './components/Table/use-table.js';
+export {
+    type EnableRowSelection,
+    useTable,
+    type TableState,
+    type TableStore,
+    type UseTableOptions,
+} from './components/Table/use-table.js';

--- a/packages/storybook/src/components/data-display/Table.stories.tsx
+++ b/packages/storybook/src/components/data-display/Table.stories.tsx
@@ -39,7 +39,8 @@ type StoryArgs = TableProps<Person> & {
     withData: boolean;
     withLayoutSelector: boolean;
     withRowActions: boolean;
-    withRowMultiSelection: boolean;
+    enableRowSelection: boolean;
+    enableMultiRowSelection: boolean;
     withLastUpdated: boolean;
     withCollapsibleRows: boolean;
     collapsibleBehavior: 'collapse' | 'accordion';
@@ -108,7 +109,8 @@ export const Demo: Story = {
         withData: true,
         withLayoutSelector: false,
         withRowActions: false,
-        withRowMultiSelection: false,
+        enableRowSelection: true,
+        enableMultiRowSelection: false,
         withLastUpdated: false,
         withCollapsibleRows: false,
         collapsibleBehavior: 'collapse',
@@ -136,7 +138,8 @@ export const Demo: Story = {
         withData,
         withLayoutSelector,
         withRowActions,
-        withRowMultiSelection,
+        enableRowSelection,
+        enableMultiRowSelection,
         withLastUpdated,
         withCollapsibleRows,
         collapsibleBehavior,
@@ -190,8 +193,8 @@ export const Demo: Story = {
                 dateRange: withDateRangePicker ? [previousWeek, today] : undefined,
                 predicates: withPredicateFilter ? {age: 'ANY'} : undefined,
             },
-            enableRowSelection: withRowActions,
-            enableMultiRowSelection: withRowMultiSelection,
+            enableRowSelection,
+            enableMultiRowSelection,
         });
 
         const filteredData = useMemo(


### PR DESCRIPTION
<!-- This notice will be removed when you mark your PR as "Ready for review" -->

### Proposed Changes

- Allow `useTable`'s `enableRowSelection` option to accept a row predicate in addition to a boolean.
- Apply row eligibility consistently to row and card interactions, selection checkboxes, select-all, and Shift-click range selection.
- Document and demonstrate conditional row selection, with coverage for row and card layouts.

### Potential Breaking Changes

- `TableStore.rowSelectionEnabled` is widened from `boolean` to `boolean | ((row) => boolean)`. Existing boolean configurations remain supported, but consumers that read the store field as a strict boolean may need to coerce or narrow it.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)