### PR TITLE
ADUI-11553 Correct StickyFooter example actions

### DIFF
--- a/.changeset/brave-comets-race.md
+++ b/.changeset/brave-comets-race.md
@@ -1,5 +1,0 @@
----
-'@coveord/plasma-mantine': patch
----
-
-Correct the `StickyFooter` example action hierarchy

--- a/.changeset/brave-comets-race.md
+++ b/.changeset/brave-comets-race.md
@@ -1,0 +1,5 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Correct the `StickyFooter` example action hierarchy

--- a/packages/storybook/src/components/layout/StickyFooter.stories.tsx
+++ b/packages/storybook/src/components/layout/StickyFooter.stories.tsx
@@ -40,8 +40,7 @@ type Story = StoryObj<typeof StickyFooter>;
 export const Default: Story = {
     render: (props) => (
         <StickyFooter {...props}>
-            <Button.Secondary>Cancel</Button.Secondary>
-            <Button.Secondary>Back</Button.Secondary>
+            <Button.Tertiary>Cancel</Button.Tertiary>
             <Button.Primary>Save</Button.Primary>
         </StickyFooter>
     ),


### PR DESCRIPTION
### Proposed Changes

Update the default `StickyFooter` Storybook example to use a tertiary Cancel action alongside the primary Save action. Remove the redundant Back action so the example presents the intended action hierarchy.

Before

<img width="1009" height="119" alt="image" src="https://github.com/user-attachments/assets/6c8b4dfc-17e4-40e8-a206-a0e416b23820" />

After

<img width="1013" height="128" alt="image" src="https://github.com/user-attachments/assets/8b18948c-de18-4999-885e-f7ddc3299897" />


### Potential Breaking Changes

None.

### Acceptance Criteria

- [x] Unit tests are not required for this documentation-only change
- [x] The potential breaking changes are clearly identified
- [x] A changeset is not required because only the private Storybook package changes
- [x] README.md does not require adjustment for this change