### PR TITLE
ADUI-11568 Embed sources in published source maps

### DIFF
--- a/.changeset/eager-otters-dance.md
+++ b/.changeset/eager-otters-dance.md
@@ -2,6 +2,7 @@
 '@coveord/plasma-mantine': patch
 '@coveord/plasma-react-icons': patch
 '@coveord/plasma-tokens': patch
+'@coveord/plasma-mcp-server': patch
 ---
 
 Publish source maps with embedded TypeScript sources

--- a/.changeset/eager-otters-dance.md
+++ b/.changeset/eager-otters-dance.md
@@ -2,7 +2,6 @@
 '@coveord/plasma-mantine': patch
 '@coveord/plasma-react-icons': patch
 '@coveord/plasma-tokens': patch
-'@coveord/plasma-mcp-server': patch
 ---
 
 Publish source maps with embedded TypeScript sources

--- a/.changeset/eager-otters-dance.md
+++ b/.changeset/eager-otters-dance.md
@@ -1,0 +1,8 @@
+---
+'@coveord/plasma-mantine': patch
+'@coveord/plasma-react-icons': patch
+'@coveord/plasma-tokens': patch
+'@coveord/plasma-mcp-server': patch
+---
+
+Publish source maps with embedded TypeScript sources

--- a/packages/tsconfig-base.json
+++ b/packages/tsconfig-base.json
@@ -13,6 +13,7 @@
         "composite": false,
         "incremental": true,
         "sourceMap": true,
+        "inlineSources": true,
         "declaration": true,
         "declarationMap": true,
 


### PR DESCRIPTION
<!-- This notice will be removed when you mark your PR as "Ready for review" -->

### Proposed Changes

Enable `inlineSources` in the shared TypeScript configuration so published JavaScript source maps embed their original TypeScript or TSX content. Add patch changesets for Plasma Mantine, React Icons, Tokens, and MCP Server.

This removes Vite and Vitest warnings such as:

```text
Sourcemap for ".../Table.js" points to missing source files
```

### Potential Breaking Changes

None.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (not relevant)

### Validation

- `pnpm test`
- `OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true pnpm lint`
- `pnpm fmt:check`
- `pnpm changeset:validate`
- Forced builds of the three originally affected packages and representative JavaScript source-map inspection