### PR TITLE
fix(mantine, Collection): inherit row background

### DIFF
--- a/.changeset/clever-ravens-wink.md
+++ b/.changeset/clever-ravens-wink.md
@@ -1,0 +1,5 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Let horizontal `Collection` rows inherit their container background

--- a/packages/mantine/src/components/Collection/layouts/horizontal-layout/HorizontalLayout.module.css
+++ b/packages/mantine/src/components/Collection/layouts/horizontal-layout/HorizontalLayout.module.css
@@ -25,7 +25,6 @@
     display: flex;
     gap: var(--mantine-spacing-sm);
     align-items: center;
-    background: var(--mantine-color-body);
 }
 
 .row[data-isdragging='true'] {


### PR DESCRIPTION
### Proposed Changes

Remove the explicit body background from horizontal `Collection` rows so they inherit the background of their containing surface.

### Potential Breaking Changes

None.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (not relevant for this styling fix)