### PR TITLE
ADUI-11539 Style unselectable Table rows

### DIFF
--- a/.changeset/clever-foxes-wander.md
+++ b/.changeset/clever-foxes-wander.md
@@ -1,0 +1,8 @@
+---
+'@coveord/plasma-mantine': patch
+'@coveord/plasma-llms': patch
+---
+
+Distinguish rows unavailable for selection
+
+Rows rejected by the `enableRowSelection` predicate now appear at 50% opacity and do not display a selection checkbox.

--- a/.changeset/clever-foxes-wander.md
+++ b/.changeset/clever-foxes-wander.md
@@ -5,4 +5,4 @@
 
 Distinguish rows unavailable for selection in the Table component
 
-Rows rejected by the `enableRowSelection` predicate now appear at 50% opacity and do not display a selection checkbox.
+Rows rejected by the `enableRowSelection` predicate now appear at 50% opacity, do not display a selection checkbox, and do not trigger `onRowDoubleClick`.

--- a/.changeset/clever-foxes-wander.md
+++ b/.changeset/clever-foxes-wander.md
@@ -3,6 +3,6 @@
 '@coveord/plasma-llms': patch
 ---
 
-Distinguish rows unavailable for selection
+Distinguish rows unavailable for selection in the Table component
 
 Rows rejected by the `enableRowSelection` predicate now appear at 50% opacity and do not display a selection checkbox.

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -53,7 +53,7 @@ Important states include:
 
 - Expandable row content SHOULD add detail without replacing the row's core scannable information.
 - When row selection is enabled, pressing Escape clears the selection unless `forceSelection` is enabled.
-- `enableRowSelection` MAY be a predicate when only some rows should be selectable. Rows rejected by the predicate cannot be selected through their surface or checkbox and are skipped by select-all and range selection.
+- `enableRowSelection` MAY be a predicate when only some rows should be selectable. Rows rejected by the predicate are displayed at 50% opacity, do not render a selection checkbox, cannot be selected through their surface, and are skipped by select-all and range selection.
 - When multi-row selection is enabled, users MAY click a row, card, or its checkbox and then Shift-click another selection target to select all selectable rows between them on the displayed page. Existing selections outside the range are preserved.
 
 ## Content guidance
@@ -92,7 +92,7 @@ Important states include:
 
 ## `useTable` row selection options
 
-**`enableRowSelection`** `boolean | ((row: Row<TData>) => boolean)` · optional · default: `true`: Whether rows can be selected, or a predicate that determines whether each row can be selected. Selection is temporarily disabled while `Table` is loading.
+**`enableRowSelection`** `boolean | ((row: Row<TData>) => boolean)` · optional · default: `true`: Whether rows can be selected, or a predicate that determines whether each row can be selected. Rows rejected by the predicate are displayed at 50% opacity and do not render a selection checkbox. Selection is temporarily disabled while `Table` is loading.
 **`enableMultiRowSelection`** `boolean` · optional · default: `false`: Whether multiple rows can be selected at the same time. Only applies when row selection is enabled.
 **`forceSelection`** `boolean` · optional · default: `false`: Forces the user to always have one row selected. When activating that setting, a good practice is to have a row already selected in the initial state.
 

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -53,7 +53,7 @@ Important states include:
 
 - Expandable row content SHOULD add detail without replacing the row's core scannable information.
 - When row selection is enabled, pressing Escape clears the selection unless `forceSelection` is enabled.
-- `enableRowSelection` MAY be a predicate when only some rows should be selectable. Rows rejected by the predicate are displayed at 50% opacity, do not render a selection checkbox, cannot be selected through their surface, and are skipped by select-all and range selection.
+- `enableRowSelection` MAY be a predicate when only some rows should be selectable. Rows rejected by the predicate are displayed at 50% opacity, do not render a selection checkbox, cannot be selected through their surface, do not trigger `onRowDoubleClick`, and are skipped by select-all and range selection.
 - When multi-row selection is enabled, users MAY click a row, card, or its checkbox and then Shift-click another selection target to select all selectable rows between them on the displayed page. Existing selections outside the range are preserved.
 
 ## Content guidance

--- a/packages/mantine/src/components/Table/Table.types.ts
+++ b/packages/mantine/src/components/Table/Table.types.ts
@@ -84,6 +84,7 @@ export interface TableProps<TData> extends BoxProps, StylesApiProps<PlasmaTableF
     layoutProps?: {
         /**
          * Called by the table layout when a row is double clicked.
+         * Rows rejected by the `enableRowSelection` predicate do not trigger this callback.
          * @param selectedRow The data of the row that was double clicked
          * @param index The index of the row that was double clicked
          * @param row The row object that was double clicked

--- a/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
@@ -163,10 +163,13 @@ describe('CardLayout', () => {
             const selectableCard = screen.getByTestId('1');
             const disabledCard = screen.getByTestId('2');
             expect(selectableCard).toHaveAttribute('data-selectable', 'true');
+            expect(selectableCard).not.toHaveAttribute('data-selection-disabled');
             expect(disabledCard).not.toHaveAttribute('data-selectable');
+            expect(disabledCard).toHaveAttribute('data-selection-disabled', 'true');
+            expect(within(selectableCard).getByRole('checkbox', {name: /select row/i})).toBeVisible();
+            expect(within(disabledCard).queryByRole('checkbox', {name: /select row/i})).not.toBeInTheDocument();
 
             await user.click(disabledCard);
-            await user.click(within(disabledCard).getByRole('checkbox', {name: /select row/i}));
             expect(disabledCard).toHaveAttribute('aria-selected', 'false');
 
             await user.click(selectableCard);
@@ -210,6 +213,31 @@ describe('CardLayout', () => {
             expect(rowCheckboxes).toHaveLength(2);
             expect(screen.getByTestId('1')).toHaveAttribute('aria-selected', 'false');
             expect(screen.getByTestId('2')).toHaveAttribute('aria-selected', 'true');
+            expect(screen.getByTestId('1')).not.toHaveAttribute('data-selection-disabled');
+            expect(screen.getByTestId('2')).not.toHaveAttribute('data-selection-disabled');
+        });
+
+        it('does not mark cards as selection disabled while loading', () => {
+            const data: RowData[] = [{id: '1', firstName: 'Selectable'}];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    enableRowSelection: (row) => !row.original.disabled,
+                });
+                return (
+                    <Table
+                        store={store}
+                        getRowId={({id}) => id}
+                        data={data}
+                        columns={columns}
+                        layouts={[CardLayout]}
+                        loading
+                    />
+                );
+            };
+            render(<Fixture />);
+
+            expect(screen.getByTestId('1')).not.toHaveAttribute('data-selection-disabled');
         });
 
         it('selects a card when clicking its checkbox', async () => {

--- a/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/CardLayout.spec.tsx
@@ -123,6 +123,30 @@ describe('CardLayout', () => {
         );
     });
 
+    it('does not call onRowDoubleClick for a card rejected by the selection predicate', async () => {
+        const user = userEvent.setup();
+        const doubleClickSpy = vi.fn();
+        const data: RowData[] = [{id: '1', firstName: 'John', lastName: 'Doe', disabled: true}];
+        const Fixture = () => {
+            const store = useTable<RowData>({enableRowSelection: (row) => !row.original.disabled});
+            return (
+                <Table
+                    store={store}
+                    getRowId={({id}) => id}
+                    data={data}
+                    columns={columns}
+                    layouts={[CardLayout]}
+                    layoutProps={{onRowDoubleClick: doubleClickSpy}}
+                />
+            );
+        };
+        render(<Fixture />);
+
+        await user.dblClick(screen.getByTestId('1'));
+
+        expect(doubleClickSpy).not.toHaveBeenCalled();
+    });
+
     describe('multi-row selection', () => {
         it('renders a checkbox in each card', () => {
             const data: RowData[] = [

--- a/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
@@ -575,10 +575,13 @@ describe('RowLayout', () => {
             const selectableRow = screen.getByTestId('1');
             const disabledRow = screen.getByTestId('2');
             expect(selectableRow).toHaveAttribute('data-selectable', 'true');
+            expect(selectableRow).not.toHaveAttribute('data-selection-disabled');
             expect(disabledRow).toHaveAttribute('data-selectable', 'false');
+            expect(disabledRow).toHaveAttribute('data-selection-disabled', 'true');
+            expect(within(selectableRow).getByRole('checkbox', {name: /select row/i})).toBeVisible();
+            expect(within(disabledRow).queryByRole('checkbox', {name: /select row/i})).not.toBeInTheDocument();
 
             await user.click(disabledRow);
-            await user.click(within(disabledRow).getByRole('checkbox', {name: /select row/i}));
             expect(disabledRow).toHaveAttribute('aria-selected', 'false');
 
             await user.click(screen.getByRole('checkbox', {name: /select all from this page/i}));
@@ -667,8 +670,26 @@ describe('RowLayout', () => {
             const rowCheckboxes = screen.getAllByRole('checkbox', {name: /select row/i});
             expect(rowCheckboxes).toHaveLength(2);
             expect(screen.getByRole('checkbox', {name: /select all/i})).toBeInTheDocument();
-            expect(screen.getByRole('row', {name: /john smith/i, selected: false})).toBeInTheDocument();
-            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).toBeInTheDocument();
+            expect(screen.getByRole('row', {name: /john smith/i, selected: false})).not.toHaveAttribute(
+                'data-selection-disabled',
+            );
+            expect(screen.getByRole('row', {name: /jane doe/i, selected: true})).not.toHaveAttribute(
+                'data-selection-disabled',
+            );
+        });
+
+        it('does not mark rows as selection disabled while loading', () => {
+            const data: RowData[] = [{id: '1', firstName: 'Selectable'}];
+            const Fixture = () => {
+                const store = useTable<RowData>({
+                    enableMultiRowSelection: true,
+                    enableRowSelection: (row) => !row.original.disabled,
+                });
+                return <Table store={store} getRowId={({id}) => id} data={data} columns={columns} loading />;
+            };
+            render(<Fixture />);
+
+            expect(screen.getByTestId('1')).not.toHaveAttribute('data-selection-disabled');
         });
 
         it('does not change the selection when clicking read-only checkboxes', async () => {

--- a/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
+++ b/packages/mantine/src/components/Table/layouts/__tests__/RowLayout.spec.tsx
@@ -238,6 +238,29 @@ describe('RowLayout', () => {
         );
     });
 
+    it('does not call the double click action for a row rejected by the selection predicate', async () => {
+        const user = userEvent.setup();
+        const doubleClickSpy = vi.fn();
+        const data: RowData[] = [{id: '🆔-1', firstName: 'Mario', disabled: true}];
+        const Fixture = () => {
+            const store = useTable<RowData>({enableRowSelection: (row) => !row.original.disabled});
+            return (
+                <Table<RowData>
+                    store={store}
+                    getRowId={({id}) => id}
+                    data={data}
+                    columns={columns}
+                    layoutProps={{onRowDoubleClick: doubleClickSpy}}
+                />
+            );
+        };
+        render(<Fixture />);
+
+        await user.dblClick(screen.getByRole('cell', {name: 'Mario'}));
+
+        expect(doubleClickSpy).not.toHaveBeenCalled();
+    });
+
     it('toggles row selection when clicking on a selected row', async () => {
         const user = userEvent.setup();
         const data: RowData[] = [

--- a/packages/mantine/src/components/Table/layouts/card-layout/CardLayout.module.css
+++ b/packages/mantine/src/components/Table/layouts/card-layout/CardLayout.module.css
@@ -2,6 +2,10 @@
     &[data-selectable='true'] {
         cursor: pointer;
     }
+
+    &[data-selection-disabled='true'] {
+        opacity: 0.5;
+    }
 }
 
 .cardCheckbox {

--- a/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
@@ -4,7 +4,7 @@ import {ForwardedRef, type MouseEvent} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../../../utils/createFactoryComponent.js';
 import {TableLayoutProps} from '../../Table.types.js';
 import {useTableContext} from '../../TableContext.js';
-import {preventRangeSelectionTextSelection} from '../../tableSelectionUtils.js';
+import {isRowSelectionPredicateRejected, preventRangeSelectionTextSelection} from '../../tableSelectionUtils.js';
 import {TableCollapsibleColumn} from '../../table-column/TableCollapsibleColumn.js';
 import {TableSelectAllCheckbox} from '../../table-column/TableSelectAllCheckbox.js';
 import {TableSelectRowCheckbox} from '../../table-column/TableSelectRowCheckbox.js';
@@ -58,6 +58,7 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
 
     const cards = table.getRowModel().rows.map((row) => {
         const isSelected = !!row.getIsSelected();
+        const isSelectionDisabled = isRowSelectionPredicateRejected(row, store);
         const onClick = (event: MouseEvent<HTMLDivElement>) => {
             preventRangeSelectionTextSelection(event, row, store);
             handleRowSelection(row, event.shiftKey);
@@ -72,6 +73,7 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
                 mod={{selected: isSelected}}
                 variant={row.getCanSelect() ? 'hover' : undefined}
                 data-selectable={row.getCanSelect() || undefined}
+                data-selection-disabled={isSelectionDisabled || undefined}
                 aria-selected={isSelected}
                 data-testid={row.id}
                 onClick={onClick}

--- a/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/card-layout/CardLayoutBody.tsx
@@ -79,7 +79,9 @@ export const CardLayoutBody = <T,>(props: CardLayoutBodyProps<T> & {ref?: Forwar
                 onClick={onClick}
                 onMouseDown={onMouseDown}
                 onDoubleClick={() => {
-                    onRowDoubleClick?.(row.original, row.index, row);
+                    if (!isSelectionDisabled) {
+                        onRowDoubleClick?.(row.original, row.index, row);
+                    }
                 }}
                 pos="relative"
                 {...cardStyles}

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayout.module.css
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayout.module.css
@@ -18,8 +18,10 @@
         padding-left: 40px;
     }
 
-    @mixin hover {
-        background-color: var(--mantine-color-gray-light-hover);
+    &[data-selectable='true'] {
+        @mixin hover {
+            background-color: var(--mantine-color-gray-light-hover);
+        }
     }
 
     &[data-selectable='false'] input[type='checkbox'] {
@@ -41,6 +43,10 @@
         &[data-multi-selection='true'] {
             background-color: transparent;
         }
+    }
+
+    &[data-selection-disabled='true'] {
+        opacity: 0.5;
     }
 
     &[data-collapsible-cell='true'] {

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
@@ -5,7 +5,7 @@ import {ForwardedRef, Fragment, type MouseEvent} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../../../utils/createFactoryComponent.js';
 import {TableLayoutProps} from '../../Table.types.js';
 import {useTableContext} from '../../TableContext.js';
-import {preventRangeSelectionTextSelection} from '../../tableSelectionUtils.js';
+import {isRowSelectionPredicateRejected, preventRangeSelectionTextSelection} from '../../tableSelectionUtils.js';
 import {TableCollapsibleColumn} from '../../table-column/TableCollapsibleColumn.js';
 import {TableSelectableColumn} from '../../table-column/TableSelectableColumn.js';
 import {TableLoading} from '../../table-loading/TableLoading.js';
@@ -43,6 +43,7 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
     const rows = table.getRowModel()?.rows.map((row) => {
         const rowChildren = getRowExpandedContent?.(row.original, row.index, row) ?? null;
         const isSelected = !!row.getIsSelected();
+        const isSelectionDisabled = isRowSelectionPredicateRejected(row, store);
         const onClick = (event: MouseEvent<HTMLTableRowElement>) => {
             preventRangeSelectionTextSelection(event, row, store);
             handleRowSelection(row, event.shiftKey);
@@ -62,6 +63,7 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
                     data-selectable={row.getCanSelect()}
                     data-selected={isSelected}
                     data-multi-selection={store.multiRowSelectionEnabled}
+                    data-selection-disabled={isSelectionDisabled || undefined}
                     aria-selected={isSelected}
                     data-testid={row.id}
                     {...ctx.getStyles('row', {classNames, className, styles, style})}

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
@@ -58,7 +58,9 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
                     onClick={onClick}
                     onMouseDown={onMouseDown}
                     onDoubleClick={() => {
-                        onRowDoubleClick?.(row.original, row.index, row);
+                        if (!isSelectionDisabled) {
+                            onRowDoubleClick?.(row.original, row.index, row);
+                        }
                     }}
                     data-selectable={row.getCanSelect()}
                     data-selected={isSelected}

--- a/packages/mantine/src/components/Table/table-column/TableSelectRowCheckbox.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableSelectRowCheckbox.tsx
@@ -3,6 +3,7 @@ import {Row} from '@tanstack/table-core';
 import {MouseEventHandler} from 'react';
 import {Checkbox} from '../../Checkbox/Checkbox.js';
 import {useTableContext} from '../TableContext.js';
+import {isRowSelectionPredicateRejected} from '../tableSelectionUtils.js';
 
 export interface TableSelectRowCheckboxProps<T> extends Omit<CheckboxProps, 'checked' | 'indeterminate' | 'onChange'> {
     row: Row<T>;
@@ -23,9 +24,9 @@ export const TableSelectRowCheckbox = <T,>({
     onDoubleClick,
     ...props
 }: TableSelectRowCheckboxProps<T>) => {
-    const {getStyles, selectionCheckboxesVisible, handleRowSelection} = useTableContext<T>();
+    const {getStyles, selectionCheckboxesVisible, handleRowSelection, store} = useTableContext<T>();
 
-    if (!selectionCheckboxesVisible) {
+    if (!selectionCheckboxesVisible || isRowSelectionPredicateRejected(row, store)) {
         return null;
     }
 

--- a/packages/mantine/src/components/Table/tableSelectionUtils.ts
+++ b/packages/mantine/src/components/Table/tableSelectionUtils.ts
@@ -1,3 +1,4 @@
+import type {Row} from '@tanstack/table-core';
 import type {TableState, TableStore} from './use-table.js';
 
 interface SelectableRow {
@@ -35,6 +36,9 @@ interface RangeSelectionMouseEvent {
 
 export const areSelectionCheckboxesVisible = <T>(store: SelectionVisibilityStore<T>): boolean =>
     store.multiRowSelectionEnabled && (!!store.rowSelectionEnabled || store.getSelectedRows().length > 0);
+
+export const isRowSelectionPredicateRejected = <T>(row: Row<T>, store: TableStore<T>): boolean =>
+    typeof store.rowSelectionEnabled === 'function' && !store.rowSelectionEnabled(row);
 
 export const getSelectableRowsInRange = <TRow extends SelectableRow>(
     rows: TRow[],

--- a/packages/mantine/src/components/Table/use-table.ts
+++ b/packages/mantine/src/components/Table/use-table.ts
@@ -190,6 +190,7 @@ export interface UseTableOptions<TData = unknown> {
      *
      * Set to `true` to allow selecting every row, `false` to disable row selection, or provide a predicate to determine
      * whether each row can be selected.
+     * Rows rejected by the predicate are displayed with reduced opacity and do not render a selection checkbox.
      *
      * @default true
      */

--- a/packages/storybook/chromatic.config.json
+++ b/packages/storybook/chromatic.config.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://www.chromatic.com/config-file.schema.json",
+    "externals": ["packages/mantine/src/**"]
+}

--- a/packages/storybook/src/components/data-display/Table.stories.tsx
+++ b/packages/storybook/src/components/data-display/Table.stories.tsx
@@ -40,6 +40,7 @@ type StoryArgs = TableProps<Person> & {
     withLayoutSelector: boolean;
     withRowActions: boolean;
     enableRowSelection: boolean;
+    withUnselectableRows: boolean;
     enableMultiRowSelection: boolean;
     withLastUpdated: boolean;
     withCollapsibleRows: boolean;
@@ -65,6 +66,7 @@ type Person = {
     bio: string;
     pic: string;
     lastActivity: Date;
+    selectable: boolean;
 };
 
 const columnHelper = createColumnHelper<Person>();
@@ -72,7 +74,7 @@ const columnHelper = createColumnHelper<Person>();
 const makeData = (len: number): Person[] =>
     Array(len)
         .fill(0)
-        .map(() => ({
+        .map((_, index) => ({
             id: faker.string.uuid(),
             pic: faker.image.avatar(),
             firstName: faker.person.firstName(),
@@ -80,6 +82,7 @@ const makeData = (len: number): Person[] =>
             age: faker.number.int(40),
             bio: faker.lorem.sentences({min: 1, max: 5}),
             lastActivity: faker.date.recent({days: 7}),
+            selectable: index % 3 !== 0,
         }));
 
 const options: TableProps<Person>['options'] = {
@@ -110,6 +113,7 @@ export const Demo: Story = {
         withLayoutSelector: false,
         withRowActions: false,
         enableRowSelection: true,
+        withUnselectableRows: false,
         enableMultiRowSelection: false,
         withLastUpdated: false,
         withCollapsibleRows: false,
@@ -126,6 +130,9 @@ export const Demo: Story = {
             control: 'radio',
             options: ['header', 'toolbar'],
         },
+        withUnselectableRows: {
+            if: {arg: 'enableRowSelection', truthy: true},
+        },
     },
     render: ({
         loading,
@@ -139,6 +146,7 @@ export const Demo: Story = {
         withLayoutSelector,
         withRowActions,
         enableRowSelection,
+        withUnselectableRows,
         enableMultiRowSelection,
         withLastUpdated,
         withCollapsibleRows,
@@ -193,7 +201,7 @@ export const Demo: Story = {
                 dateRange: withDateRangePicker ? [previousWeek, today] : undefined,
                 predicates: withPredicateFilter ? {age: 'ANY'} : undefined,
             },
-            enableRowSelection,
+            enableRowSelection: enableRowSelection && (withUnselectableRows ? (row) => row.original.selectable : true),
             enableMultiRowSelection,
         });
 


### PR DESCRIPTION
### Proposed Changes

- Display rows rejected by the `enableRowSelection` predicate at 50% opacity in Row and Card layouts.
- Hide their selection checkboxes and remove the Row layout hover effect.

#### How to test

1. [Open demo](https://adui-11539-style-unselectable-table-r--69e1126f9e24a5e560359ac2.chromatic.com/?path=/story/table--demo&args=withLayoutSelector:!true;withRowActions:!true;withUnselectableRows:!true;enableMultiRowSelection:!true)
2. Rows that are disabled should have a 50% opactity and not be selectable to perform row actions.

### Potential Breaking Changes

None.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (not relevant)